### PR TITLE
Fix bug in Installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if(MSYS OR MINGW OR UNIX OR APPLE)
 	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -mtune=native -march=native -mfpmath=both")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mtune=native -march=native -mfpmath=both")
 
-	if(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 8.0.0)
+	if(8.0.0 VERSION_LESS ${CMAKE_CXX_COMPILER_VERSION})
 		set(PYBIND11_CPP_STANDARD -std=gnu++11)
 	endif()
 

--- a/build_gcc.sh
+++ b/build_gcc.sh
@@ -4,12 +4,12 @@ GCC_COMMAND=gcc
 GXX_COMMAND=g++
 
 # if gcc/g++ version is less than 7, use gcc-7/g++-7
-GCC_VERSION=$(gcc -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
+GCC_VERSION=$(gcc -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
 if [ "$GCC_VERSION" -lt 70000 ]; then
   GCC_COMMAND=gcc-7
 fi
-GCC_VERSION=$(gcc -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GCC_VERSION" -lt 70000 ]; then
+GXX_VERSION=$(g++ -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
+if [ "$GXX_VERSION" -lt 70000 ]; then
   GXX_COMMAND=g++-7
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ class CMakeBuild(build_ext):
             build_args += ['--', '/m']
         else:
             try:
-                gcc_out = subprocess.check_output(['gcc', '-dumpversion']).decode()
+                gcc_out = subprocess.check_output(['gcc', '-dumpfullversion', '-dumpversion']).decode()
                 gcc_version = LooseVersion(gcc_out)
-                gxx_out = subprocess.check_output(['g++', '-dumpversion']).decode()
+                gxx_out = subprocess.check_output(['g++', '-dumpfullversion', '-dumpversion']).decode()
                 gxx_version = LooseVersion(gxx_out)
             except OSError:
                 raise RuntimeError("gcc/g++ must be installed to build the following extensions: " +


### PR DESCRIPTION
#26 

### Update
- Use `VERSION_LESS`, instead of `VERSION_GREATER_EQUAL`(It doesn't work on cmake==3.5.1)
- Add `-dumpfullversion` flag to getting version of `gcc-7`, `g++-7`