### PR TITLE
Add function for creating observable from openfermion text

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -48,7 +48,7 @@ PYBIND11_MODULE(qulacs, m) {
 
 	py::class_<Observable>(m, "Observable")
 		.def(py::init<unsigned int>())
-		.def(py::init<std::string>())
+		// .def(py::init<std::string>())
 		.def("add_operator", (void (Observable::*)(PauliOperator*)) &Observable::add_operator)
 		.def("add_operator", (void (Observable::*)(double coef, std::string))&Observable::add_operator)
 		.def("get_qubit_count", &Observable::get_qubit_count)
@@ -59,6 +59,11 @@ PYBIND11_MODULE(qulacs, m) {
 		.def("get_transition_amplitude", &Observable::get_transition_amplitude)
 		//.def_static("get_split_Observable", &(Observable::get_split_observable));
 		;
+    auto mobservable = m.def_submodule("observable");
+    mobservable.def("create_observable_from_openfermion_file", &observable::create_observable_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
+    mobservable.def("create_observable_from_openfermion_text", &observable::create_observable_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
+    mobservable.def("create_split_observable", &observable::create_split_observable, pybind11::return_value_policy::automatic_reference);
+
 
 	py::class_<QuantumStateBase>(m, "QuantumStateBase");
 	py::class_<QuantumState,QuantumStateBase>(m, "QuantumState")

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -13,56 +13,8 @@
 #include <utility>
 
 
-
-
-
 Observable::Observable(UINT qubit_count){
     _qubit_count = qubit_count;
-}
-
-Observable::Observable(std::string filename)
-{
-    UINT qubit_count = 0;
-
-    std::ifstream ifs;
-    ifs.open(filename);
-
-    if (!ifs){
-        std::cerr << "ERROR: Cannot open file" << std::endl;
-        std::exit(EXIT_FAILURE);
-    }
-
-    std::string str;
-    std::vector<CPPCTYPE> coefs;
-    std::vector<std::string> ops;
-    while (getline(ifs, str)) {
-        std::vector<std::string> elems;
-        std::vector<std::string> index_list;
-        elems = split(str, "()j[]+");
-
-        chfmt(elems[3]);
-
-        CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
-        coefs.push_back(coef);
-        ops.push_back(elems[3]);
-
-        index_list = split(elems[3], "XYZ ");
-        for (UINT i = 0; i < index_list.size(); ++i){
-            UINT n = std::stoi(index_list[i]) + 1;
-            if (qubit_count < n)
-                qubit_count = n;
-        }
-    }
-    if (!ifs.eof()){
-        std::cerr << "ERROR: Invalid format" << std::endl;
-    }
-    ifs.close();
-
-    _qubit_count = qubit_count;
-
-    for (UINT i = 0; i < ops.size(); ++i){
-        this->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
-    }
 }
 
 Observable::~Observable(){
@@ -95,55 +47,141 @@ CPPCTYPE Observable::get_transition_amplitude(const QuantumStateBase* state_bra,
 	return sum;
 }
 
-std::pair<Observable*, Observable*> Observable::get_split_observable(std::string filename){
-    UINT qubit_count = 0;
+namespace observable{
+    Observable* create_observable_from_openfermion_file(std::string file_path){
+        UINT qubit_count = 0;
 
-    std::ifstream ifs;
-    ifs.open(filename);
+        std::ifstream ifs;
+        ifs.open(file_path);
 
-    if (!ifs){
-        std::cerr << "ERROR: Cannot open file" << std::endl;
-        std::exit(EXIT_FAILURE);
-    }
-
-    // loading lines and check qubit_count
-    std::string str;
-    std::vector<CPPCTYPE> coefs;
-    std::vector<std::string> ops;
-
-    while (getline(ifs, str)) {
-        std::vector<std::string> elems;
-        std::vector<std::string> index_list;
-        elems = split(str, "()j[]+");
-
-        chfmt(elems[3]);
-
-        CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
-        coefs.push_back(coef);
-        ops.push_back(elems[3]);
-
-        index_list = split(elems[3], "XYZ ");
-        for (UINT i = 0; i < index_list.size(); ++i){
-            UINT n = std::stoi(index_list[i]) + 1;
-            if (qubit_count < n)
-                qubit_count = n;
+        if (!ifs){
+            std::cerr << "ERROR: Cannot open file" << std::endl;
+            std::exit(EXIT_FAILURE);
         }
-    }
-    if (!ifs.eof()){
-        std::cerr << "ERROR: Invalid format" << std::endl;
-    }
-    ifs.close();
 
-    Observable* observable_diag =  new Observable(qubit_count);
-    Observable* observable_non_diag =  new Observable(qubit_count);
+        std::string str;
+        std::vector<CPPCTYPE> coefs;
+        std::vector<std::string> ops;
+        while (getline(ifs, str)) {
+            std::vector<std::string> elems;
+            std::vector<std::string> index_list;
+            elems = split(str, "()j[]+");
 
-    for (UINT i = 0; i < ops.size(); ++i){
-        if (ops[i].find("X") != std::string::npos || ops[i].find("Y") != std::string::npos){
-            observable_non_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
-        }else{
-            observable_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+            chfmt(elems[3]);
+
+            CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+            coefs.push_back(coef);
+            ops.push_back(elems[3]);
+
+            index_list = split(elems[3], "XYZ ");
+            for (UINT i = 0; i < index_list.size(); ++i){
+                UINT n = std::stoi(index_list[i]) + 1;
+                if (qubit_count < n)
+                    qubit_count = n;
+            }
         }
+        if (!ifs.eof()){
+            std::cerr << "ERROR: Invalid format" << std::endl;
+        }
+        ifs.close();
+
+        Observable* observable = new Observable(qubit_count);
+
+        for (UINT i = 0; i < ops.size(); ++i){
+            observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+        }
+
+        return observable;
     }
 
-    return std::make_pair(observable_diag, observable_non_diag);
+    Observable* create_observable_from_openfermion_text(std::string text){
+        UINT qubit_count = 0;
+
+        std::vector<std::string> lines;
+        std::vector<CPPCTYPE> coefs;
+        std::vector<std::string> ops;
+        lines = split(text, "\n");
+
+        for (std::string line: lines){
+            std::vector<std::string> elems;
+            std::vector<std::string> index_list;
+            elems = split(line, "()j[]+");
+
+            chfmt(elems[3]);
+
+            CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+            coefs.push_back(coef);
+            ops.push_back(elems[3]);
+
+            index_list = split(elems[3], "XYZ ");
+            for (UINT i = 0; i < index_list.size(); ++i){
+                UINT n = std::stoi(index_list[i]) + 1;
+                if (qubit_count < n)
+                    qubit_count = n;
+            }
+        }
+
+        Observable* observable = new Observable(qubit_count);
+
+        for (UINT i = 0; i < ops.size(); ++i){
+            observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+        }
+
+        return observable;
+    }
+
+    std::pair<Observable*, Observable*> create_split_observable(std::string file_path){
+        UINT qubit_count = 0;
+
+        std::ifstream ifs;
+        ifs.open(file_path);
+
+        if (!ifs){
+            std::cerr << "ERROR: Cannot open file" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+
+        // loading lines and check qubit_count
+        std::string str;
+        std::vector<CPPCTYPE> coefs;
+        std::vector<std::string> ops;
+
+        while (getline(ifs, str)) {
+            std::vector<std::string> elems;
+            std::vector<std::string> index_list;
+            elems = split(str, "()j[]+");
+
+            chfmt(elems[3]);
+
+            CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+            coefs.push_back(coef);
+            ops.push_back(elems[3]);
+
+            index_list = split(elems[3], "XYZ ");
+            for (UINT i = 0; i < index_list.size(); ++i){
+                UINT n = std::stoi(index_list[i]) + 1;
+                if (qubit_count < n)
+                    qubit_count = n;
+            }
+        }
+        if (!ifs.eof()){
+            std::cerr << "ERROR: Invalid format" << std::endl;
+        }
+        ifs.close();
+
+        Observable* observable_diag =  new Observable(qubit_count);
+        Observable* observable_non_diag =  new Observable(qubit_count);
+
+        for (UINT i = 0; i < ops.size(); ++i){
+            if (ops[i].find("X") != std::string::npos || ops[i].find("Y") != std::string::npos){
+                observable_non_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+            }else{
+                observable_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+            }
+        }
+
+        return std::make_pair(observable_diag, observable_non_diag);
+    }
 }
+
+

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -38,17 +38,6 @@ public:
 	Observable(UINT qubit_count);
 
 	/**
-	 * \~japanese-en
-	 * コンストラクタ。
-	 *
-	 * OpenFermionから出力されたオブザーバブルのテキストファイルを読み込んでObservableを生成します。
-	 *
-	 * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
-	 * @return Observableのインスタンス
-	 **/
-	Observable(std::string filename);
-
-	/**
      * \~japanese-en
 	 * デストラクタ。このとき、オブザーバブルが保持しているPauliOperatorは解放される。
 	 */
@@ -126,11 +115,34 @@ public:
 	 */
 	CPPCTYPE get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const;
 
-	/**
+};
+
+namespace observable{
+    /**
+	 * \~japanese-en
+	 *
+	 * OpenFermionから出力されたオブザーバブルのテキストファイルを読み込んでObservableを生成します。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
+	 *
+	 * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
+	 * @return Observableのインスタンス
+	 **/
+    DllExport Observable* create_observable_from_openfermion_file(std::string file_path);
+
+    /**
+	 * \~japanese-en
+	 *
+	 * OpenFermionの出力テキストを読み込んでObservableを生成します。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
+	 *
+	 * @param[in] filename OpenFermion形式のテキスト
+	 * @return Observableのインスタンス
+	 **/
+    DllExport Observable* create_observable_from_openfermion_text(std::string text);
+
+    /**
      * \~japanese-en
      * OpenFermion形式のファイルを読んで、対角なObservableと非対角なObservableを返す。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
      *
 	 * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
      */
-	static std::pair<Observable*, Observable*> get_split_observable(std::string filename);
-};
+    DllExport std::pair<Observable*, Observable*> create_split_observable(std::string file_path);
+}

--- a/test/cppsim/test_hamiltonian.cpp
+++ b/test/cppsim/test_hamiltonian.cpp
@@ -89,7 +89,7 @@ TEST(ObservableTest, CheckExpectationValue) {
 	}
 }
 
-TEST(ObservableTest, CheckParsedObservable){
+TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile){
 	auto func = [](const std::string path, const QuantumStateBase* state) -> double {
 		    std::ifstream ifs;
 			ifs.open(path);
@@ -133,13 +133,14 @@ TEST(ObservableTest, CheckParsedObservable){
 	double res, test_res;
 
 
-	Observable observable(filename);
-    UINT qubit_count = observable.get_qubit_count();
+	Observable* observable;
+    observable = observable::create_observable_from_openfermion_file(filename);
+    UINT qubit_count = observable->get_qubit_count();
 
 	QuantumState state(qubit_count);
 	state.set_computational_basis(0);
 
-	res = observable.get_expectation_value(&state);
+	res = observable->get_expectation_value(&state);
 	test_res = func(filename, &state);
 
 	ASSERT_EQ(test_res, res);
@@ -147,8 +148,77 @@ TEST(ObservableTest, CheckParsedObservable){
 
 	state.set_Haar_random_state();
 
-	res = observable.get_expectation_value(&state);
+	res = observable->get_expectation_value(&state);
 	test_res = func(filename, &state);
+
+	ASSERT_NEAR(test_res, res, eps);
+}
+
+TEST(ObservableTest, CheckParsedObservableFromOpenFermionText){
+	auto func = [](const std::string str, const QuantumStateBase* state) -> double {
+			double energy = 0;
+
+            std::vector<std::string> lines = split(str, "\n");
+
+			for (std::string line: lines) {
+				// std::cout << state->get_norm() << std::endl;
+
+				std::vector<std::string> elems;
+				elems = split(line, "()j[]+");
+
+				chfmt(elems[3]);
+
+				CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+				// std::cout << elems[3].c_str() << std::endl;
+
+				PauliOperator mpt(elems[3].c_str(), coef.real());
+
+				// std::cout << mpt.get_coef() << " ";
+				// std::cout << elems[3].c_str() << std::endl;
+				energy += mpt.get_expectation_value(state);
+				// mpt.get_expectation_value(state);
+
+			}
+			return energy;
+	};
+
+	const double eps = 1e-14;
+	const std::string text = "(-0.8126100000000005+0j) [] +\n"
+        "(0.04532175+0j) [X0 Z1 X2] +\n"
+        "(0.04532175+0j) [X0 Z1 X2 Z3] +\n"
+        "(0.04532175+0j) [Y0 Z1 Y2] +\n"
+        "(0.04532175+0j) [Y0 Z1 Y2 Z3] +\n"
+        "(0.17120100000000002+0j) [Z0] +\n"
+        "(0.17120100000000002+0j) [Z0 Z1] +\n"
+        "(0.165868+0j) [Z0 Z1 Z2] +\n"
+        "(0.165868+0j) [Z0 Z1 Z2 Z3] +\n"
+        "(0.12054625+0j) [Z0 Z2] +\n"
+        "(0.12054625+0j) [Z0 Z2 Z3] +\n"
+        "(0.16862325+0j) [Z1] +\n"
+        "(-0.22279649999999998+0j) [Z1 Z2 Z3] +\n"
+        "(0.17434925+0j) [Z1 Z3] +\n"
+        "(-0.22279649999999998+0j) [Z2]";
+
+	double res, test_res;
+
+
+	Observable* observable;
+    observable = observable::create_observable_from_openfermion_text(text);
+    UINT qubit_count = observable->get_qubit_count();
+
+	QuantumState state(qubit_count);
+	state.set_computational_basis(0);
+
+	res = observable->get_expectation_value(&state);
+	test_res = func(text, &state);
+
+	ASSERT_EQ(test_res, res);
+
+
+	state.set_Haar_random_state();
+
+	res = observable->get_expectation_value(&state);
+	test_res = func(text, &state);
 
 	ASSERT_NEAR(test_res, res, eps);
 }
@@ -197,7 +267,8 @@ TEST(ObservableTest, CheckSplitObservable){
 
 	double diag_res, test_res, non_diag_res;
 
-    std::pair<Observable*, Observable*> observables = Observable::get_split_observable(filename);
+    std::pair<Observable*, Observable*> observables;
+    observables = observable::create_split_observable(filename);
 
     UINT qubit_count = observables.first->get_qubit_count();
     QuantumState state(qubit_count);


### PR DESCRIPTION
Update
- add `observable` namespace
  - add `create_observable_from_openfermion_file(file_path)` in `observable` namespace
  - add `create_observable_from_openfermion_text(text)` in `observable` namespace
  - rename `get_split_observable` to `create_split_observable` and move into `observable` namespace
- modify test for `create_observable_from_openfermion_file(file_path)`
- add test for `create_observable_from_openfermion_text(text)`
- add python binding for above functions