### PR TITLE
bugfix for qulacs.Observable.add_operator(PauliOperator*)

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -49,7 +49,7 @@ PYBIND11_MODULE(qulacs, m) {
     py::class_<Observable>(m, "Observable")
         .def(py::init<unsigned int>())
         // .def(py::init<std::string>())
-        .def("add_operator", (void (Observable::*)(PauliOperator*)) &Observable::add_operator)
+        .def("add_operator", (void (Observable::*)(const PauliOperator*)) &Observable::add_operator)
         .def("add_operator", (void (Observable::*)(double coef, std::string))&Observable::add_operator)
         .def("get_qubit_count", &Observable::get_qubit_count)
         .def("get_state_dim", &Observable::get_state_dim)

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -23,8 +23,9 @@ Observable::~Observable(){
     }
 }
 
-void Observable::add_operator(PauliOperator* mpt){
-    this->_operator_list.push_back(mpt);
+void Observable::add_operator(const PauliOperator* mpt){
+    PauliOperator* _mpt = mpt->copy();
+    this->_operator_list.push_back(_mpt);
 }
 
 void Observable::add_operator(double coef, std::string pauli_string) {

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -49,7 +49,7 @@ public:
      *
      * @param[in] mpt 追加するPauliOperatorのインスタンス
      */
-    void add_operator(PauliOperator* mpt);
+    void add_operator(const PauliOperator* mpt);
 
     /**
      * \~japanese-en


### PR DESCRIPTION
# Description
Fix python crashing after calling `qulacs.observable.add_operator(mpt)`.

# Related Issue
#33 
I think this is caused by double-free.

# Update
- make argument to const
- create copy object from `mpt` and add to `_operator_list`