### PR TITLE
add get_gate_function and Adaptive gate

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -4,6 +4,7 @@
 #include <pybind11/complex.h>
 #include <pybind11/operators.h>
 #include <pybind11/eigen.h>
+#include <pybind11/functional.h>
 
 #ifndef _MSC_VER
 extern "C" {
@@ -207,7 +208,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def("remove_gate", &QuantumCircuit::remove_gate)
 
         .def("get_gate", [](const QuantumCircuit& circuit, unsigned int index) -> QuantumGateBase* { return circuit.gate_list[index]->copy(); }, pybind11::return_value_policy::automatic_reference)
-        .def("get_gate_count", [](const QuantumCircuit& circuit) -> unsigned int {return circuit.gate_list.size(); })
+        .def("get_gate_count", [](const QuantumCircuit& circuit) -> unsigned int {return (unsigned int)circuit.gate_list.size(); })
 
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*))&QuantumCircuit::update_quantum_state)
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*, unsigned int, unsigned int))&QuantumCircuit::update_quantum_state)

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -207,6 +207,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def("remove_gate", &QuantumCircuit::remove_gate)
 
         .def("get_gate", [](const QuantumCircuit& circuit, unsigned int index) -> QuantumGateBase* { return circuit.gate_list[index]->copy(); }, pybind11::return_value_policy::automatic_reference)
+        .def("get_gate_count", [](const QuantumCircuit& circuit) -> unsigned int {return circuit.gate_list.size(); })
 
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*))&QuantumCircuit::update_quantum_state)
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*, unsigned int, unsigned int))&QuantumCircuit::update_quantum_state)


### PR DESCRIPTION
- update1

I've added a new function get_gate_count for getting the number of gates in a circuit.
This feature is proposed in #62 by @kosukemtr .

- usage1

```python
import qulacs
qc = qulacs.QuantumCircuit(3)
for ind in range(100):
    qc.add_X_gate(0);
    gc = qc.get_gate_count()
    assert(gc != ind+1)
```


---

- Update2

I have added Adaptive gate, which allows python-user to send python-function to c++, and use it as "conditional function" for executing a quantum gate.
This feature was intended to be already exported, but was not properly exported. This problem is mentioned in #61 .

- Usage2

The below code apply gate "X" if a function "adaptive" returns True.
A array "classical_values" in QuantumState are typically updated through 

1. QuantumState::set_classical_value
2. Instrument or Measurement writes measurement results to classical_value.

```python
from qulacs import QuantumState
from qulacs.gate import Adaptive,X

def adaptive(vec) -> bool:
	print("this function got type : {} , content : {}".format(type(vec), vec))
	if(len(vec)==0):
		return False
	return vec[0]==1

gate = X(0)
gate2 = Adaptive(gate, adaptive)
state = QuantumState(1)

gate2.update_quantum_state(state)
print(state)

state.set_classical_value(0,1)
gate2.update_quantum_state(state)
print(state)
```

This code outputs 
```
this function got type : <class 'list'> , content : []
 *** Quantum State ***
 * Qubit Count : 1
 * Dimension   : 2
 * State vector :
(1,0)
(0,0)

this function got type : <class 'list'> , content : [1]
 *** Quantum State ***
 * Qubit Count : 1
 * Dimension   : 2
 * State vector :
(0,0)
(1,0)
```