### PR TITLE
Add retrying for the Chocolatey commands in Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,8 @@ cache:
 before_install:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
-      choco install -y cmake
-      choco install -y python --version "${PYTHON}"
+      travis_retry choco install -y cmake
+      travis_retry choco install -y python --version "${PYTHON}"
       if [[ "${PYTHON}" == "3"* ]]; then
         alias python="python3"
       fi


### PR DESCRIPTION
Fix #48 .

Travis CI has a retry function: [`travis_retry`](https://docs.travis-ci.com/user/common-build-problems/#travis_retry) so I try this to prevent us from failing Windows CI due to Chocolatey server down.