### PR TITLE
Add `pip install` test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,8 @@ install:
       chmod +x ./script/build_gcc.sh
       ./script/build_gcc.sh
     fi
+  # Check if `pip install` will be done successfully or not
+  - python setup.py install
 
 script:
   - |


### PR DESCRIPTION
### Abstract

- There are some differences between `make python` and  `python setup.py install`
    - `python setup.py install` command is used when a user install qulacs by `pip`
- So I added to test `python setup.py install`

### Review Points

- In Travis CI, `python setup.py install` will run after `build_gcc.sh` or `build_msvc.bat`
    - Is it OK?
    - Now we run 6 parallel tests (two Python version and three operating systems) in Travis CI so I think we should not increase parallelism more. That's why I would not separate `python setup.py install` and `build_gcc.sh`
