### PR TITLE
Add random unitary gate

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -232,7 +232,9 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("DenseMatrix", ptr1, pybind11::return_value_policy::automatic_reference);
     mgate.def("DenseMatrix", ptr2, pybind11::return_value_policy::automatic_reference);
 
-    mgate.def("BitFlipNoise", &gate::BitFlipNoise);
+	mgate.def("RandomUnitary", &gate::RandomUnitary, pybind11::return_value_policy::automatic_reference);
+	
+	mgate.def("BitFlipNoise", &gate::BitFlipNoise);
     mgate.def("DephasingNoise", &gate::DephasingNoise);
     mgate.def("IndependentXZNoise", &gate::IndependentXZNoise);
     mgate.def("DepolarizingNoise", &gate::DepolarizingNoise);
@@ -319,7 +321,8 @@ PYBIND11_MODULE(qulacs, m) {
         .def("add_multi_Pauli_rotation_gate", (void (QuantumCircuit::*)(const PauliOperator&))&QuantumCircuit::add_multi_Pauli_rotation_gate)
         .def("add_dense_matrix_gate", (void (QuantumCircuit::*)(unsigned int, const ComplexMatrix&))&QuantumCircuit::add_dense_matrix_gate)
         .def("add_dense_matrix_gate", (void (QuantumCircuit::*)(std::vector<unsigned int>, const ComplexMatrix&))&QuantumCircuit::add_dense_matrix_gate)
-        .def("add_diagonal_observable_rotation_gate", &QuantumCircuit::add_diagonal_observable_rotation_gate)
+		.def("add_random_unitary_gate", &QuantumCircuit::add_random_unitary_gate)
+		.def("add_diagonal_observable_rotation_gate", &QuantumCircuit::add_diagonal_observable_rotation_gate)
         .def("add_observable_rotation_gate", &QuantumCircuit::add_observable_rotation_gate)
         .def("__repr__", [](const QuantumCircuit &p) {return p.to_string(); });
     ;

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -375,3 +375,6 @@ void QuantumCircuit::add_dense_matrix_gate(std::vector<UINT> target_index_list, 
 	this->add_gate(gate::DenseMatrix(target_index_list, matrix));
 }
 
+void QuantumCircuit::add_random_unitary_gate(std::vector<UINT> target_index_list) {
+	this->add_gate(gate::RandomUnitary(target_index_list));
+}

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -445,6 +445,14 @@ public:
      * @param[in] matrix 作用する行列
      */
     virtual void add_dense_matrix_gate(std::vector<UINT> target_index_list, const ComplexMatrix& matrix);
+
+	/**
+	 * \~japanese-en multi qubitのランダムユニタリゲートを追加する。
+	 *
+	 * @param[in] target_index_list 作用するtarget qubitの添え字のリスト
+	 * @param[in] matrix 作用する行列
+	 */
+	virtual void add_random_unitary_gate(std::vector<UINT> target_index_list);
 };
 
 

--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -35,6 +35,11 @@ UINT QuantumCircuitOptimizer::get_merged_gate_size(UINT gate_index1, UINT gate_i
     auto control_index_list1 = fetch_control_index(circuit->gate_list[gate_index1]->control_qubit_list);
     auto control_index_list2 = fetch_control_index(circuit->gate_list[gate_index2]->control_qubit_list);
 
+	std::sort(target_index_list1.begin(), target_index_list1.end());
+	std::sort(target_index_list2.begin(), target_index_list2.end());
+	std::sort(control_index_list1.begin(), control_index_list1.end());
+	std::sort(control_index_list2.begin(), control_index_list2.end());
+
     std::vector<UINT> target_index_merge, control_index_merge, whole_index;
     std::set_union(
         target_index_list1.begin(), target_index_list1.end(),

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -140,7 +140,7 @@ namespace gate{
 		ComplexMatrix matrix(dim, dim);
 		for (ITYPE i = 0; i < dim; ++i) {
 			for (ITYPE j = 0; j < dim; ++j) {
-				matrix(i, j) = random.normal() + 1.i * random.normal();
+				matrix(i, j) = (random.normal() + 1.i * random.normal())/sqrt(2.);
 			}
 		}
 		Eigen::HouseholderQR<ComplexMatrix> qr_solver(matrix);

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -13,6 +13,7 @@
 #include "gate_named_pauli.hpp"
 #include "gate_matrix.hpp"
 #include "type.hpp"
+#include <Eigen/QR>
 
 namespace gate{
     ComplexMatrix get_IBMQ_matrix(double theta, double phi, double lambda);
@@ -131,6 +132,30 @@ namespace gate{
     QuantumGateMatrix* DenseMatrix(std::vector<UINT> target_list, ComplexMatrix matrix) {
         return new QuantumGateMatrix(target_list, matrix);
     }
+
+	QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
+		Random random;
+		UINT qubit_count = (UINT)target_list.size();
+		ITYPE dim = 1ULL << qubit_count;
+		ComplexMatrix matrix(dim, dim);
+		for (ITYPE i = 0; i < dim; ++i) {
+			for (ITYPE j = 0; j < dim; ++j) {
+				matrix(i, j) = random.normal() + 1.i * random.normal();
+			}
+		}
+		Eigen::HouseholderQR<ComplexMatrix> qr_solver(matrix);
+		ComplexMatrix Q = qr_solver.householderQ();
+		// actual R matrix is upper-right triangle of matrixQR
+		auto R = qr_solver.matrixQR();
+		for (ITYPE i = 0; i < dim; ++i) {
+			CPPCTYPE phase = R(i, i) / abs(R(i, i));
+			for (ITYPE j = 0; j < dim; ++j) {
+				Q(j,i) *= phase;
+			}
+		}
+		return new QuantumGateMatrix(target_list, Q);
+	}
+
 
     QuantumGateBase* BitFlipNoise(UINT target_index, double prob) {
         return new QuantumGate_Probabilistic({ prob }, { X(target_index) });

--- a/src/cppsim/gate_factory.hpp
+++ b/src/cppsim/gate_factory.hpp
@@ -294,6 +294,14 @@ namespace gate{
      */
     DllExport QuantumGateMatrix* DenseMatrix(std::vector<UINT> target_qubit_index_list, ComplexMatrix matrix);
 
+	/**
+	 * \f$n\f$-qubit のランダムユニタリゲートを作成する。
+	 *
+	 * @param[in] target_qubit_index_list ターゲットとなる量子ビットの添え字
+	 * @return 作成されたゲートのインスタンス
+	 */
+	DllExport QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_qubit_index_list);
+
 
     /**
      * bit-flipノイズを発生させるゲート

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -534,6 +534,64 @@ TEST(CircuitTest, RandomCircuitOptimize) {
 
 }
 
+TEST(CircuitTest, RandomCircuitOptimize2) {
+	const UINT n = 5;
+	const UINT dim = 1ULL << n;
+	const UINT depth = 10;
+	Random random;
+	double eps = 1e-14;
+	UINT max_repeat = 3;
+	UINT max_block_size = n;
+
+	for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+		QuantumState state(n), org_state(n), test_state(n);
+		state.set_Haar_random_state();
+		org_state.load(&state);
+		QuantumCircuit circuit(n);
+
+		for (UINT d = 0; d < depth; ++d) {
+			for (UINT i = 0; i < n; ++i) {
+				UINT r = random.int32() % 6;
+				if (r == 0)    circuit.add_sqrtX_gate(i);
+				else if (r == 1) circuit.add_sqrtY_gate(i);
+				else if (r == 2) circuit.add_T_gate(i);
+				else if (r == 3) {
+					UINT r2 = random.int32() % n;
+					if (r2 == i) r2 = (r2 + 1) % n;
+					if (i + 1 < n) circuit.add_CNOT_gate(i, r2);
+				}
+				else if (r == 4) {
+					UINT r2 = random.int32() % n;
+					if (r2 == i) r2 = (r2 + 1) % n;
+					if (i + 1 < n) circuit.add_CZ_gate(i, r2);
+				}
+				else if (r == 5) {
+					UINT r2 = random.int32() % n;
+					if (r2 == i) r2 = (r2 + 1) % n;
+					if (i + 1 < n) circuit.add_SWAP_gate(i, r2);
+				}
+			}
+		}
+
+		test_state.load(&org_state);
+		circuit.update_quantum_state(&test_state);
+		//std::cout << circuit << std::endl;
+		QuantumCircuitOptimizer qco;
+		for (UINT block_size = 1; block_size <= max_block_size; ++block_size) {
+			QuantumCircuit* copy_circuit = circuit.copy();
+			qco.optimize(copy_circuit, block_size);
+			state.load(&org_state);
+			copy_circuit->update_quantum_state(&state);
+			//std::cout << copy_circuit << std::endl;
+			for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+			delete copy_circuit;
+		}
+	}
+
+}
+
+
+
 TEST(CircuitTest, SuzukiTrotterExpansion) {
     CPPCTYPE J(0.0, 1.0);
     Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1047,3 +1047,28 @@ TEST(GateTest, GateAdd) {
     // TODO assert matrix element
 }
 
+
+TEST(GateTest, RandomUnitaryGate) {
+	double eps = 1e-14;
+	for (UINT qubit_count = 1; qubit_count < 5; ++qubit_count) {
+		ITYPE dim = 1ULL << qubit_count;
+		std::vector<UINT> target_qubit_list;
+		for (int i = 0; i < qubit_count; ++i) {
+			target_qubit_list.push_back(i);
+		}
+		auto gate = gate::RandomUnitary(target_qubit_list);
+		ComplexMatrix cm;
+		gate->set_matrix(cm);
+		auto eye = cm*cm.adjoint();
+		for (int i = 0; i < dim; ++i) {
+			for (int j = 0; j < dim; ++j) {
+				if (i == j) {
+					ASSERT_NEAR(abs(eye(i, j)), 1, eps);
+				}
+				else {
+					ASSERT_NEAR(abs(eye(i,j)), 0, eps);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Update

I've added new function RandomUnitary and add_random_unitary_gate.
I also added some tests for them.

- Usage

```python
# for gate instance
from qulacs.gate import RandomUnitary
gate = RandomUnitary([2,4,5]) # this is random SU(8) on 2,4,5-th qubits
matrix = gate.get_matrix()
matrix@matrix.T.conj() # this is identity

# for circuit
from qulacs import QuantumCircuit
qc = QuantumCircuit(10)
qc.add_random_unitary_gate([2,4,5])
```
