### PR TITLE
Fix bugs in default copy constructors

### DIFF
--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -46,13 +46,26 @@ void QuantumCircuit::update_quantum_state(QuantumStateBase* state, UINT start, U
     }
 }
 
+QuantumCircuit::QuantumCircuit(const QuantumCircuit& obj):
+	qubit_count(_qubit_count), gate_list(_gate_list)
+{
+	_gate_list.clear();
+	_qubit_count = (obj.qubit_count);
+	for (UINT i = 0; i < obj.gate_list.size(); ++i) {
+		_gate_list.push_back(obj.gate_list[i]->copy());
+	}
+};
 
-QuantumCircuit::QuantumCircuit(UINT qubit_count_){
+
+QuantumCircuit::QuantumCircuit(UINT qubit_count_):
+	qubit_count(_qubit_count), gate_list(_gate_list)
+{
     this->_qubit_count = qubit_count_;
 }
 
 
-QuantumCircuit::QuantumCircuit(std::string qasm_path, std::string qasm_loader_script_path){
+QuantumCircuit::QuantumCircuit(std::string qasm_path, std::string qasm_loader_script_path):
+qubit_count(_qubit_count), gate_list(_gate_list) {
 	// generate quantum circuit from qasm
 	// now we delegate compile of qasm string to quantumopencompiler in qiskit-sdk.
 	std::string exec_string = std::string("python ")+qasm_loader_script_path+" "+qasm_path;
@@ -200,7 +213,7 @@ std::string QuantumCircuit::to_string() const {
     std::vector<UINT> gate_size_count(this->_qubit_count, 0);
     UINT max_block_size = 0;
 
-    for (const auto& gate : this->_gate_list) {
+    for (const auto gate : this->_gate_list) {
         UINT whole_qubit_index_count = (UINT)(gate->target_qubit_list.size() + gate->control_qubit_list.size());
 		if (whole_qubit_index_count == 0) continue;
         gate_size_count[whole_qubit_index_count - 1]++;

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -24,17 +24,17 @@ typedef HermitianQuantumOperator Observable;
  * 管理する量子ゲートは量子回路の解放時にすべて解放される。
  */
 class DllExport QuantumCircuit{
-private:
+protected:
     std::vector<QuantumGateBase*> _gate_list; 
     UINT _qubit_count;                 
 
     // prohibit shallow copy
-    QuantumCircuit(const QuantumCircuit&) = default;
-    QuantumCircuit& operator= (const QuantumCircuit&) = default;
+	QuantumCircuit(const QuantumCircuit& obj);
+    QuantumCircuit& operator= (const QuantumCircuit&) = delete;
 
 public:
-    const UINT& qubit_count = _qubit_count; /**< \~japanese-en 量子ビットの数*/
-    const std::vector<QuantumGateBase*>& gate_list = _gate_list; /**< \~japanese-en 量子ゲートのリスト*/
+	const UINT& qubit_count; /**< \~japanese-en 量子ビットの数*/
+	const std::vector<QuantumGateBase*>& gate_list; /**< \~japanese-en 量子ゲートのリスト*/
 
     /**
      * \~japanese-en 空の量子回路を作成する

--- a/src/cppsim/gate.hpp
+++ b/src/cppsim/gate.hpp
@@ -80,17 +80,26 @@ protected:
     std::string _name="Generic gate";
 
     // prohibit constructor, destructor, copy constructor, and insertion
-    QuantumGateBase() {};
-    QuantumGateBase(const QuantumGateBase& obj) = default;
-    QuantumGateBase& operator=(const QuantumGateBase& rhs) = default;
+    QuantumGateBase():
+		target_qubit_list(_target_qubit_list), control_qubit_list(_control_qubit_list) 
+	{};
+	QuantumGateBase(const QuantumGateBase& obj):
+		target_qubit_list(_target_qubit_list), control_qubit_list(_control_qubit_list)
+	{
+		_gate_property = obj._gate_property;
+		_name = obj._name;
+		_target_qubit_list = obj.target_qubit_list;
+		_control_qubit_list = obj.control_qubit_list;
+	};
+    QuantumGateBase& operator=(const QuantumGateBase& rhs) = delete;
 public:
     /**
      * \~japanese-en デストラクタ
      */
     virtual ~QuantumGateBase() {};
 
-    const std::vector<TargetQubitInfo>& target_qubit_list = _target_qubit_list; /**< ターゲット量子ビットのリスト */
-    const std::vector<ControlQubitInfo>& control_qubit_list = _control_qubit_list; /**< コントロール量子ビットのリスト */
+	const std::vector<TargetQubitInfo>& target_qubit_list; /**< ターゲット量子ビットのリスト */
+	const std::vector<ControlQubitInfo>& control_qubit_list; /**< コントロール量子ビットのリスト */
 
     /**
      * \~japanese-en ターゲット量子ビットの添え字のリストを取得する

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -27,16 +27,18 @@ protected:
     UINT _qubit_count;
     std::vector<UINT> _classical_register;
 public:
-    const UINT& qubit_count = _qubit_count; /**< \~japanese-en 量子ビット数 */
-    const ITYPE& dim = _dim; /**< \~japanese-en 量子状態の次元 */
-    const std::vector<UINT>& classical_register = _classical_register; /**< \~japanese-en 古典ビットのレジスタ */
+	const UINT& qubit_count; /**< \~japanese-en 量子ビット数 */
+    const ITYPE& dim; /**< \~japanese-en 量子状態の次元 */
+    const std::vector<UINT>& classical_register; /**< \~japanese-en 古典ビットのレジスタ */
 
     /**
      * \~japanese-en コンストラクタ
      * 
      * @param qubit_count_ 量子ビット数
      */
-    QuantumStateBase(UINT qubit_count_){
+    QuantumStateBase(UINT qubit_count_):
+		qubit_count(_qubit_count), dim(_dim), classical_register(_classical_register)
+	{
         this->_qubit_count = qubit_count_;
         this->_dim = 1ULL << qubit_count_;
     }


### PR DESCRIPTION
- Overview

Fix bugs in copy constructors of QuantumGate, QuantumCircuit, and QuantumState.
This bug is reported by @kosukemtr in issue #74 .

- Detail

When we copy an instance of any of QuantumGate, QuantumCircuit, or QuantumState through <code>copy</code> function, and when we call some functions of copied instances, segfault may occur.
See #74 for details and codes for regeneration.

- Reason

These classes have read-only variables using const references for public access, e.g.
```C++
private:
T m_var;
public:
const T& var = m_var;
```
However, when we use default copy constructor for copying instances,<code>var</code> in the new instance refers an address of <code>m_var</code> in the original instance.
If we access <code>var</code> in the copied instances after the original instance is released, it refers invalid address and causes segfault.

- Fix

1. Initialization-in-statement for read-only member variables is removed.
2. Default copy-assignment-operator is deleted for prohibiting unintended use.
3. All the read-only member variables are explicitly initialized in constructor and copy-constructor.





