### PR TITLE
Fix error in optimization for quantum gates with unordered qubit indices

### DIFF
--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -35,6 +35,11 @@ UINT QuantumCircuitOptimizer::get_merged_gate_size(UINT gate_index1, UINT gate_i
     auto control_index_list1 = fetch_control_index(circuit->gate_list[gate_index1]->control_qubit_list);
     auto control_index_list2 = fetch_control_index(circuit->gate_list[gate_index2]->control_qubit_list);
 
+	std::sort(target_index_list1.begin(), target_index_list1.end());
+	std::sort(target_index_list2.begin(), target_index_list2.end());
+	std::sort(control_index_list1.begin(), control_index_list1.end());
+	std::sort(control_index_list2.begin(), control_index_list2.end());
+
     std::vector<UINT> target_index_merge, control_index_merge, whole_index;
     std::set_union(
         target_index_list1.begin(), target_index_list1.end(),

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -534,6 +534,64 @@ TEST(CircuitTest, RandomCircuitOptimize) {
 
 }
 
+TEST(CircuitTest, RandomCircuitOptimize2) {
+	const UINT n = 5;
+	const UINT dim = 1ULL << n;
+	const UINT depth = 10;
+	Random random;
+	double eps = 1e-14;
+	UINT max_repeat = 3;
+	UINT max_block_size = n;
+
+	for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+		QuantumState state(n), org_state(n), test_state(n);
+		state.set_Haar_random_state();
+		org_state.load(&state);
+		QuantumCircuit circuit(n);
+
+		for (UINT d = 0; d < depth; ++d) {
+			for (UINT i = 0; i < n; ++i) {
+				UINT r = random.int32() % 6;
+				if (r == 0)    circuit.add_sqrtX_gate(i);
+				else if (r == 1) circuit.add_sqrtY_gate(i);
+				else if (r == 2) circuit.add_T_gate(i);
+				else if (r == 3) {
+					UINT r2 = random.int32() % n;
+					if (r2 == i) r2 = (r2 + 1) % n;
+					if (i + 1 < n) circuit.add_CNOT_gate(i, r2);
+				}
+				else if (r == 4) {
+					UINT r2 = random.int32() % n;
+					if (r2 == i) r2 = (r2 + 1) % n;
+					if (i + 1 < n) circuit.add_CZ_gate(i, r2);
+				}
+				else if (r == 5) {
+					UINT r2 = random.int32() % n;
+					if (r2 == i) r2 = (r2 + 1) % n;
+					if (i + 1 < n) circuit.add_SWAP_gate(i, r2);
+				}
+			}
+		}
+
+		test_state.load(&org_state);
+		circuit.update_quantum_state(&test_state);
+		//std::cout << circuit << std::endl;
+		QuantumCircuitOptimizer qco;
+		for (UINT block_size = 1; block_size <= max_block_size; ++block_size) {
+			QuantumCircuit* copy_circuit = circuit.copy();
+			qco.optimize(copy_circuit, block_size);
+			state.load(&org_state);
+			copy_circuit->update_quantum_state(&state);
+			//std::cout << copy_circuit << std::endl;
+			for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+			delete copy_circuit;
+		}
+	}
+
+}
+
+
+
 TEST(CircuitTest, SuzukiTrotterExpansion) {
     CPPCTYPE J(0.0, 1.0);
     Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);


### PR DESCRIPTION
- Bug
When we use quantum circuit optimizer, gate will be greedily merged as far as the size of merged gate does not exceed  given <code>block_size</code>. To this end, circuit optimizer has a function to compute the size of merged gates before merging. However, this function does not output correct answer for two gates of which the <code>target_qubit_index_list</code> is not sorted.
This potentially causes insufficient or over-optimization according to <code>block_size</code>.

- Update
I've fixed codes in gate optimization, and added test with unsorted gates.
Note that I think numerical results do no change with this bug and update.


