### PR TITLE
Bugfix and add some features for Observable and PauliOperator

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -63,9 +63,9 @@ PYBIND11_MODULE(qulacs, m) {
         //.def_static("get_split_GeneralQuantumOperator", &(GeneralQuantumOperator::get_split_observable));
         ;
     auto mquantum_operator = m.def_submodule("quantum_operator");
-    mquantum_operator.def("create_quantum_operator_from_openfermion_file", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
-    mquantum_operator.def("create_quantum_operator_from_openfermion_text", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
-    mquantum_operator.def("create_split_quantum_operator", &generalQuantumOperator::create_split_general_quantum_operator, pybind11::return_value_policy::automatic_reference);
+    mquantum_operator.def("create_quantum_operator_from_openfermion_file", &quantum_operator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
+    mquantum_operator.def("create_quantum_operator_from_openfermion_text", &quantum_operator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
+    mquantum_operator.def("create_split_quantum_operator", &quantum_operator::create_split_general_quantum_operator, pybind11::return_value_policy::automatic_reference);
 
     py::class_<Observable, GeneralQuantumOperator>(m, "Observable")
         .def(py::init<unsigned int>())

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -53,7 +53,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def(py::init<unsigned int>())
         // .def(py::init<std::string>())
         .def("add_operator", (void (Observable::*)(const PauliOperator*)) &Observable::add_operator)
-        .def("add_operator", (void (Observable::*)(double coef, std::string))&Observable::add_operator)
+        .def("add_operator", (void (Observable::*)(std::complex<double> coef, std::string))&Observable::add_operator)
         .def("get_qubit_count", &Observable::get_qubit_count)
         .def("get_state_dim", &Observable::get_state_dim)
         .def("get_term_count", &Observable::get_term_count)

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -62,10 +62,10 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_transition_amplitude", &GeneralQuantumOperator::get_transition_amplitude)
         //.def_static("get_split_GeneralQuantumOperator", &(GeneralQuantumOperator::get_split_observable));
         ;
-    auto mgeneral_quantum_operator = m.def_submodule("generalQuantumOperator");
-    mgeneral_quantum_operator.def("create_general_quantum_operator_from_openfermion_file", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
-    mgeneral_quantum_operator.def("create_general_quantum_operator_from_openfermion_text", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
-    mgeneral_quantum_operator.def("create_split_general_quantum_operator", &generalQuantumOperator::create_split_general_quantum_operator, pybind11::return_value_policy::automatic_reference);
+    auto mquantum_operator = m.def_submodule("quantum_operator");
+    mquantum_operator.def("create_quantum_operator_from_openfermion_file", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
+    mquantum_operator.def("create_quantum_operator_from_openfermion_text", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
+    mquantum_operator.def("create_split_quantum_operator", &generalQuantumOperator::create_split_general_quantum_operator, pybind11::return_value_policy::automatic_reference);
 
     py::class_<Observable, GeneralQuantumOperator>(m, "Observable")
         .def(py::init<unsigned int>())

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -49,7 +49,25 @@ PYBIND11_MODULE(qulacs, m) {
         .def("copy", &PauliOperator::copy, pybind11::return_value_policy::automatic_reference)
         ;
 
-    py::class_<Observable>(m, "Observable")
+    py::class_<GeneralQuantumOperator>(m, "GeneralQuantumOperator")
+        .def(py::init<unsigned int>())
+        // .def(py::init<std::string>())
+        .def("add_operator", (void (GeneralQuantumOperator::*)(const PauliOperator*)) &GeneralQuantumOperator::add_operator)
+        .def("add_operator", (void (GeneralQuantumOperator::*)(std::complex<double> coef, std::string))&GeneralQuantumOperator::add_operator)
+        .def("get_qubit_count", &GeneralQuantumOperator::get_qubit_count)
+        .def("get_state_dim", &GeneralQuantumOperator::get_state_dim)
+        .def("get_term_count", &GeneralQuantumOperator::get_term_count)
+        .def("get_term", &GeneralQuantumOperator::get_term, pybind11::return_value_policy::automatic_reference)
+        .def("get_expectation_value", &GeneralQuantumOperator::get_expectation_value)
+        .def("get_transition_amplitude", &GeneralQuantumOperator::get_transition_amplitude)
+        //.def_static("get_split_GeneralQuantumOperator", &(GeneralQuantumOperator::get_split_observable));
+        ;
+    auto mgeneral_quantum_operator = m.def_submodule("generalQuantumOperator");
+    mgeneral_quantum_operator.def("create_general_quantum_operator_from_openfermion_file", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
+    mgeneral_quantum_operator.def("create_general_quantum_operator_from_openfermion_text", &generalQuantumOperator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
+    mgeneral_quantum_operator.def("create_split_general_quantum_operator", &generalQuantumOperator::create_split_general_quantum_operator, pybind11::return_value_policy::automatic_reference);
+
+    py::class_<Observable, GeneralQuantumOperator>(m, "Observable")
         .def(py::init<unsigned int>())
         // .def(py::init<std::string>())
         .def("add_operator", (void (Observable::*)(const PauliOperator*)) &Observable::add_operator)

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <sstream>
+#include <stdexcept>
 #include "gate.hpp"
 #include "gate_matrix.hpp"
 #include "gate_factory.hpp"
@@ -249,12 +250,18 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(std::vector<UINT> target_inde
     this->add_gate(gate::PauliRotation(target_index_list, pauli_id_list,angle));
 }
 void QuantumCircuit::add_multi_Pauli_rotation_gate(const PauliOperator& pauli_operator) {
-    this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(), pauli_operator.get_pauli_id_list(), pauli_operator.get_coef() ));
+    if (pauli_operator.get_coef().imag() != 0.){
+        throw std::logic_error(__func__ + std::string(": not impremented for non hermitian"));
+    }
+    this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(), pauli_operator.get_pauli_id_list(), pauli_operator.get_coef().real()));
 }
 void QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& observable, double angle) {
     std::vector<PauliOperator*> operator_list = observable.get_terms();
     for (auto pauli: operator_list){
-        auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef() * angle);
+        if (pauli->get_coef().imag() != 0.){
+            throw std::logic_error(__func__ + std::string(": not impremented for non hermitian"));
+        }
+        auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle);
         if (!pauli_rotation->is_diagonal())
             std::cerr << "ERROR: Observable is not diagonal" << std::endl;
         this->add_gate(pauli_rotation);
@@ -268,7 +275,10 @@ void QuantumCircuit::add_observable_rotation_gate(const Observable& observable, 
     // std::cout << num_repeats << std::endl;
     for (UINT repeat = 0; repeat < (UINT)num_repeats; ++repeat){
         for (auto pauli: operator_list){
-            this->add_gate(gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef() * angle/ num_repeats));
+            if (pauli->get_coef().imag() != 0.){
+                throw std::logic_error(__func__ + std::string(": not impremented for non hermitian"));
+            }
+            this->add_gate(gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle/ num_repeats));
         }
     }
 }

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -251,7 +251,7 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(std::vector<UINT> target_inde
 }
 void QuantumCircuit::add_multi_Pauli_rotation_gate(const PauliOperator& pauli_operator) {
     if (pauli_operator.get_coef().imag() != 0.){
-        throw std::logic_error(__func__ + std::string(": not impremented for non hermitian"));
+        std::cerr <<  "Error: QuantumCircuit::add_multi_Pauli_rotation_gate(const PauliOperator& pauli_operator): not impremented for non hermitian" << std::endl;
     }
     this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(), pauli_operator.get_pauli_id_list(), pauli_operator.get_coef().real()));
 }
@@ -259,7 +259,7 @@ void QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& obs
     std::vector<PauliOperator*> operator_list = observable.get_terms();
     for (auto pauli: operator_list){
         if (pauli->get_coef().imag() != 0.){
-            throw std::logic_error(__func__ + std::string(": not impremented for non hermitian"));
+            std::cerr << "Error: QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& observable, double angle): not impremented for non hermitian" << std::endl;
         }
         auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle);
         if (!pauli_rotation->is_diagonal())
@@ -276,7 +276,7 @@ void QuantumCircuit::add_observable_rotation_gate(const Observable& observable, 
     for (UINT repeat = 0; repeat < (UINT)num_repeats; ++repeat){
         for (auto pauli: operator_list){
             if (pauli->get_coef().imag() != 0.){
-                throw std::logic_error(__func__ + std::string(": not impremented for non hermitian"));
+                std::cerr << "Error: QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats): not impremented for non hermitian" << std::endl;
             }
             this->add_gate(gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle/ num_repeats));
         }

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -315,30 +315,32 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(const PauliOperator& pauli_op
     this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(), pauli_operator.get_pauli_id_list(), pauli_operator.get_coef().real()));
 }
 void QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& observable, double angle) {
+    if (!observable.is_hermitian()){
+        std::cerr << "Error: QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats): not impremented for non hermitian" << std::endl;
+        return;
+    }
     std::vector<PauliOperator*> operator_list = observable.get_terms();
-    const double eps = 1e-14;
     for (auto pauli: operator_list){
-        if (std::abs(pauli->get_coef().imag()) > eps){
-            std::cerr << "Error: QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& observable, double angle): not impremented for non hermitian" << std::endl;
-        }
         auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle);
-        if (!pauli_rotation->is_diagonal())
+        if (!pauli_rotation->is_diagonal()){
             std::cerr << "ERROR: Observable is not diagonal" << std::endl;
+            return;
+        }
         this->add_gate(pauli_rotation);
     }
 }
 void QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats) {
+    if (!observable.is_hermitian()){
+        std::cerr << "Error: QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats): not impremented for non hermitian" << std::endl;
+        return;
+    }
     UINT qubit_count_ = observable.get_qubit_count();
-    const double eps = 1e-14;
     std::vector<PauliOperator*> operator_list = observable.get_terms();
     if (num_repeats == 0)
         num_repeats = (UINT) std::ceil(angle * (double)qubit_count_ * 100.);
     // std::cout << num_repeats << std::endl;
     for (UINT repeat = 0; repeat < (UINT)num_repeats; ++repeat){
         for (auto pauli: operator_list){
-            if (std::abs(pauli->get_coef().imag()) > eps){
-                std::cerr << "Error: QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats): not impremented for non hermitian" << std::endl;
-            }
             this->add_gate(gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle/ num_repeats));
         }
     }

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -308,15 +308,17 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(std::vector<UINT> target_inde
     this->add_gate(gate::PauliRotation(target_index_list, pauli_id_list,angle));
 }
 void QuantumCircuit::add_multi_Pauli_rotation_gate(const PauliOperator& pauli_operator) {
-    if (pauli_operator.get_coef().imag() != 0.){
+    const double eps = 1e-14;
+    if (std::abs(pauli_operator.get_coef().imag()) > eps){
         std::cerr <<  "Error: QuantumCircuit::add_multi_Pauli_rotation_gate(const PauliOperator& pauli_operator): not impremented for non hermitian" << std::endl;
     }
     this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(), pauli_operator.get_pauli_id_list(), pauli_operator.get_coef().real()));
 }
 void QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& observable, double angle) {
     std::vector<PauliOperator*> operator_list = observable.get_terms();
+    const double eps = 1e-14;
     for (auto pauli: operator_list){
-        if (pauli->get_coef().imag() != 0.){
+        if (std::abs(pauli->get_coef().imag()) > eps){
             std::cerr << "Error: QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& observable, double angle): not impremented for non hermitian" << std::endl;
         }
         auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle);
@@ -327,13 +329,14 @@ void QuantumCircuit::add_diagonal_observable_rotation_gate(const Observable& obs
 }
 void QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats) {
     UINT qubit_count_ = observable.get_qubit_count();
+    const double eps = 1e-14;
     std::vector<PauliOperator*> operator_list = observable.get_terms();
     if (num_repeats == 0)
         num_repeats = (UINT) std::ceil(angle * (double)qubit_count_ * 100.);
     // std::cout << num_repeats << std::endl;
     for (UINT repeat = 0; repeat < (UINT)num_repeats; ++repeat){
         for (auto pauli: operator_list){
-            if (pauli->get_coef().imag() != 0.){
+            if (std::abs(pauli->get_coef().imag()) > eps){
                 std::cerr << "Error: QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats): not impremented for non hermitian" << std::endl;
             }
             this->add_gate(gate::PauliRotation(pauli->get_index_list(), pauli->get_pauli_id_list(), pauli->get_coef().real() * angle/ num_repeats));

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -14,7 +14,8 @@
 class QuantumStateBase;
 class QuantumGateBase;
 class PauliOperator;
-class Observable;
+class RealValuedQuantumOperator;
+typedef RealValuedQuantumOperator Observable;
 
 /**
  * \~japanese-en 量子回路のクラス

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -14,8 +14,8 @@
 class QuantumStateBase;
 class QuantumGateBase;
 class PauliOperator;
-class RealValuedQuantumOperator;
-typedef RealValuedQuantumOperator Observable;
+class HermitianQuantumOperator;
+typedef HermitianQuantumOperator Observable;
 
 /**
  * \~japanese-en 量子回路のクラス

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -33,7 +33,7 @@ CPPCTYPE RealValuedQuantumOperator::get_expectation_value(const QuantumStateBase
     return GeneralQuantumOperator::get_expectation_value(state).real();
 }
 
-namespace realValuedQuantumOperator{
+namespace observable{
     RealValuedQuantumOperator* create_observable_from_openfermion_file(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -83,6 +83,7 @@ namespace observable{
     Observable* create_observable_from_openfermion_file(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;
+        UINT str_idx;
 
         std::ifstream ifs;
         ifs.open(file_path);
@@ -103,16 +104,14 @@ namespace observable{
                 continue;
             }
 
-            chfmt(elems[3]);
 
             imag_idx = 1;
+            str_idx = 3;
 
             if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                // std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
-                // throw std::domain_error("Observable should be Hermitian.");
-                // continue;
+                str_idx = 1;
             } else if (elems[1].find("j") != std::string::npos){
                 coef_real = std::stod(elems[imag_idx-1]);
             } else {
@@ -120,12 +119,13 @@ namespace observable{
             }
 
             coef_imag = std::stod(elems[imag_idx]);
+            chfmt(elems[str_idx]);
 
             CPPCTYPE coef(coef_real, coef_imag);
             coefs.push_back(coef);
-            ops.push_back(elems[3]);
+            ops.push_back(elems[str_idx]);
 
-            index_list = split(elems[3], "XYZ ");
+            index_list = split(elems[str_idx], "XYZ ");
             for (UINT i = 0; i < index_list.size(); ++i){
                 UINT n = std::stoi(index_list[i]) + 1;
                 if (qubit_count < n)
@@ -150,6 +150,7 @@ namespace observable{
     Observable* create_observable_from_openfermion_text(std::string text){
         UINT qubit_count = 0;
         UINT imag_idx;
+        UINT str_idx;
 
         std::vector<std::string> lines;
         std::vector<CPPCTYPE> coefs;
@@ -165,16 +166,13 @@ namespace observable{
             if (elems.size() < 3){
                 continue;
             }
-            chfmt(elems[3]);
 
             imag_idx = 1;
-
+            str_idx = 3;
             if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                // std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
-                // throw std::domain_error("Observable should be Hermitian.");
-                // continue;
+                str_idx = 1;
             } else if (elems[1].find("j") != std::string::npos){
                 coef_real = std::stod(elems[imag_idx-1]);
             } else {
@@ -182,13 +180,14 @@ namespace observable{
             }
 
             coef_imag = std::stod(elems[imag_idx]);
+            chfmt(elems[str_idx]);
 
             CPPCTYPE coef(coef_real, coef_imag);
 
             coefs.push_back(coef);
-            ops.push_back(elems[3]);
+            ops.push_back(elems[str_idx]);
 
-            index_list = split(elems[3], "XYZ ");
+            index_list = split(elems[str_idx], "XYZ ");
             for (UINT i = 0; i < index_list.size(); ++i){
                 UINT n = std::stoi(index_list[i]) + 1;
                 if (qubit_count < n)
@@ -208,7 +207,7 @@ namespace observable{
     std::pair<Observable*, Observable*> create_split_observable(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;
-
+        UINT str_idx;
         std::ifstream ifs;
         ifs.open(file_path);
 
@@ -230,16 +229,13 @@ namespace observable{
             if (elems.size() < 3){
                 continue;
             }
-            chfmt(elems[3]);
 
             imag_idx = 1;
-
+            str_idx = 3;
             if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                // std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
-                // throw std::domain_error("Observable should be Hermitian.");
-                // continue;
+                str_idx = 1;
             } else if (elems[1].find("j") == std::string::npos){
                 coef_real = std::stod(elems[imag_idx-1]);
             } else {
@@ -247,12 +243,13 @@ namespace observable{
             }
 
             coef_imag = std::stod(elems[imag_idx]);
+            chfmt(elems[str_idx]);
 
             CPPCTYPE coef(coef_real, coef_imag);
             coefs.push_back(coef);
-            ops.push_back(elems[3]);
+            ops.push_back(elems[str_idx]);
 
-            index_list = split(elems[3], "XYZ ");
+            index_list = split(elems[str_idx], "XYZ ");
             for (UINT i = 0; i < index_list.size(); ++i){
                 UINT n = std::stoi(index_list[i]) + 1;
                 if (qubit_count < n)

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -13,28 +13,28 @@
 #include <iostream>
 #include <utility>
 
-void RealValuedQuantumOperator::add_operator(const PauliOperator* mpt){
+void HermitianQuantumOperator::add_operator(const PauliOperator* mpt){
     if (std::abs(mpt->get_coef().imag()) > 0){
-        std::cerr << "Error: RealValuedQuantumOperator::add_operator(const PauliOperator* mpt): PauliOperator must be Hermitian." << std::endl;
+        std::cerr << "Error: HermitianQuantumOperator::add_operator(const PauliOperator* mpt): PauliOperator must be Hermitian." << std::endl;
         return;
     }
     GeneralQuantumOperator::add_operator(mpt);
 }
 
-void RealValuedQuantumOperator::add_operator(CPPCTYPE coef, std::string pauli_string) {
+void HermitianQuantumOperator::add_operator(CPPCTYPE coef, std::string pauli_string) {
     if (std::abs(coef.imag()) > 0){
-        std::cerr << "Error: RealValuedQuantumOperator::add_operator(const PauliOperator* mpt): PauliOperator must be Hermitian." << std::endl;
+        std::cerr << "Error: HermitianQuantumOperator::add_operator(const PauliOperator* mpt): PauliOperator must be Hermitian." << std::endl;
         return;
     }
 	GeneralQuantumOperator::add_operator(coef, pauli_string);
 }
 
-CPPCTYPE RealValuedQuantumOperator::get_expectation_value(const QuantumStateBase* state) const {
+CPPCTYPE HermitianQuantumOperator::get_expectation_value(const QuantumStateBase* state) const {
     return GeneralQuantumOperator::get_expectation_value(state).real();
 }
 
 namespace observable{
-    RealValuedQuantumOperator* create_observable_from_openfermion_file(std::string file_path){
+    HermitianQuantumOperator* create_observable_from_openfermion_file(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;
         UINT str_idx;
@@ -92,7 +92,7 @@ namespace observable{
 		}
         ifs.close();
 
-        RealValuedQuantumOperator* observable = new RealValuedQuantumOperator(qubit_count);
+        HermitianQuantumOperator* observable = new HermitianQuantumOperator(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
             observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
@@ -101,7 +101,7 @@ namespace observable{
         return observable;
     }
 
-    RealValuedQuantumOperator* create_observable_from_openfermion_text(std::string text){
+    HermitianQuantumOperator* create_observable_from_openfermion_text(std::string text){
         UINT qubit_count = 0;
         UINT imag_idx;
         UINT str_idx;
@@ -149,7 +149,7 @@ namespace observable{
             }
         }
 
-        RealValuedQuantumOperator* observable = new RealValuedQuantumOperator(qubit_count);
+        HermitianQuantumOperator* observable = new HermitianQuantumOperator(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
             observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
@@ -158,7 +158,7 @@ namespace observable{
         return observable;
     }
 
-    std::pair<RealValuedQuantumOperator*, RealValuedQuantumOperator*> create_split_observable(std::string file_path){
+    std::pair<HermitianQuantumOperator*, HermitianQuantumOperator*> create_split_observable(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;
         UINT str_idx;
@@ -167,7 +167,7 @@ namespace observable{
 
         if (!ifs){
             std::cerr << "ERROR: Cannot open file" << std::endl;
-			return std::make_pair((RealValuedQuantumOperator*)NULL, (RealValuedQuantumOperator*)NULL);
+			return std::make_pair((HermitianQuantumOperator*)NULL, (HermitianQuantumOperator*)NULL);
         }
 
         // loading lines and check qubit_count
@@ -212,12 +212,12 @@ namespace observable{
         }
         if (!ifs.eof()){
             std::cerr << "ERROR: Invalid format" << std::endl;
-			return std::make_pair((RealValuedQuantumOperator*)NULL, (RealValuedQuantumOperator*)NULL);
+			return std::make_pair((HermitianQuantumOperator*)NULL, (HermitianQuantumOperator*)NULL);
 		}
         ifs.close();
 
-        RealValuedQuantumOperator* observable_diag =  new RealValuedQuantumOperator(qubit_count);
-        RealValuedQuantumOperator* observable_non_diag =  new RealValuedQuantumOperator(qubit_count);
+        HermitianQuantumOperator* observable_diag =  new HermitianQuantumOperator(qubit_count);
+        HermitianQuantumOperator* observable_non_diag =  new HermitianQuantumOperator(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
             if (ops[i].find("X") != std::string::npos || ops[i].find("Y") != std::string::npos){

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -76,10 +76,11 @@ namespace observable{
 
             imag_idx = 1;
 
-            if (elems[0].back() == 'j'){
+            if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                throw std::domain_error("Observable should be Hermitian.");
+                std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
+                // throw std::domain_error("Observable should be Hermitian.");
             } else if (elems[1].back() != 'j'){
                 continue;
             } else {
@@ -135,11 +136,12 @@ namespace observable{
 
             imag_idx = 1;
 
-            if (elems[0].back() == 'j'){
+            if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                throw std::domain_error("Observable should be Hermitian.");
-            } else if (elems[1].back() != 'j'){
+                std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
+                // throw std::domain_error("Observable should be Hermitian.");
+            } else if (elems[1].find("j") == std::string::npos){
                 continue;
             } else {
                 coef_real = std::stod(elems[imag_idx-1]);
@@ -198,11 +200,12 @@ namespace observable{
 
             imag_idx = 1;
 
-            if (elems[0].back() == 'j'){
+            if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                throw std::domain_error("Observable should be Hermitian.");
-            } else if (elems[1].back() != 'j'){
+                std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
+                // throw std::domain_error("Observable should be Hermitian.");
+            } else if (elems[0].find("j") == std::string::npos){
                 continue;
             } else {
                 coef_real = std::stod(elems[imag_idx-1]);

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -81,7 +81,8 @@ namespace observable{
                 imag_idx = 0;
                 std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
                 // throw std::domain_error("Observable should be Hermitian.");
-            } else if (elems[1].back() != 'j'){
+                continue;
+            } else if (elems[1].find("j") == std::string::npos){
                 continue;
             } else {
                 coef_real = std::stod(elems[imag_idx-1]);
@@ -141,6 +142,7 @@ namespace observable{
                 imag_idx = 0;
                 std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
                 // throw std::domain_error("Observable should be Hermitian.");
+                continue;
             } else if (elems[1].find("j") == std::string::npos){
                 continue;
             } else {
@@ -205,7 +207,8 @@ namespace observable{
                 imag_idx = 0;
                 std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
                 // throw std::domain_error("Observable should be Hermitian.");
-            } else if (elems[0].find("j") == std::string::npos){
+                continue;
+            } else if (elems[1].find("j") == std::string::npos){
                 continue;
             } else {
                 coef_real = std::stod(elems[imag_idx-1]);

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -28,12 +28,12 @@ void Observable::add_operator(const PauliOperator* mpt){
     this->_operator_list.push_back(_mpt);
 }
 
-void Observable::add_operator(double coef, std::string pauli_string) {
+void Observable::add_operator(CPPCTYPE coef, std::string pauli_string) {
     this->add_operator(new PauliOperator(pauli_string, coef));
 }
 
-double Observable::get_expectation_value(const QuantumStateBase* state) const {
-    double sum = 0;
+CPPCTYPE Observable::get_expectation_value(const QuantumStateBase* state) const {
+    CPPCTYPE sum = 0;
     for (auto pauli : this->_operator_list) {
         sum += pauli->get_expectation_value(state);
     }
@@ -79,13 +79,13 @@ namespace observable{
             if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
+                // std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
                 // throw std::domain_error("Observable should be Hermitian.");
-                continue;
-            } else if (elems[1].find("j") == std::string::npos){
-                continue;
-            } else {
+                // continue;
+            } else if (elems[1].find("j") != std::string::npos){
                 coef_real = std::stod(elems[imag_idx-1]);
+            } else {
+                continue;
             }
 
             coef_imag = std::stod(elems[imag_idx]);
@@ -109,7 +109,7 @@ namespace observable{
         Observable* observable = new Observable(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
-            observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+            observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
         }
 
         return observable;
@@ -140,13 +140,13 @@ namespace observable{
             if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
+                // std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
                 // throw std::domain_error("Observable should be Hermitian.");
-                continue;
-            } else if (elems[1].find("j") == std::string::npos){
-                continue;
-            } else {
+                // continue;
+            } else if (elems[1].find("j") != std::string::npos){
                 coef_real = std::stod(elems[imag_idx-1]);
+            } else {
+                continue;
             }
 
             coef_imag = std::stod(elems[imag_idx]);
@@ -167,7 +167,7 @@ namespace observable{
         Observable* observable = new Observable(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
-            observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+            observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
         }
 
         return observable;
@@ -205,13 +205,13 @@ namespace observable{
             if (elems[0].find("j") != std::string::npos){
                 coef_real = 0;
                 imag_idx = 0;
-                std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
+                // std::cerr << "ERROR: Observable should be Hermitian." << std::endl;
                 // throw std::domain_error("Observable should be Hermitian.");
-                continue;
+                // continue;
             } else if (elems[1].find("j") == std::string::npos){
-                continue;
-            } else {
                 coef_real = std::stod(elems[imag_idx-1]);
+            } else {
+                continue;
             }
 
             coef_imag = std::stod(elems[imag_idx]);
@@ -237,9 +237,9 @@ namespace observable{
 
         for (UINT i = 0; i < ops.size(); ++i){
             if (ops[i].find("X") != std::string::npos || ops[i].find("Y") != std::string::npos){
-                observable_non_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+                observable_non_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
             }else{
-                observable_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
+                observable_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
             }
         }
 

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -13,74 +13,28 @@
 #include <iostream>
 #include <utility>
 
-bool check_Pauli_operator(const Observable* observable, const PauliOperator* pauli_operator);
-
-bool check_Pauli_operator(const Observable* observable, const PauliOperator* pauli_operator) {
-	auto vec = pauli_operator->get_index_list();
-	UINT val = 0;
-	if (vec.size() > 0) {
-		val = std::max(val, *std::max_element(vec.begin(), vec.end()));
-	}
-	return val < (observable->get_qubit_count());
-}
-
-Observable::Observable(UINT qubit_count){
-    _qubit_count = qubit_count;
-}
-
-Observable::~Observable(){
-    for(auto& term : this->_operator_list){
-        delete term;
+void RealValuedQuantumOperator::add_operator(const PauliOperator* mpt){
+    if (std::abs(mpt->get_coef().imag()) > 0){
+        std::cerr << "Error: RealValuedQuantumOperator::add_operator(const PauliOperator* mpt): PauliOperator must be Hermitian." << std::endl;
+        return;
     }
+    GeneralQuantumOperator::add_operator(mpt);
 }
 
-void Observable::add_operator(const PauliOperator* mpt){
-    PauliOperator* _mpt = mpt->copy();
-	if (!check_Pauli_operator(this, _mpt)) {
-		std::cerr << "Error: Observable::add_operator(const PauliOperator*): pauli_operator applies target qubit of which the index is larger than qubit_count" << std::endl;
-		return;
-	}
-
-    this->_operator_list.push_back(_mpt);
-}
-
-void Observable::add_operator(CPPCTYPE coef, std::string pauli_string) {
-	PauliOperator* _mpt = new PauliOperator(pauli_string, coef);
-	if (!check_Pauli_operator(this, _mpt)) {
-		std::cerr << "Error: Observable::add_operator(double,std::string): pauli_operator applies target qubit of which the index is larger than qubit_count" << std::endl;
-		return;
-	}
-	this->add_operator(_mpt);
-}
-
-CPPCTYPE Observable::get_expectation_value(const QuantumStateBase* state) const {
-	if (this->_qubit_count != state->qubit_count) {
-		std::cerr << "Error: Observable::get_expectation_value(const QuantumStateBase*): invalid qubit count" << std::endl;
-		return 0.;
-	}
-
-    CPPCTYPE sum = 0;
-    for (auto pauli : this->_operator_list) {
-        sum += pauli->get_expectation_value(state);
+void RealValuedQuantumOperator::add_operator(CPPCTYPE coef, std::string pauli_string) {
+    if (std::abs(coef.imag()) > 0){
+        std::cerr << "Error: RealValuedQuantumOperator::add_operator(const PauliOperator* mpt): PauliOperator must be Hermitian." << std::endl;
+        return;
     }
-    return sum;
+	GeneralQuantumOperator::add_operator(coef, pauli_string);
 }
 
-CPPCTYPE Observable::get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const {
-	if (this->_qubit_count != state_bra->qubit_count || this->_qubit_count != state_ket->qubit_count) {
-		std::cerr << "Error: Observable::get_transition_amplitude(const QuantumStateBase*, const QuantumStateBase*): invalid qubit count" << std::endl;
-		return 0.;
-	}
-	
-	CPPCTYPE sum = 0;
-    for (auto pauli : this->_operator_list) {
-        sum += pauli->get_transition_amplitude(state_bra, state_ket);
-    }
-    return sum;
+CPPCTYPE RealValuedQuantumOperator::get_expectation_value(const QuantumStateBase* state) const {
+    return GeneralQuantumOperator::get_expectation_value(state).real();
 }
 
-namespace observable{
-    Observable* create_observable_from_openfermion_file(std::string file_path){
+namespace realValuedQuantumOperator{
+    RealValuedQuantumOperator* create_observable_from_openfermion_file(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;
         UINT str_idx;
@@ -138,7 +92,7 @@ namespace observable{
 		}
         ifs.close();
 
-        Observable* observable = new Observable(qubit_count);
+        RealValuedQuantumOperator* observable = new RealValuedQuantumOperator(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
             observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
@@ -147,7 +101,7 @@ namespace observable{
         return observable;
     }
 
-    Observable* create_observable_from_openfermion_text(std::string text){
+    RealValuedQuantumOperator* create_observable_from_openfermion_text(std::string text){
         UINT qubit_count = 0;
         UINT imag_idx;
         UINT str_idx;
@@ -195,7 +149,7 @@ namespace observable{
             }
         }
 
-        Observable* observable = new Observable(qubit_count);
+        RealValuedQuantumOperator* observable = new RealValuedQuantumOperator(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
             observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
@@ -204,7 +158,7 @@ namespace observable{
         return observable;
     }
 
-    std::pair<Observable*, Observable*> create_split_observable(std::string file_path){
+    std::pair<RealValuedQuantumOperator*, RealValuedQuantumOperator*> create_split_observable(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;
         UINT str_idx;
@@ -213,7 +167,7 @@ namespace observable{
 
         if (!ifs){
             std::cerr << "ERROR: Cannot open file" << std::endl;
-			return std::make_pair((Observable*)NULL, (Observable*)NULL);
+			return std::make_pair((RealValuedQuantumOperator*)NULL, (RealValuedQuantumOperator*)NULL);
         }
 
         // loading lines and check qubit_count
@@ -258,12 +212,12 @@ namespace observable{
         }
         if (!ifs.eof()){
             std::cerr << "ERROR: Invalid format" << std::endl;
-			return std::make_pair((Observable*)NULL, (Observable*)NULL);
+			return std::make_pair((RealValuedQuantumOperator*)NULL, (RealValuedQuantumOperator*)NULL);
 		}
         ifs.close();
 
-        Observable* observable_diag =  new Observable(qubit_count);
-        Observable* observable_non_diag =  new Observable(qubit_count);
+        RealValuedQuantumOperator* observable_diag =  new RealValuedQuantumOperator(qubit_count);
+        RealValuedQuantumOperator* observable_non_diag =  new RealValuedQuantumOperator(qubit_count);
 
         for (UINT i = 0; i < ops.size(); ++i){
             if (ops[i].find("X") != std::string::npos || ops[i].find("Y") != std::string::npos){

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -51,10 +51,11 @@ CPPCTYPE Observable::get_transition_amplitude(const QuantumStateBase* state_bra,
 namespace observable{
     Observable* create_observable_from_openfermion_file(std::string file_path){
         UINT qubit_count = 0;
+        UINT imag_idx;
 
         std::ifstream ifs;
         ifs.open(file_path);
-
+        double coef_real, coef_imag;
         if (!ifs){
             std::cerr << "ERROR: Cannot open file" << std::endl;
             std::exit(EXIT_FAILURE);
@@ -66,11 +67,25 @@ namespace observable{
         while (getline(ifs, str)) {
             std::vector<std::string> elems;
             std::vector<std::string> index_list;
-            elems = split(str, "()j[]+");
+            elems = split(str, "()[]+");
 
             chfmt(elems[3]);
 
-            CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+            imag_idx = 1;
+
+            if (elems[0].back() == 'j'){
+                coef_real = 0;
+                imag_idx = 0;
+                throw std::domain_error("Observable should be Hermitian.");
+            } else if (elems[1].back() != 'j'){
+                continue;
+            } else {
+                coef_real = std::stod(elems[imag_idx-1]);
+            }
+
+            coef_imag = std::stod(elems[imag_idx]);
+
+            CPPCTYPE coef(coef_real, coef_imag);
             coefs.push_back(coef);
             ops.push_back(elems[3]);
 
@@ -88,6 +103,10 @@ namespace observable{
 
         Observable* observable = new Observable(qubit_count);
 
+        // if (ops.size() == 0){
+        //     return observable;
+        // }
+
         for (UINT i = 0; i < ops.size(); ++i){
             observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
         }
@@ -97,20 +116,38 @@ namespace observable{
 
     Observable* create_observable_from_openfermion_text(std::string text){
         UINT qubit_count = 0;
+        UINT imag_idx;
 
         std::vector<std::string> lines;
         std::vector<CPPCTYPE> coefs;
         std::vector<std::string> ops;
+        double coef_real, coef_imag;
+
         lines = split(text, "\n");
 
         for (std::string line: lines){
             std::vector<std::string> elems;
             std::vector<std::string> index_list;
-            elems = split(line, "()j[]+");
+            elems = split(line, "()[]+");
 
             chfmt(elems[3]);
 
-            CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+            imag_idx = 1;
+
+            if (elems[0].back() == 'j'){
+                coef_real = 0;
+                imag_idx = 0;
+                throw std::domain_error("Observable should be Hermitian.");
+            } else if (elems[1].back() != 'j'){
+                continue;
+            } else {
+                coef_real = std::stod(elems[imag_idx-1]);
+            }
+
+            coef_imag = std::stod(elems[imag_idx]);
+
+            CPPCTYPE coef(coef_real, coef_imag);
+
             coefs.push_back(coef);
             ops.push_back(elems[3]);
 
@@ -133,6 +170,7 @@ namespace observable{
 
     std::pair<Observable*, Observable*> create_split_observable(std::string file_path){
         UINT qubit_count = 0;
+        UINT imag_idx;
 
         std::ifstream ifs;
         ifs.open(file_path);
@@ -146,15 +184,30 @@ namespace observable{
         std::string str;
         std::vector<CPPCTYPE> coefs;
         std::vector<std::string> ops;
+        double coef_real, coef_imag;
 
         while (getline(ifs, str)) {
             std::vector<std::string> elems;
             std::vector<std::string> index_list;
-            elems = split(str, "()j[]+");
+            elems = split(str, "()[]+");
 
             chfmt(elems[3]);
 
-            CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+            imag_idx = 1;
+
+            if (elems[0].back() == 'j'){
+                coef_real = 0;
+                imag_idx = 0;
+                throw std::domain_error("Observable should be Hermitian.");
+            } else if (elems[1].back() != 'j'){
+                continue;
+            } else {
+                coef_real = std::stod(elems[imag_idx-1]);
+            }
+
+            coef_imag = std::stod(elems[imag_idx]);
+
+            CPPCTYPE coef(coef_real, coef_imag);
             coefs.push_back(coef);
             ops.push_back(elems[3]);
 

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -68,6 +68,9 @@ namespace observable{
             std::vector<std::string> elems;
             std::vector<std::string> index_list;
             elems = split(str, "()[]+");
+            if (elems.size() < 3){
+                continue;
+            }
 
             chfmt(elems[3]);
 
@@ -103,10 +106,6 @@ namespace observable{
 
         Observable* observable = new Observable(qubit_count);
 
-        // if (ops.size() == 0){
-        //     return observable;
-        // }
-
         for (UINT i = 0; i < ops.size(); ++i){
             observable->add_operator(new PauliOperator(ops[i].c_str(), coefs[i].real()));
         }
@@ -129,7 +128,9 @@ namespace observable{
             std::vector<std::string> elems;
             std::vector<std::string> index_list;
             elems = split(line, "()[]+");
-
+            if (elems.size() < 3){
+                continue;
+            }
             chfmt(elems[3]);
 
             imag_idx = 1;
@@ -190,7 +191,9 @@ namespace observable{
             std::vector<std::string> elems;
             std::vector<std::string> index_list;
             elems = split(str, "()[]+");
-
+            if (elems.size() < 3){
+                continue;
+            }
             chfmt(elems[3]);
 
             imag_idx = 1;

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -58,7 +58,7 @@ public:
      * @param[in] coef pauli_stringで作られるPauliOperatorの係数
      * @param[in] pauli_string パウリ演算子と掛かるindexの組からなる文字列。(example: "X 1 Y 2 Z 5")
      */
-    void add_operator(double coef, std::string pauli_string);
+    void add_operator(CPPCTYPE coef, std::string pauli_string);
 
     /**
      * \~japanese-en
@@ -103,7 +103,7 @@ public:
      * @param[in] state 期待値をとるときの量子状態
      * @return 入力で与えた量子状態に対応するオブザーバブルの期待値
      */
-    double get_expectation_value(const QuantumStateBase* state) const ;
+    CPPCTYPE get_expectation_value(const QuantumStateBase* state) const ;
 
     /**
      * \~japanese-en

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -1,6 +1,6 @@
 /**
  * @file Observable.hpp
- * @brief Definition and basic functions for Observable
+ * @brief Definition and basic functions for RealValuedQuantumOperator
  */
 
 
@@ -11,38 +11,29 @@
 #include <vector>
 #include <utility>
 #include <string>
+#include "pauli_operator.hpp"
 
 class QuantumStateBase;
 class PauliOperator;
+class GeneralQuantumOperator;
 
 /**
  * \~japanese-en
- * @struct Observable
+ * @struct RealValuedQuantumOperator
  * オブザーバブルの情報を保持するクラス。
  * PauliOperatorをリストとして持ち, 種々の操作を行う。解放時には保持しているPauliOperatorを全て解放する。
  */
-class DllExport Observable {
-private:
-    //! list of multi pauli term
-    std::vector<PauliOperator*> _operator_list;
-    //! the number of qubits
-    UINT _qubit_count;
+class DllExport RealValuedQuantumOperator : public GeneralQuantumOperator {
 public:
     /**
      * \~japanese-en
      * コンストラクタ。
      *
-     * 空のオブザーバブルを作成する。
+     * 空のRealValuedQuantumOperatorを作成する。
      * @param[in] qubit_count qubit数
-     * @return Observableのインスタンス
+     * @return RealValuedQuantumOperatorのインスタンス
      */
-    Observable(UINT qubit_count);
-
-    /**
-     * \~japanese-en
-     * デストラクタ。このとき、オブザーバブルが保持しているPauliOperatorは解放される。
-     */
-    virtual ~Observable();
+    using GeneralQuantumOperator::GeneralQuantumOperator;
 
     /**
      * \~japanese-en
@@ -63,77 +54,24 @@ public:
 
     /**
      * \~japanese-en
-     * オブザーバブルが掛かるqubit数を返す。
-     * @return オブザーバブルのqubit数
-     */
-    UINT get_qubit_count() const { return _qubit_count; }
-
-    /**
-     * \~japanese-en
-     * オブザーバブルの行列表現の次元を返す。
-     * @return オブザーバブルの次元
-     */
-    ITYPE get_state_dim() const { return (1ULL) << _qubit_count; }
-
-    /**
-     * \~japanese-en
-     * オブザーバブルが保持するPauliOperatorの数を返す
-     * @return オブザーバブルが保持するPauliOperatorの数
-     */
-    UINT get_term_count() const { return (UINT)_operator_list.size(); }
-
-    /**
-     * \~japanese-en
-     * オブザーバブルの指定した添字に対応するPauliOperatorを返す
-     * @param[in] index オブザーバブルが保持するPauliOperatorのリストの添字
-     * @return 指定したindexにあるPauliOperator
-     */
-    const PauliOperator* get_term(UINT index) const { 
-		if (index >= _operator_list.size()) {
-			std::cerr << "Error: PauliOperator::get_term(UINT): index out of range" << std::endl;
-			return NULL;
-		}
-		return _operator_list[index]; 
-	}
-
-    /**
-     * \~japanese-en
-     * オブザーバブルが保持するPauliOperatorのリストを返す
-     * @return オブザーバブルが持つPauliOperatorのリスト
-     */
-    std::vector<PauliOperator*> get_terms() const { return _operator_list;}
-
-    /**
-     * \~japanese-en
-     * オブザーバブルのある量子状態に対応するエネルギー(期待値)を計算して返す
+     * RealValuedQuantumOperatorのある量子状態に対応するエネルギー(期待値)を計算して返す
      *
      * @param[in] state 期待値をとるときの量子状態
-     * @return 入力で与えた量子状態に対応するオブザーバブルの期待値
+     * @return 入力で与えた量子状態に対応するRealValuedQuantumOperatorの期待値
      */
     CPPCTYPE get_expectation_value(const QuantumStateBase* state) const ;
-
-    /**
-     * \~japanese-en
-     * オブザーバブルによってある状態が別の状態に移る遷移振幅を計算して返す
-     *
-     * @param[in] state_bra 遷移先の量子状態
-     * @param[in] state_ket 遷移前の量子状態
-     * @return 入力で与えた量子状態に対応するオブザーバブルの遷移振幅
-     */
-    CPPCTYPE get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const;
-
 };
 
-namespace observable{
+namespace realValuedQuantumOperator{
     /**
      * \~japanese-en
      *
-     * OpenFermionから出力されたオブザーバブルのテキストファイルを読み込んでObservableを生成します。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
+     * OpenFermionから出力されたオブザーバブルのテキストファイルを読み込んでRealValuedQuantumOperatorを生成します。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
      *
      * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
      * @return Observableのインスタンス
      **/
-    DllExport Observable* create_observable_from_openfermion_file(std::string file_path);
+    DllExport RealValuedQuantumOperator* create_observable_from_openfermion_file(std::string file_path);
 
     /**
      * \~japanese-en
@@ -143,7 +81,7 @@ namespace observable{
      * @param[in] filename OpenFermion形式のテキスト
      * @return Observableのインスタンス
      **/
-    DllExport Observable* create_observable_from_openfermion_text(std::string text);
+    DllExport RealValuedQuantumOperator* create_observable_from_openfermion_text(std::string text);
 
     /**
      * \~japanese-en
@@ -151,5 +89,9 @@ namespace observable{
      *
      * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
      */
-    DllExport std::pair<Observable*, Observable*> create_split_observable(std::string file_path);
+    DllExport std::pair<RealValuedQuantumOperator*, RealValuedQuantumOperator*> create_split_observable(std::string file_path);
+
 }
+
+typedef RealValuedQuantumOperator Observable;
+namespace observable = realValuedQuantumOperator;

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -1,6 +1,6 @@
 /**
  * @file Observable.hpp
- * @brief Definition and basic functions for RealValuedQuantumOperator
+ * @brief Definition and basic functions for HermitianQuantumOperator
  */
 
 
@@ -19,19 +19,19 @@ class GeneralQuantumOperator;
 
 /**
  * \~japanese-en
- * @struct RealValuedQuantumOperator
+ * @struct HermitianQuantumOperator
  * オブザーバブルの情報を保持するクラス。
  * PauliOperatorをリストとして持ち, 種々の操作を行う。解放時には保持しているPauliOperatorを全て解放する。
  */
-class DllExport RealValuedQuantumOperator : public GeneralQuantumOperator {
+class DllExport HermitianQuantumOperator : public GeneralQuantumOperator {
 public:
     /**
      * \~japanese-en
      * コンストラクタ。
      *
-     * 空のRealValuedQuantumOperatorを作成する。
+     * 空の HermitianQuantumOperator を作成する。
      * @param[in] qubit_count qubit数
-     * @return RealValuedQuantumOperatorのインスタンス
+     * @return HermitianQuantumOperatorのインスタンス
      */
     using GeneralQuantumOperator::GeneralQuantumOperator;
 
@@ -54,10 +54,10 @@ public:
 
     /**
      * \~japanese-en
-     * RealValuedQuantumOperatorのある量子状態に対応するエネルギー(期待値)を計算して返す
+     * HermitianQuantumOperatorのある量子状態に対応するエネルギー(期待値)を計算して返す
      *
      * @param[in] state 期待値をとるときの量子状態
-     * @return 入力で与えた量子状態に対応するRealValuedQuantumOperatorの期待値
+     * @return 入力で与えた量子状態に対応するHermitianQuantumOperatorの期待値
      */
     CPPCTYPE get_expectation_value(const QuantumStateBase* state) const ;
 };
@@ -66,12 +66,12 @@ namespace observable{
     /**
      * \~japanese-en
      *
-     * OpenFermionから出力されたオブザーバブルのテキストファイルを読み込んでRealValuedQuantumOperatorを生成します。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
+     * OpenFermionから出力されたオブザーバブルのテキストファイルを読み込んでHermitianQuantumOperatorを生成します。オブザーバブルのqubit数はファイル読み込み時に、オブザーバブルの構成に必要なqubit数となります。
      *
      * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
      * @return Observableのインスタンス
      **/
-    DllExport RealValuedQuantumOperator* create_observable_from_openfermion_file(std::string file_path);
+    DllExport HermitianQuantumOperator* create_observable_from_openfermion_file(std::string file_path);
 
     /**
      * \~japanese-en
@@ -81,7 +81,7 @@ namespace observable{
      * @param[in] filename OpenFermion形式のテキスト
      * @return Observableのインスタンス
      **/
-    DllExport RealValuedQuantumOperator* create_observable_from_openfermion_text(std::string text);
+    DllExport HermitianQuantumOperator* create_observable_from_openfermion_text(std::string text);
 
     /**
      * \~japanese-en
@@ -89,8 +89,8 @@ namespace observable{
      *
      * @param[in] filename OpenFermion形式のオブザーバブルのファイル名
      */
-    DllExport std::pair<RealValuedQuantumOperator*, RealValuedQuantumOperator*> create_split_observable(std::string file_path);
+    DllExport std::pair<HermitianQuantumOperator*, HermitianQuantumOperator*> create_split_observable(std::string file_path);
 
 }
 
-typedef RealValuedQuantumOperator Observable;
+typedef HermitianQuantumOperator Observable;

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -62,7 +62,7 @@ public:
     CPPCTYPE get_expectation_value(const QuantumStateBase* state) const ;
 };
 
-namespace realValuedQuantumOperator{
+namespace observable{
     /**
      * \~japanese-en
      *
@@ -94,4 +94,3 @@ namespace realValuedQuantumOperator{
 }
 
 typedef RealValuedQuantumOperator Observable;
-namespace observable = realValuedQuantumOperator;

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -11,7 +11,7 @@ extern "C"{
 #include "pauli_operator.hpp"
 #include "state.hpp"
 
-PauliOperator::PauliOperator(std::string strings, double coef){
+PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef){
     _coef = coef;
     std::stringstream ss(strings);
     std::string pauli_str;
@@ -31,7 +31,7 @@ PauliOperator::PauliOperator(std::string strings, double coef){
     }
 }
 
-PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list, std::string Pauli_operator_type_list, double coef){
+PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list, std::string Pauli_operator_type_list, CPPCTYPE coef){
     _coef = coef;
     UINT term_count = (UINT)(strlen(Pauli_operator_type_list.c_str()));
     UINT pauli_type = 0;
@@ -53,7 +53,7 @@ PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list, std::st
     }
 }
 
-PauliOperator::PauliOperator(const std::vector<UINT>& pauli_list, double coef) {
+PauliOperator::PauliOperator(const std::vector<UINT>& pauli_list, CPPCTYPE coef) {
     _coef = coef;
     for (UINT term_index = 0; term_index < pauli_list.size(); ++term_index) {
         if (pauli_list[term_index] != 0)
@@ -61,7 +61,7 @@ PauliOperator::PauliOperator(const std::vector<UINT>& pauli_list, double coef) {
     }
 }
 
-PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_index_list, const std::vector<UINT>& target_qubit_pauli_list, double coef) {
+PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_index_list, const std::vector<UINT>& target_qubit_pauli_list, CPPCTYPE coef) {
     _coef = coef;
     assert(target_qubit_index_list.size() == target_qubit_pauli_list.size());
     for (UINT term_index = 0; term_index < target_qubit_index_list.size(); ++term_index) {
@@ -73,7 +73,7 @@ void PauliOperator::add_single_Pauli(UINT qubit_index, UINT pauli_type){
     this->_pauli_list.push_back(SinglePauliOperator(qubit_index, pauli_type));
 }
 
-double PauliOperator::get_expectation_value(const QuantumStateBase* state) const {
+CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) const {
     return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
         this->get_index_list().data(),
         this->get_pauli_id_list().data(),
@@ -84,7 +84,7 @@ double PauliOperator::get_expectation_value(const QuantumStateBase* state) const
 }
 
 CPPCTYPE PauliOperator::get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const {
-    return _coef * transition_amplitude_multi_qubit_Pauli_operator_partial_list(
+    return _coef * (CPPCTYPE)transition_amplitude_multi_qubit_Pauli_operator_partial_list(
         this->get_index_list().data(),
         this->get_pauli_id_list().data(),
         (UINT)this->get_index_list().size(),

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -187,7 +187,7 @@ CPPCTYPE GeneralQuantumOperator::get_transition_amplitude(const QuantumStateBase
     return sum;
 }
 
-namespace generalQuantumOperator{
+namespace quantum_operator{
     GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_file(std::string file_path){
         UINT qubit_count = 0;
         UINT imag_idx;

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -1,6 +1,18 @@
 #include <cassert>
 #include <cstring>
 
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "type.hpp"
+#include "utility.hpp"
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <utility>
+
+
 #ifndef _MSC_VER
 extern "C"{
 #include <csim/stat_ops.h>
@@ -10,6 +22,7 @@ extern "C"{
 #endif
 #include "pauli_operator.hpp"
 #include "state.hpp"
+
 
 PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef){
     _coef = coef;
@@ -102,3 +115,274 @@ PauliOperator* PauliOperator::copy() const {
     }
     return pauli;
 }
+
+
+bool check_Pauli_operator(const GeneralQuantumOperator* observable, const PauliOperator* pauli_operator) {
+	auto vec = pauli_operator->get_index_list();
+	UINT val = 0;
+	if (vec.size() > 0) {
+		val = std::max(val, *std::max_element(vec.begin(), vec.end()));
+	}
+	return val < (observable->get_qubit_count());
+}
+
+GeneralQuantumOperator::GeneralQuantumOperator(UINT qubit_count){
+    _qubit_count = qubit_count;
+    _is_hermitian = true;
+}
+
+GeneralQuantumOperator::~GeneralQuantumOperator(){
+    for(auto& term : this->_operator_list){
+        delete term;
+    }
+}
+
+void GeneralQuantumOperator::add_operator(const PauliOperator* mpt){
+    PauliOperator* _mpt = mpt->copy();
+	if (!check_Pauli_operator(this, _mpt)) {
+		std::cerr << "Error: GeneralQuantumOperator::add_operator(const PauliOperator*): pauli_operator applies target qubit of which the index is larger than qubit_count" << std::endl;
+		return;
+	}
+    if (this->_is_hermitian && std::abs(_mpt->get_coef().imag()) > 0){
+        this->_is_hermitian = false;
+    }
+    this->_operator_list.push_back(_mpt);
+}
+
+void GeneralQuantumOperator::add_operator(CPPCTYPE coef, std::string pauli_string) {
+	PauliOperator* _mpt = new PauliOperator(pauli_string, coef);
+	if (!check_Pauli_operator(this, _mpt)) {
+		std::cerr << "Error: GeneralQuantumOperator::add_operator(double,std::string): pauli_operator applies target qubit of which the index is larger than qubit_count" << std::endl;
+		return;
+	}
+    if (this->_is_hermitian && std::abs(coef.imag()) > 0){
+        this->_is_hermitian = false;
+    }
+	this->add_operator(_mpt);
+}
+
+CPPCTYPE GeneralQuantumOperator::get_expectation_value(const QuantumStateBase* state) const {
+	if (this->_qubit_count != state->qubit_count) {
+		std::cerr << "Error: GeneralQuantumOperator::get_expectation_value(const QuantumStateBase*): invalid qubit count" << std::endl;
+		return 0.;
+	}
+
+    CPPCTYPE sum = 0;
+    for (auto pauli : this->_operator_list) {
+        sum += pauli->get_expectation_value(state);
+    }
+    return sum;
+}
+
+CPPCTYPE GeneralQuantumOperator::get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const {
+	if (this->_qubit_count != state_bra->qubit_count || this->_qubit_count != state_ket->qubit_count) {
+		std::cerr << "Error: GeneralQuantumOperator::get_transition_amplitude(const QuantumStateBase*, const QuantumStateBase*): invalid qubit count" << std::endl;
+		return 0.;
+	}
+
+	CPPCTYPE sum = 0;
+    for (auto pauli : this->_operator_list) {
+        sum += pauli->get_transition_amplitude(state_bra, state_ket);
+    }
+    return sum;
+}
+
+namespace generalQuantumOperator{
+    GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_file(std::string file_path){
+        UINT qubit_count = 0;
+        UINT imag_idx;
+        UINT str_idx;
+
+        std::ifstream ifs;
+        ifs.open(file_path);
+        double coef_real, coef_imag;
+        if (!ifs){
+            std::cerr << "ERROR: Cannot open file" << std::endl;
+			return NULL;
+		}
+
+        std::string str;
+        std::vector<CPPCTYPE> coefs;
+        std::vector<std::string> ops;
+        while (getline(ifs, str)) {
+            std::vector<std::string> elems;
+            std::vector<std::string> index_list;
+            elems = split(str, "()[]+");
+            if (elems.size() < 3){
+                continue;
+            }
+
+
+            imag_idx = 1;
+            str_idx = 3;
+
+            if (elems[0].find("j") != std::string::npos){
+                coef_real = 0;
+                imag_idx = 0;
+                str_idx = 1;
+            } else if (elems[1].find("j") != std::string::npos){
+                coef_real = std::stod(elems[imag_idx-1]);
+            } else {
+                continue;
+            }
+
+            coef_imag = std::stod(elems[imag_idx]);
+            chfmt(elems[str_idx]);
+
+            CPPCTYPE coef(coef_real, coef_imag);
+            coefs.push_back(coef);
+            ops.push_back(elems[str_idx]);
+
+            index_list = split(elems[str_idx], "XYZ ");
+            for (UINT i = 0; i < index_list.size(); ++i){
+                UINT n = std::stoi(index_list[i]) + 1;
+                if (qubit_count < n)
+                    qubit_count = n;
+            }
+        }
+        if (!ifs.eof()){
+            std::cerr << "ERROR: Invalid format" << std::endl;
+			return NULL;
+		}
+        ifs.close();
+
+        GeneralQuantumOperator* general_quantum_operator = new GeneralQuantumOperator(qubit_count);
+
+        for (UINT i = 0; i < ops.size(); ++i){
+            general_quantum_operator->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
+        }
+
+        return general_quantum_operator;
+    }
+
+    GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_text(std::string text){
+        UINT qubit_count = 0;
+        UINT imag_idx;
+        UINT str_idx;
+
+        std::vector<std::string> lines;
+        std::vector<CPPCTYPE> coefs;
+        std::vector<std::string> ops;
+        double coef_real, coef_imag;
+
+        lines = split(text, "\n");
+
+        for (std::string line: lines){
+            std::vector<std::string> elems;
+            std::vector<std::string> index_list;
+            elems = split(line, "()[]+");
+            if (elems.size() < 3){
+                continue;
+            }
+
+            imag_idx = 1;
+            str_idx = 3;
+            if (elems[0].find("j") != std::string::npos){
+                coef_real = 0;
+                imag_idx = 0;
+                str_idx = 1;
+            } else if (elems[1].find("j") != std::string::npos){
+                coef_real = std::stod(elems[imag_idx-1]);
+            } else {
+                continue;
+            }
+
+            coef_imag = std::stod(elems[imag_idx]);
+            chfmt(elems[str_idx]);
+
+            CPPCTYPE coef(coef_real, coef_imag);
+
+            coefs.push_back(coef);
+            ops.push_back(elems[str_idx]);
+
+            index_list = split(elems[str_idx], "XYZ ");
+            for (UINT i = 0; i < index_list.size(); ++i){
+                UINT n = std::stoi(index_list[i]) + 1;
+                if (qubit_count < n)
+                    qubit_count = n;
+            }
+        }
+
+        GeneralQuantumOperator* general_quantum_operator = new GeneralQuantumOperator(qubit_count);
+
+        for (UINT i = 0; i < ops.size(); ++i){
+            general_quantum_operator->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
+        }
+
+        return general_quantum_operator;
+    }
+
+    std::pair<GeneralQuantumOperator*, GeneralQuantumOperator*> create_split_general_quantum_operator(std::string file_path){
+        UINT qubit_count = 0;
+        UINT imag_idx;
+        UINT str_idx;
+        std::ifstream ifs;
+        ifs.open(file_path);
+
+        if (!ifs){
+            std::cerr << "ERROR: Cannot open file" << std::endl;
+			return std::make_pair((GeneralQuantumOperator*)NULL, (GeneralQuantumOperator*)NULL);
+        }
+
+        // loading lines and check qubit_count
+        std::string str;
+        std::vector<CPPCTYPE> coefs;
+        std::vector<std::string> ops;
+        double coef_real, coef_imag;
+
+        while (getline(ifs, str)) {
+            std::vector<std::string> elems;
+            std::vector<std::string> index_list;
+            elems = split(str, "()[]+");
+            if (elems.size() < 3){
+                continue;
+            }
+
+            imag_idx = 1;
+            str_idx = 3;
+            if (elems[0].find("j") != std::string::npos){
+                coef_real = 0;
+                imag_idx = 0;
+                str_idx = 1;
+            } else if (elems[1].find("j") == std::string::npos){
+                coef_real = std::stod(elems[imag_idx-1]);
+            } else {
+                continue;
+            }
+
+            coef_imag = std::stod(elems[imag_idx]);
+            chfmt(elems[str_idx]);
+
+            CPPCTYPE coef(coef_real, coef_imag);
+            coefs.push_back(coef);
+            ops.push_back(elems[str_idx]);
+
+            index_list = split(elems[str_idx], "XYZ ");
+            for (UINT i = 0; i < index_list.size(); ++i){
+                UINT n = std::stoi(index_list[i]) + 1;
+                if (qubit_count < n)
+                    qubit_count = n;
+            }
+        }
+        if (!ifs.eof()){
+            std::cerr << "ERROR: Invalid format" << std::endl;
+			return std::make_pair((GeneralQuantumOperator*)NULL, (GeneralQuantumOperator*)NULL);
+		}
+        ifs.close();
+
+        GeneralQuantumOperator* general_quantum_operator_diag =  new GeneralQuantumOperator(qubit_count);
+        GeneralQuantumOperator* general_quantum_operator_non_diag =  new GeneralQuantumOperator(qubit_count);
+
+        for (UINT i = 0; i < ops.size(); ++i){
+            if (ops[i].find("X") != std::string::npos || ops[i].find("Y") != std::string::npos){
+                general_quantum_operator_non_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
+            }else{
+                general_quantum_operator_diag->add_operator(new PauliOperator(ops[i].c_str(), coefs[i]));
+            }
+        }
+
+        return std::make_pair(general_quantum_operator_diag, general_quantum_operator_non_diag);
+    }
+}
+
+

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -63,7 +63,7 @@ public:
 class DllExport PauliOperator{
 private:
     std::vector<SinglePauliOperator> _pauli_list;
-    double _coef;
+    CPPCTYPE _coef;
 public:
     /**
      * \~japanese-en
@@ -102,7 +102,7 @@ public:
      * @param[in] coef 係数。デフォルトは1.0
      * @return 係数がcoefの空のインスタンス
      */
-    PauliOperator(double coef=1.0): _coef(coef){};
+    PauliOperator(CPPCTYPE coef=1.): _coef(coef){};
 
     /**
      * \~japanese-en
@@ -114,7 +114,7 @@ public:
      * @param[in] coef 演算子の係数
      * @return 入力のパウリ演算子と係数をもつPauliOpetatorのインスタンス
      */
-    PauliOperator(std::string strings, double coef=1.0);
+    PauliOperator(std::string strings, CPPCTYPE coef=1.);
 
     /**
      * \~japanese-en
@@ -128,7 +128,7 @@ public:
      * @param[in] coef 係数
      * @return 入力として与えたパウリ演算子のリストと添字のリスト、係数から生成されるPauliOperatorのインスタンス
      */
-    PauliOperator(const std::vector<UINT>& target_qubit_index_list, std::string Pauli_operator_type_list, double coef = 1.);
+    PauliOperator(const std::vector<UINT>& target_qubit_index_list, std::string Pauli_operator_type_list, CPPCTYPE coef = 1.);
 
     /**
      * \~japanese-en
@@ -139,7 +139,7 @@ public:
      * @param[in] coef 係数
      * @return pauli_listの添字に対応するqubitに作用するパウリ演算子と係数をもつインスタンス
      */
-    PauliOperator(const std::vector<UINT>& pauli_list, double coef = 1.);
+    PauliOperator(const std::vector<UINT>& pauli_list, CPPCTYPE coef = 1.);
 
     /**
      * \~japanese-en
@@ -153,7 +153,7 @@ public:
      * @param[in] coef 係数
      * @return 入力として与えたパウリ演算子のリストと添字のリスト、係数から生成されるPauliOperatorのインスタンス
      */
-    PauliOperator(const std::vector<UINT>& target_qubit_index_list, const std::vector<UINT>& target_qubit_pauli_list, double coef=1.);
+    PauliOperator(const std::vector<UINT>& target_qubit_index_list, const std::vector<UINT>& target_qubit_pauli_list, CPPCTYPE coef=1.);
 
 
     /**
@@ -162,7 +162,7 @@ public:
      *
      * @return 自身の係数
      */
-    virtual double get_coef() const { return _coef; }
+    virtual CPPCTYPE get_coef() const { return _coef; }
 
     virtual ~PauliOperator(){};
 
@@ -182,7 +182,7 @@ public:
      * @param[in] state 期待値をとるときの量子状態
      * @return stateに対応する期待値
      */
-    virtual double get_expectation_value(const QuantumStateBase* state) const;
+    virtual CPPCTYPE get_expectation_value(const QuantumStateBase* state) const;
 
     /**
      * \~japanese-en

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -321,7 +321,7 @@ public:
 
 };
 
-namespace generalQuantumOperator{
+namespace quantum_operator{
     /**
      * \~japanese-en
      *

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -206,3 +206,149 @@ public:
     virtual PauliOperator* copy() const;
 
 };
+
+
+
+class DllExport GeneralQuantumOperator {
+private:
+    //! list of multi pauli term
+    std::vector<PauliOperator*> _operator_list;
+    //! the number of qubits
+    UINT _qubit_count;
+    bool _is_hermitian;
+public:
+    /**
+     * \~japanese-en
+     * コンストラクタ。
+     *
+     * 空のGeneralQuantumOperatorを作成する。
+     * @param[in] qubit_count qubit数
+     * @return Observableのインスタンス
+     */
+    GeneralQuantumOperator(UINT qubit_count);
+
+    /**
+     * \~japanese-en
+     * デストラクタ。このとき、GeneralQuantumOperatorが保持しているPauliOperatorは解放される。
+     */
+    virtual ~GeneralQuantumOperator();
+
+    /**
+     * \~japanese-en
+     * PauliOperatorを内部で保持するリストの末尾に追加する。
+     *
+     * @param[in] mpt 追加するPauliOperatorのインスタンス
+     */
+    virtual bool is_hermitian() const { return _is_hermitian; }
+
+    /**
+     * \~japanese-en
+     * PauliOperatorを内部で保持するリストの末尾に追加する。
+     *
+     * @param[in] mpt 追加するPauliOperatorのインスタンス
+     */
+    virtual void add_operator(const PauliOperator* mpt);
+
+    /**
+     * \~japanese-en
+     * パウリ演算子の文字列と係数の組をGeneralQuantumOperatorに追加する。
+     *
+     * @param[in] coef pauli_stringで作られるPauliOperatorの係数
+     * @param[in] pauli_string パウリ演算子と掛かるindexの組からなる文字列。(example: "X 1 Y 2 Z 5")
+     */
+    virtual void add_operator(CPPCTYPE coef, std::string pauli_string);
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorが掛かるqubit数を返す。
+     * @return GeneralQuantumOperatorのqubit数
+     */
+    virtual UINT get_qubit_count() const { return _qubit_count; }
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorの行列表現の次元を返す。
+     * @return GeneralQuantumOperatorの次元
+     */
+    virtual ITYPE get_state_dim() const { return (1ULL) << _qubit_count; }
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorが保持するPauliOperatorの数を返す
+     * @return GeneralQuantumOperatorが保持するPauliOperatorの数
+     */
+    virtual UINT get_term_count() const { return (UINT)_operator_list.size(); }
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorの指定した添字に対応するPauliOperatorを返す
+     * @param[in] index GeneralQuantumOperatorが保持するPauliOperatorのリストの添字
+     * @return 指定したindexにあるPauliOperator
+     */
+    virtual const PauliOperator* get_term(UINT index) const {
+		if (index >= _operator_list.size()) {
+			std::cerr << "Error: PauliOperator::get_term(UINT): index out of range" << std::endl;
+			return NULL;
+		}
+		return _operator_list[index];
+	}
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorが保持するPauliOperatorのリストを返す
+     * @return GeneralQuantumOperatorが持つPauliOperatorのリスト
+     */
+    virtual std::vector<PauliOperator*> get_terms() const { return _operator_list;}
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorのある量子状態に対応するエネルギー(期待値)を計算して返す
+     *
+     * @param[in] state 期待値をとるときの量子状態
+     * @return 入力で与えた量子状態に対応するGeneralQuantumOperatorの期待値
+     */
+    virtual CPPCTYPE get_expectation_value(const QuantumStateBase* state) const ;
+
+    /**
+     * \~japanese-en
+     * GeneralQuantumOperatorによってある状態が別の状態に移る遷移振幅を計算して返す
+     *
+     * @param[in] state_bra 遷移先の量子状態
+     * @param[in] state_ket 遷移前の量子状態
+     * @return 入力で与えた量子状態に対応するGeneralQuantumOperatorの遷移振幅
+     */
+    virtual CPPCTYPE get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const;
+
+};
+
+namespace generalQuantumOperator{
+    /**
+     * \~japanese-en
+     *
+     * OpenFermionから出力されたGeneralQuantumOperatorのテキストファイルを読み込んでGeneralQuantumOperatorを生成します。GeneralQuantumOperatorのqubit数はファイル読み込み時に、GeneralQuantumOperatorの構成に必要なqubit数となります。
+     *
+     * @param[in] filename OpenFermion形式のGeneralQuantumOperatorのファイル名
+     * @return Observableのインスタンス
+     **/
+    DllExport GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_file(std::string file_path);
+
+    /**
+     * \~japanese-en
+     *
+     * OpenFermionの出力テキストを読み込んでGeneralQuantumOperatorを生成します。GeneralQuantumOperatorのqubit数はファイル読み込み時に、GeneralQuantumOperatorの構成に必要なqubit数となります。
+     *
+     * @param[in] filename OpenFermion形式のテキスト
+     * @return General_Quantum_Operatorのインスタンス
+     **/
+    DllExport GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_text(std::string text);
+
+    /**
+     * \~japanese-en
+     * OpenFermion形式のファイルを読んで、対角なGeneralQuantumOperatorと非対角なGeneralQuantumOperatorを返す。GeneralQuantumOperatorのqubit数はファイル読み込み時に、GeneralQuantumOperatorの構成に必要なqubit数となります。
+     *
+     * @param[in] filename OpenFermion形式のGeneralQuantumOperatorのファイル名
+     */
+    DllExport std::pair<GeneralQuantumOperator*, GeneralQuantumOperator*> create_split_general_quantum_operator(std::string file_path);
+}
+
+bool check_Pauli_operator(const GeneralQuantumOperator* observable, const PauliOperator* pauli_operator);

--- a/src/cppsim/simulator.cpp
+++ b/src/cppsim/simulator.cpp
@@ -30,7 +30,7 @@ void QuantumCircuitSimulator::simulate_range(UINT start, UINT end) {
     _circuit->update_quantum_state(_state, start, end);
 }
 
-double QuantumCircuitSimulator::get_expectation_value(const Observable* observable) {
+CPPCTYPE QuantumCircuitSimulator::get_expectation_value(const Observable* observable) {
     return observable->get_expectation_value(_state);
 }
 

--- a/src/cppsim/simulator.hpp
+++ b/src/cppsim/simulator.hpp
@@ -5,7 +5,8 @@
 #include "type.hpp"
 #include "circuit.hpp"
 class QuantumStateBase;
-class Observable;
+class RealValuedQuantumOperator;
+typedef RealValuedQuantumOperator Observable;
 
 
 /**

--- a/src/cppsim/simulator.hpp
+++ b/src/cppsim/simulator.hpp
@@ -5,8 +5,8 @@
 #include "type.hpp"
 #include "circuit.hpp"
 class QuantumStateBase;
-class RealValuedQuantumOperator;
-typedef RealValuedQuantumOperator Observable;
+class HermitianQuantumOperator;
+typedef HermitianQuantumOperator Observable;
 
 
 /**

--- a/src/cppsim/simulator.hpp
+++ b/src/cppsim/simulator.hpp
@@ -60,7 +60,7 @@ public:
      * @param observable オブザーバブル
      * @return 期待値
      */
-    double get_expectation_value(const Observable* observable);
+    CPPCTYPE get_expectation_value(const Observable* observable);
 
     /**
      * \~japanese-en 量子回路中のゲートの数を取得する

--- a/src/vqcsim/problem.hpp
+++ b/src/vqcsim/problem.hpp
@@ -79,7 +79,7 @@ public:
     virtual ITYPE get_state_dim() const { return _observable->get_state_dim(); }
     virtual UINT get_qubit_count() const { return _observable->get_qubit_count(); }
     virtual double compute_loss(const QuantumStateBase* state) const {
-        return _observable->get_expectation_value(state);
+        return _observable->get_expectation_value(state).real();
     };
 };
 

--- a/src/vqcsim/solver.hpp
+++ b/src/vqcsim/solver.hpp
@@ -120,7 +120,7 @@ public:
         ComplexMatrix observable_matrix = ComplexMatrix::Zero(matrix_dim, matrix_dim);
         for (UINT term_index = 0; term_index < term_count; ++term_index) {
             auto Pauli_operator = instance->get_Pauli_operator(term_index);
-            double coef = Pauli_operator->get_coef();
+            CPPCTYPE coef = Pauli_operator->get_coef();
             auto target_index_list = Pauli_operator->get_index_list();
             auto pauli_id_list = Pauli_operator->get_pauli_id_list();
             

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -554,7 +554,7 @@ TEST(CircuitTest, SuzukiTrotterExpansion) {
     Random random;
     random.set_seed(seed);
 
-    double res;
+    CPPCTYPE res;
     CPPCTYPE test_res;
 
     Observable diag_observable(n), non_diag_observable(n), observable(n);
@@ -605,7 +605,7 @@ TEST(CircuitTest, SuzukiTrotterExpansion) {
 
     res = observable.get_expectation_value(&state);
     test_res = (test_state.adjoint() * test_observable * test_state);
-    ASSERT_NEAR(abs(test_res.real() - res)/ res, 0, 0.01);
+    ASSERT_NEAR(abs(test_res.real() - res.real())/ test_res.real(), 0, 0.01);
 
 
     state.set_Haar_random_state(seed);
@@ -616,7 +616,7 @@ TEST(CircuitTest, SuzukiTrotterExpansion) {
 
     res = observable.get_expectation_value(&state);
     test_res = (test_state.adjoint() * test_observable * test_state);
-    ASSERT_NEAR(abs(test_res.real() - res)/ res, 0, 0.01);
+    ASSERT_NEAR(abs(test_res.real() - res.real())/ test_res.real(), 0, 0.01);
 }
 
 
@@ -635,7 +635,7 @@ TEST(CircuitTest, RotateDiagonalObservable){
     double angle, coef1, coef2;
     Random random;
 
-    double res;
+    CPPCTYPE res;
     CPPCTYPE test_res;
 
     Observable observable(n);
@@ -673,8 +673,10 @@ TEST(CircuitTest, RotateDiagonalObservable){
     test_res = (test_state.adjoint() * test_observable * test_state);
 
     // for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(test_state[i] - state.data_cpp()[i]), 0, eps);
-    ASSERT_NEAR(abs(test_res.real() - res)/test_res.real(), 0, 0.01);
+    ASSERT_NEAR(abs(test_res.real() - res.real())/test_res.real(), 0, 0.01);
+    ASSERT_NEAR(res.imag(), 0, eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);
+
 
     state.set_Haar_random_state();
     for (ITYPE i = 0; i < dim; ++i) test_state[i] = state.data_cpp()[i];
@@ -689,7 +691,8 @@ TEST(CircuitTest, RotateDiagonalObservable){
     test_res = (test_state.adjoint() * test_observable * test_state);
 
     // for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(test_state[i] - state.data_cpp()[i]), 0, eps);
-    ASSERT_NEAR(abs(test_res.real() - res)/test_res.real(), 0, 0.01);
+    ASSERT_NEAR(abs(test_res.real() - res.real())/test_res.real(), 0, 0.01);
+    ASSERT_NEAR(res.imag(), 0, eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);
 
 }

--- a/test/cppsim/test_hamiltonian.cpp
+++ b/test/cppsim/test_hamiltonian.cpp
@@ -16,8 +16,8 @@ TEST(ObservableTest, CheckExpectationValue) {
     const UINT dim = 1ULL << n;
     const double eps = 1e-14;
     double coef;
-    double res;
-    std::complex<double> test_res;
+    CPPCTYPE res;
+    CPPCTYPE test_res;
     Random random;
 
     Eigen::MatrixXcd X(2, 2);
@@ -36,14 +36,16 @@ TEST(ObservableTest, CheckExpectationValue) {
 
     res = observable.get_expectation_value(&state);
     test_res = (test_state.adjoint() * test_observable * test_state);
-    ASSERT_NEAR(test_res.real(), res, eps);
+    ASSERT_NEAR(test_res.real(), res.real(), eps);
+    ASSERT_NEAR(res.imag(), 0, eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);
 
     state.set_Haar_random_state();
     for (ITYPE i = 0; i < dim; ++i) test_state[i] = state.data_cpp()[i];
     res = observable.get_expectation_value(&state);
     test_res = (test_state.adjoint() * test_observable * test_state);
-    ASSERT_NEAR(test_res.real(), res, eps);
+    ASSERT_NEAR(test_res.real(), res.real(), eps);
+    ASSERT_NEAR(res.imag(), 0, eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);
 
 
@@ -83,14 +85,15 @@ TEST(ObservableTest, CheckExpectationValue) {
 
         res = rand_observable.get_expectation_value(&state);
         test_res = test_state.adjoint() * test_rand_observable * test_state;
-        ASSERT_NEAR(test_res.real(), res, eps);
+        ASSERT_NEAR(test_res.real(), res.real(), eps);
+        ASSERT_NEAR(res.imag(), 0, eps);
         ASSERT_NEAR(test_res.imag(), 0, eps);
 
     }
 }
 
 TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile){
-    auto func = [](const std::string path, const QuantumStateBase* state) -> double {
+    auto func = [](const std::string path, const QuantumStateBase* state) -> CPPCTYPE {
             std::ifstream ifs;
             ifs.open(path);
             if (!ifs){
@@ -98,7 +101,7 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile){
                 std::exit(EXIT_FAILURE);
             }
 
-            double energy = 0;
+            CPPCTYPE energy = 0;
 
             std::string str;
             while (getline(ifs, str)) {
@@ -130,7 +133,7 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile){
     const double eps = 1e-14;
     const char* filename = "../test/cppsim/H2.txt";
 
-    double res, test_res;
+    CPPCTYPE res, test_res;
 
 
     Observable* observable;
@@ -151,12 +154,15 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile){
     res = observable->get_expectation_value(&state);
     test_res = func(filename, &state);
 
-    ASSERT_NEAR(test_res, res, eps);
+    ASSERT_NEAR(test_res.real(), res.real(), eps);
+    ASSERT_NEAR(test_res.imag(), 0, eps);
+    ASSERT_NEAR(res.imag(), 0, eps);
+
 }
 
 TEST(ObservableTest, CheckParsedObservableFromOpenFermionText){
-    auto func = [](const std::string str, const QuantumStateBase* state) -> double {
-            double energy = 0;
+    auto func = [](const std::string str, const QuantumStateBase* state) -> CPPCTYPE {
+            CPPCTYPE energy = 0;
 
             std::vector<std::string> lines = split(str, "\n");
 
@@ -199,7 +205,7 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionText){
         "(0.17434925+0j) [Z1 Z3] +\n"
         "(-0.22279649999999998+0j) [Z2]";
 
-    double res, test_res;
+    CPPCTYPE res, test_res;
 
 
     Observable* observable;
@@ -220,11 +226,15 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionText){
     res = observable->get_expectation_value(&state);
     test_res = func(text, &state);
 
-    ASSERT_NEAR(test_res, res, eps);
+    ASSERT_NEAR(test_res.real(), res.real(), eps);
+    ASSERT_NEAR(test_res.imag(), 0, eps);
+    ASSERT_NEAR(res.imag(), 0, eps);
+
+
 }
 
 TEST(ObservableTest, CheckSplitObservable){
-    auto func = [](const std::string path, const QuantumStateBase* state) -> double {
+    auto func = [](const std::string path, const QuantumStateBase* state) -> CPPCTYPE {
             std::ifstream ifs;
             CPPCTYPE coef;
             ifs.open(path);
@@ -233,7 +243,7 @@ TEST(ObservableTest, CheckSplitObservable){
                 std::exit(EXIT_FAILURE);
             }
 
-            double energy = 0;
+            CPPCTYPE energy = 0;
 
             std::string str;
             while (getline(ifs, str)) {
@@ -265,7 +275,7 @@ TEST(ObservableTest, CheckSplitObservable){
     const double eps = 1e-14;
     const char* filename  = "../test/cppsim/H2.txt";
 
-    double diag_res, test_res, non_diag_res;
+    CPPCTYPE diag_res, test_res, non_diag_res;
 
     std::pair<Observable*, Observable*> observables;
     observables = observable::create_split_observable(filename);
@@ -279,7 +289,10 @@ TEST(ObservableTest, CheckSplitObservable){
     non_diag_res = observables.second->get_expectation_value(&state);
     test_res = func(filename, &state);
 
-    ASSERT_NEAR(test_res, diag_res + non_diag_res, eps);
+    ASSERT_NEAR(test_res.real(), (diag_res + non_diag_res).real(), eps);
+    ASSERT_NEAR(test_res.imag(), 0, eps);
+    ASSERT_NEAR(diag_res.imag(), 0, eps);
+    ASSERT_NEAR(non_diag_res.imag(), 0, eps);
 
 
     state.set_Haar_random_state();
@@ -288,7 +301,10 @@ TEST(ObservableTest, CheckSplitObservable){
     non_diag_res = observables.second->get_expectation_value(&state);
     test_res = func(filename, &state);
 
-    ASSERT_NEAR(test_res, diag_res + non_diag_res, eps);
+    ASSERT_NEAR(test_res.real(), (diag_res + non_diag_res).real(), eps);
+    ASSERT_NEAR(test_res.imag(), 0, eps);
+    ASSERT_NEAR(diag_res.imag(), 0, eps);
+    ASSERT_NEAR(non_diag_res.imag(), 0, eps);
 
 }
 


### PR DESCRIPTION
# Update

## [Bugfix] Fix parse for openfermion text
- Bug description
This bug is reported in issue #51 by @TenninYan .

When we passed string of hamiltonian whose coefficient is 0 or its real value is 0 to `Observable::create_observable_from_openfermion_text`, the kernel crashes. 

- Reason
The method accept only a format like `(~~ + ~~j) [~ ~]` in parsing procedure.

- Update
I modified parsing process of `Observable::create_observable_from_openfermion_text`, `Observable::create_observable_from_openfermion_file` and `Observable::create_split_observable`.

## [Feature] Making PauliOperator class availalble to use some limited operation for non hermitian operators
In the previous version, `PauliOperator` class takes only real value as coefficients (it's same as `Observable` class). This changes make possible to take complex value as coefficients, and compute expected value, transition amplitude of non hermitian operator.

**The type of return value of `get_expected_value` and `get_transition_amplitude` is always complex (regardless of whether Observable or PauliOperator is hermitian or not)**

If function for rotation of non hermitian PauliOperator or Observable was called, it outputs error that it is not implemented yet.

### Example 1:
```python3
from qulacs.observable import create_observable_from_openfermion_text
from openfermion.ops import FermionOperator
from openfermion.transforms import jordan_wigner

jw_hamiltonian = jordan_wigner(FermionOperator('0^ 1', 1))
print(jw_hamiltonian)

qulacs_hamiltonian = create_observable_from_openfermion_text(str(jw_hamiltonian))

term_count = qulacs_hamiltonian.get_term_count()
print(term_count)

for i in range(term_count):
    pauli = qulacs_hamiltonian.get_term(i)
    print(pauli)
    print(pauli.get_coef())
    print(pauli.get_index_list())
    print(pauli.get_pauli_id_list())

jw = jordan_wigner(FermionOperator('0^ 0^ 0 0', 1))
print(jw)
qulacs_hamiltonian = create_observable_from_openfermion_text(str(jw))
```
This code outputs 
```
(0.25+0j) [X0 X1] +
0.25j [X0 Y1] +
-0.25j [Y0 X1] +
(0.25+0j) [Y0 Y1]
4
<qulacs.PauliOperator object at 0x10ac85030>
(0.25+0j)
[0, 1]
[1, 1]
<qulacs.PauliOperator object at 0x10ac85538>
0.25j
[0, 1]
[1, 2]
<qulacs.PauliOperator object at 0x10ac85030>
-0.25j
[0, 1]
[2, 1]
<qulacs.PauliOperator object at 0x10ac85538>
(0.25+0j)
[0, 1]
[2, 2]
0
```
### Example 2: 
```python3
import qulacs
from qulacs.observable import create_observable_from_openfermion_text
from openfermion.ops import FermionOperator
from openfermion.transforms import jordan_wigner

jw_hamiltonian = jordan_wigner(FermionOperator('0^ 1', 1))
print(jw_hamiltonian)
qulacs_hamiltonian = create_observable_from_openfermion_text(str(jw_hamiltonian))
bra = qulacs.QuantumState(2)
ket = qulacs.QuantumState(2)
bra.set_computational_basis(1)
ket.set_computational_basis(2)

res = qulacs_hamiltonian.get_transition_amplitude(bra, ket)
print(res)
```
the outputs is complex number
```
(0.25+0j) [X0 X1] +
0.25j [X0 Y1] +
-0.25j [Y0 X1] +
(0.25+0j) [Y0 Y1]
(1+0j)
```
### Example 3:
If you try to rotate with non hermitian operator as this code, 
```python
import qulacs
from qulacs.observable import create_observable_from_openfermion_text
from openfermion.ops import FermionOperator
from openfermion.transforms import jordan_wigner

jw_hamiltonian = jordan_wigner(FermionOperator('0^ 1', 1))

circuit = qulacs.QuantumCircuit(2)
qulacs_hamiltonian = create_observable_from_openfermion_text(str(jw_hamiltonian))
circuit.add_observable_rotation_gate(qulacs_hamiltonian, 0.1, 100)
```
you will get outputs as following
```
Error: QuantumCircuit::add_observable_rotation_gate(const Observable& observable, double angle, UINT num_repeats): not impremented for non hermitian
...
```