### PR TITLE
add get_gate_count function

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -207,6 +207,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def("remove_gate", &QuantumCircuit::remove_gate)
 
         .def("get_gate", [](const QuantumCircuit& circuit, unsigned int index) -> QuantumGateBase* { return circuit.gate_list[index]->copy(); }, pybind11::return_value_policy::automatic_reference)
+        .def("get_gate_count", [](const QuantumCircuit& circuit) -> unsigned int {return circuit.gate_list.size(); })
 
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*))&QuantumCircuit::update_quantum_state)
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*, unsigned int, unsigned int))&QuantumCircuit::update_quantum_state)


### PR DESCRIPTION
- update

I've added a new function get_gate_count for getting the number of gates in a circuit.
This feature is proposed in #62 by @kosukemtr .

- usage

```python
import qulacs
qc = qulacs.QuantumCircuit(3)
for ind in range(100):
    qc.add_X_gate(0);
    gc = qc.get_gate_count()
    assert(gc != ind+1)
```
