### PR TITLE
[bugfix] Change return value policy for avoiding memory leak

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -62,7 +62,10 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_qubit_count", &GeneralQuantumOperator::get_qubit_count)
         .def("get_state_dim", &GeneralQuantumOperator::get_state_dim)
         .def("get_term_count", &GeneralQuantumOperator::get_term_count)
-        .def("get_term", &GeneralQuantumOperator::get_term, pybind11::return_value_policy::take_ownership)
+        //.def("get_term", &GeneralQuantumOperator::get_term, pybind11::return_value_policy::take_ownership)
+        .def("get_term",[](const GeneralQuantumOperator& quantum_operator, const unsigned int index) {
+            return quantum_operator.get_term(index)->copy();
+        }, pybind11::return_value_policy::take_ownership)
         .def("get_expectation_value", &GeneralQuantumOperator::get_expectation_value)
         .def("get_transition_amplitude", &GeneralQuantumOperator::get_transition_amplitude)
         //.def_static("get_split_GeneralQuantumOperator", &(GeneralQuantumOperator::get_split_observable));
@@ -80,7 +83,10 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_qubit_count", &HermitianQuantumOperator::get_qubit_count)
         .def("get_state_dim", &HermitianQuantumOperator::get_state_dim)
         .def("get_term_count", &HermitianQuantumOperator::get_term_count)
-        .def("get_term", &HermitianQuantumOperator::get_term, pybind11::return_value_policy::take_ownership)
+        //.def("get_term", &HermitianQuantumOperator::get_term, pybind11::return_value_policy::take_ownership)
+        .def("get_term",[](const HermitianQuantumOperator& quantum_operator, const unsigned int index) {
+            return quantum_operator.get_term(index)->copy();
+        }, pybind11::return_value_policy::take_ownership)
         // .def("get_expectation_value", &HermitianQuantumOperator::get_expectation_value)
         .def("get_expectation_value", [](const HermitianQuantumOperator& observable, const QuantumStateBase* state) {
                                           double res = observable.get_expectation_value(state).real();

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -232,7 +232,7 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("DenseMatrix", ptr1, pybind11::return_value_policy::take_ownership);
     mgate.def("DenseMatrix", ptr2, pybind11::return_value_policy::take_ownership);
 
-	mgate.def("RandomUnitary", &gate::RandomUnitary, pybind11::return_value_policy::automatic_reference);
+	mgate.def("RandomUnitary", &gate::RandomUnitary, pybind11::return_value_policy::take_ownership);
 	
 	mgate.def("BitFlipNoise", &gate::BitFlipNoise);
     mgate.def("DephasingNoise", &gate::DephasingNoise);

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -277,8 +277,8 @@ PYBIND11_MODULE(qulacs, m) {
         // In order to avoid double release, we force using add_gate_copy in python
         .def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*))&QuantumCircuit::add_gate)
         .def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate)
-        .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase&))&QuantumCircuit::add_gate_copy)
-        .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase&, unsigned int))&QuantumCircuit::add_gate_copy)
+        .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*))&QuantumCircuit::add_gate_copy)
+        .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate_copy)
         .def("remove_gate", &QuantumCircuit::remove_gate)
 
         .def("get_gate", [](const QuantumCircuit& circuit, unsigned int index) -> QuantumGateBase* { 
@@ -338,8 +338,8 @@ PYBIND11_MODULE(qulacs, m) {
         .def("copy", &ParametricQuantumCircuit::copy, pybind11::return_value_policy::take_ownership)
         .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate))  &ParametricQuantumCircuit::add_parametric_gate)
         .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate, UINT))  &ParametricQuantumCircuit::add_parametric_gate)
-        .def("add_gate", (void (ParametricQuantumCircuit::*)(QuantumGateBase* gate))  &ParametricQuantumCircuit::add_gate )
-        .def("add_gate", (void (ParametricQuantumCircuit::*)(QuantumGateBase* gate, unsigned int))  &ParametricQuantumCircuit::add_gate)
+        .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate))  &ParametricQuantumCircuit::add_gate_copy )
+        .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate, unsigned int))  &ParametricQuantumCircuit::add_gate_copy)
         .def("get_parameter_count", &ParametricQuantumCircuit::get_parameter_count)
         .def("get_parameter", &ParametricQuantumCircuit::get_parameter)
         .def("set_parameter", &ParametricQuantumCircuit::set_parameter)

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -51,7 +51,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def("add_single_Pauli", &PauliOperator::add_single_Pauli)
         .def("get_expectation_value", &PauliOperator::get_expectation_value)
         .def("get_transition_amplitude", &PauliOperator::get_transition_amplitude)
-        .def("copy", &PauliOperator::copy, pybind11::return_value_policy::automatic_reference)
+        .def("copy", &PauliOperator::copy, pybind11::return_value_policy::take_ownership)
         ;
 
     py::class_<GeneralQuantumOperator>(m, "GeneralQuantumOperator")
@@ -62,15 +62,15 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_qubit_count", &GeneralQuantumOperator::get_qubit_count)
         .def("get_state_dim", &GeneralQuantumOperator::get_state_dim)
         .def("get_term_count", &GeneralQuantumOperator::get_term_count)
-        .def("get_term", &GeneralQuantumOperator::get_term, pybind11::return_value_policy::automatic_reference)
+        .def("get_term", &GeneralQuantumOperator::get_term, pybind11::return_value_policy::take_ownership)
         .def("get_expectation_value", &GeneralQuantumOperator::get_expectation_value)
         .def("get_transition_amplitude", &GeneralQuantumOperator::get_transition_amplitude)
         //.def_static("get_split_GeneralQuantumOperator", &(GeneralQuantumOperator::get_split_observable));
         ;
     auto mquantum_operator = m.def_submodule("quantum_operator");
-    mquantum_operator.def("create_quantum_operator_from_openfermion_file", &quantum_operator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
-    mquantum_operator.def("create_quantum_operator_from_openfermion_text", &quantum_operator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
-    mquantum_operator.def("create_split_quantum_operator", &quantum_operator::create_split_general_quantum_operator, pybind11::return_value_policy::automatic_reference);
+    mquantum_operator.def("create_quantum_operator_from_openfermion_file", &quantum_operator::create_general_quantum_operator_from_openfermion_file, pybind11::return_value_policy::take_ownership);
+    mquantum_operator.def("create_quantum_operator_from_openfermion_text", &quantum_operator::create_general_quantum_operator_from_openfermion_text, pybind11::return_value_policy::take_ownership);
+    mquantum_operator.def("create_split_quantum_operator", &quantum_operator::create_split_general_quantum_operator, pybind11::return_value_policy::take_ownership);
 
     py::class_<HermitianQuantumOperator, GeneralQuantumOperator>(m, "Observable")
         .def(py::init<unsigned int>())
@@ -80,7 +80,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_qubit_count", &HermitianQuantumOperator::get_qubit_count)
         .def("get_state_dim", &HermitianQuantumOperator::get_state_dim)
         .def("get_term_count", &HermitianQuantumOperator::get_term_count)
-        .def("get_term", &HermitianQuantumOperator::get_term, pybind11::return_value_policy::automatic_reference)
+        .def("get_term", &HermitianQuantumOperator::get_term, pybind11::return_value_policy::take_ownership)
         // .def("get_expectation_value", &HermitianQuantumOperator::get_expectation_value)
         .def("get_expectation_value", [](const HermitianQuantumOperator& observable, const QuantumStateBase* state) {
                                           double res = observable.get_expectation_value(state).real();
@@ -89,9 +89,9 @@ PYBIND11_MODULE(qulacs, m) {
         //.def_static("get_split_Observable", &(HermitianQuantumOperator::get_split_observable));
         ;
     auto mobservable = m.def_submodule("observable");
-    mobservable.def("create_observable_from_openfermion_file", &observable::create_observable_from_openfermion_file, pybind11::return_value_policy::automatic_reference);
-    mobservable.def("create_observable_from_openfermion_text", &observable::create_observable_from_openfermion_text, pybind11::return_value_policy::automatic_reference);
-    mobservable.def("create_split_observable", &observable::create_split_observable, pybind11::return_value_policy::automatic_reference);
+    mobservable.def("create_observable_from_openfermion_file", &observable::create_observable_from_openfermion_file, pybind11::return_value_policy::take_ownership);
+    mobservable.def("create_observable_from_openfermion_text", &observable::create_observable_from_openfermion_text, pybind11::return_value_policy::take_ownership);
+    mobservable.def("create_split_observable", &observable::create_split_observable, pybind11::return_value_policy::take_ownership);
 
 
     py::class_<QuantumStateBase>(m, "QuantumStateBase");
@@ -169,7 +169,7 @@ PYBIND11_MODULE(qulacs, m) {
 
     py::class_<QuantumGateBase>(m, "QuantumGateBase")
         .def("update_quantum_state", &QuantumGateBase::update_quantum_state)
-        .def("copy",&QuantumGateBase::copy, pybind11::return_value_policy::automatic_reference)
+        .def("copy",&QuantumGateBase::copy, pybind11::return_value_policy::take_ownership)
         .def("to_string", &QuantumGateBase::to_string)
 
         .def("get_matrix", [](const QuantumGateBase& gate) {
@@ -184,7 +184,7 @@ PYBIND11_MODULE(qulacs, m) {
         .def("update_quantum_state", &QuantumGateMatrix::update_quantum_state)
         .def("add_control_qubit", &QuantumGateMatrix::add_control_qubit)
         .def("multiply_scalar", &QuantumGateMatrix::multiply_scalar)
-        .def("copy", &QuantumGateMatrix::copy, pybind11::return_value_policy::automatic_reference)
+        .def("copy", &QuantumGateMatrix::copy, pybind11::return_value_policy::take_ownership)
         .def("to_string", &QuantumGateMatrix::to_string)
 
         .def("get_matrix", [](const QuantumGateMatrix& gate) {
@@ -196,41 +196,41 @@ PYBIND11_MODULE(qulacs, m) {
         ;
 
     auto mgate = m.def_submodule("gate");
-    mgate.def("Identity", &gate::Identity, pybind11::return_value_policy::automatic_reference);
-    mgate.def("X", &gate::X, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Y", &gate::Y, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Z", &gate::Z, pybind11::return_value_policy::automatic_reference);
-    mgate.def("H", &gate::H, pybind11::return_value_policy::automatic_reference);
-    mgate.def("S", &gate::S, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Sdag", &gate::Sdag, pybind11::return_value_policy::automatic_reference);
-    mgate.def("T", &gate::T, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Tdag", &gate::Tdag, pybind11::return_value_policy::automatic_reference);
-    mgate.def("sqrtX", &gate::sqrtX, pybind11::return_value_policy::automatic_reference);
-    mgate.def("sqrtXdag", &gate::sqrtXdag, pybind11::return_value_policy::automatic_reference);
-    mgate.def("sqrtY", &gate::sqrtY, pybind11::return_value_policy::automatic_reference);
-    mgate.def("sqrtYdag", &gate::sqrtYdag, pybind11::return_value_policy::automatic_reference);
-    mgate.def("P0", &gate::P0, pybind11::return_value_policy::automatic_reference);
-    mgate.def("P1", &gate::P1, pybind11::return_value_policy::automatic_reference);
+    mgate.def("Identity", &gate::Identity, pybind11::return_value_policy::take_ownership);
+    mgate.def("X", &gate::X, pybind11::return_value_policy::take_ownership);
+    mgate.def("Y", &gate::Y, pybind11::return_value_policy::take_ownership);
+    mgate.def("Z", &gate::Z, pybind11::return_value_policy::take_ownership);
+    mgate.def("H", &gate::H, pybind11::return_value_policy::take_ownership);
+    mgate.def("S", &gate::S, pybind11::return_value_policy::take_ownership);
+    mgate.def("Sdag", &gate::Sdag, pybind11::return_value_policy::take_ownership);
+    mgate.def("T", &gate::T, pybind11::return_value_policy::take_ownership);
+    mgate.def("Tdag", &gate::Tdag, pybind11::return_value_policy::take_ownership);
+    mgate.def("sqrtX", &gate::sqrtX, pybind11::return_value_policy::take_ownership);
+    mgate.def("sqrtXdag", &gate::sqrtXdag, pybind11::return_value_policy::take_ownership);
+    mgate.def("sqrtY", &gate::sqrtY, pybind11::return_value_policy::take_ownership);
+    mgate.def("sqrtYdag", &gate::sqrtYdag, pybind11::return_value_policy::take_ownership);
+    mgate.def("P0", &gate::P0, pybind11::return_value_policy::take_ownership);
+    mgate.def("P1", &gate::P1, pybind11::return_value_policy::take_ownership);
 
-    mgate.def("U1", &gate::U1, pybind11::return_value_policy::automatic_reference);
-    mgate.def("U2", &gate::U2, pybind11::return_value_policy::automatic_reference);
-    mgate.def("U3", &gate::U3, pybind11::return_value_policy::automatic_reference);
+    mgate.def("U1", &gate::U1, pybind11::return_value_policy::take_ownership);
+    mgate.def("U2", &gate::U2, pybind11::return_value_policy::take_ownership);
+    mgate.def("U3", &gate::U3, pybind11::return_value_policy::take_ownership);
 
-    mgate.def("RX", &gate::RX, pybind11::return_value_policy::automatic_reference);
-    mgate.def("RY", &gate::RY, pybind11::return_value_policy::automatic_reference);
-    mgate.def("RZ", &gate::RZ, pybind11::return_value_policy::automatic_reference);
+    mgate.def("RX", &gate::RX, pybind11::return_value_policy::take_ownership);
+    mgate.def("RY", &gate::RY, pybind11::return_value_policy::take_ownership);
+    mgate.def("RZ", &gate::RZ, pybind11::return_value_policy::take_ownership);
 
-    mgate.def("CNOT", &gate::CNOT, pybind11::return_value_policy::automatic_reference);
-    mgate.def("CZ", &gate::CZ, pybind11::return_value_policy::automatic_reference);
-    mgate.def("SWAP", &gate::SWAP, pybind11::return_value_policy::automatic_reference);
+    mgate.def("CNOT", &gate::CNOT, pybind11::return_value_policy::take_ownership);
+    mgate.def("CZ", &gate::CZ, pybind11::return_value_policy::take_ownership);
+    mgate.def("SWAP", &gate::SWAP, pybind11::return_value_policy::take_ownership);
 
-    mgate.def("Pauli", &gate::Pauli, pybind11::return_value_policy::automatic_reference);
-    mgate.def("PauliRotation", &gate::PauliRotation, pybind11::return_value_policy::automatic_reference);
+    mgate.def("Pauli", &gate::Pauli, pybind11::return_value_policy::take_ownership);
+    mgate.def("PauliRotation", &gate::PauliRotation, pybind11::return_value_policy::take_ownership);
 
     QuantumGateMatrix*(*ptr1)(unsigned int, ComplexMatrix) = &gate::DenseMatrix;
     QuantumGateMatrix*(*ptr2)(std::vector<unsigned int>, ComplexMatrix) = &gate::DenseMatrix;
-    mgate.def("DenseMatrix", ptr1, pybind11::return_value_policy::automatic_reference);
-    mgate.def("DenseMatrix", ptr2, pybind11::return_value_policy::automatic_reference);
+    mgate.def("DenseMatrix", ptr1, pybind11::return_value_policy::take_ownership);
+    mgate.def("DenseMatrix", ptr2, pybind11::return_value_policy::take_ownership);
 
     mgate.def("BitFlipNoise", &gate::BitFlipNoise);
     mgate.def("DephasingNoise", &gate::DephasingNoise);
@@ -239,22 +239,22 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("Measurement", &gate::Measurement);
 
     QuantumGateMatrix*(*ptr3)(const QuantumGateBase*, const QuantumGateBase*) = &gate::merge;
-    mgate.def("merge", ptr3, pybind11::return_value_policy::automatic_reference);
+    mgate.def("merge", ptr3, pybind11::return_value_policy::take_ownership);
 
     QuantumGateMatrix*(*ptr4)(std::vector<const QuantumGateBase*>) = &gate::merge;
-    mgate.def("merge", ptr4, pybind11::return_value_policy::automatic_reference);
+    mgate.def("merge", ptr4, pybind11::return_value_policy::take_ownership);
 
     QuantumGateMatrix*(*ptr5)(const QuantumGateBase*, const QuantumGateBase*) = &gate::add;
-    mgate.def("add", ptr5, pybind11::return_value_policy::automatic_reference);
+    mgate.def("add", ptr5, pybind11::return_value_policy::take_ownership);
 
     QuantumGateMatrix*(*ptr6)(std::vector<const QuantumGateBase*>) = &gate::add;
-    mgate.def("add", ptr6, pybind11::return_value_policy::automatic_reference);
+    mgate.def("add", ptr6, pybind11::return_value_policy::take_ownership);
 
-    mgate.def("to_matrix_gate", &gate::to_matrix_gate, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Probabilistic", &gate::Probabilistic, pybind11::return_value_policy::automatic_reference);
-    mgate.def("CPTP", &gate::CPTP, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Instrument", &gate::Instrument, pybind11::return_value_policy::automatic_reference);
-    mgate.def("Adaptive", &gate::Adaptive, pybind11::return_value_policy::automatic_reference);
+    mgate.def("to_matrix_gate", &gate::to_matrix_gate, pybind11::return_value_policy::take_ownership);
+    mgate.def("Probabilistic", &gate::Probabilistic, pybind11::return_value_policy::take_ownership);
+    mgate.def("CPTP", &gate::CPTP, pybind11::return_value_policy::take_ownership);
+    mgate.def("Instrument", &gate::Instrument, pybind11::return_value_policy::take_ownership);
+    mgate.def("Adaptive", &gate::Adaptive, pybind11::return_value_policy::take_ownership);
 
 
     mgate.def("ParametricRX", &gate::ParametricRX);
@@ -265,7 +265,7 @@ PYBIND11_MODULE(qulacs, m) {
 
     py::class_<QuantumCircuit>(m, "QuantumCircuit")
         .def(py::init<unsigned int>())
-        .def("copy", &QuantumCircuit::copy, pybind11::return_value_policy::automatic_reference)
+        .def("copy", &QuantumCircuit::copy, pybind11::return_value_policy::take_ownership)
         // In order to avoid double release, we force using add_gate_copy in python
         .def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*))&QuantumCircuit::add_gate)
         .def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate)
@@ -279,7 +279,7 @@ PYBIND11_MODULE(qulacs, m) {
 			return NULL;
 		}
 		return circuit.gate_list[index]->copy(); 
-	    }, pybind11::return_value_policy::automatic_reference)
+	    }, pybind11::return_value_policy::take_ownership)
         .def("get_gate_count", [](const QuantumCircuit& circuit) -> unsigned int {return (unsigned int)circuit.gate_list.size(); })
 
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*))&QuantumCircuit::update_quantum_state)
@@ -326,7 +326,7 @@ PYBIND11_MODULE(qulacs, m) {
 
     py::class_<ParametricQuantumCircuit, QuantumCircuit>(m, "ParametricQuantumCircuit")
         .def(py::init<unsigned int>())
-        .def("copy", &ParametricQuantumCircuit::copy, pybind11::return_value_policy::automatic_reference)
+        .def("copy", &ParametricQuantumCircuit::copy, pybind11::return_value_policy::take_ownership)
         .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate))  &ParametricQuantumCircuit::add_parametric_gate)
         .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate, UINT))  &ParametricQuantumCircuit::add_parametric_gate)
         .def("add_gate", (void (ParametricQuantumCircuit::*)(QuantumGateBase* gate))  &ParametricQuantumCircuit::add_gate )
@@ -351,7 +351,7 @@ PYBIND11_MODULE(qulacs, m) {
     py::class_<QuantumCircuitOptimizer>(mcircuit, "QuantumCircuitOptimizer")
         .def(py::init<>())
         .def("optimize", &QuantumCircuitOptimizer::optimize)
-        .def("merge_all", &QuantumCircuitOptimizer::merge_all, pybind11::return_value_policy::automatic_reference)
+        .def("merge_all", &QuantumCircuitOptimizer::merge_all, pybind11::return_value_policy::take_ownership)
         ;
 
     py::class_<QuantumCircuitSimulator>(m, "QuantumCircuitSimulator")

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -124,6 +124,13 @@ class TestPointerHandling(unittest.TestCase):
         circuit.update_quantum_state(state)
         del circuit
         del state
+    
+    def test_observable(self):
+        from qulacs import Observable
+        obs = Observable(1)
+        obs.add_operator(1.0, "X 0")
+        term = obs.get_term(0)
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -122,6 +122,7 @@ class TestPointerHandling(unittest.TestCase):
         circuit.update_quantum_state(state)
         circuit.update_quantum_state(state)
         circuit.update_quantum_state(state)
+        circuit.to_string()
         del circuit
         del state
     
@@ -130,6 +131,26 @@ class TestPointerHandling(unittest.TestCase):
         obs = Observable(1)
         obs.add_operator(1.0, "X 0")
         term = obs.get_term(0)
+
+    def test_add_gate(self):
+        from qulacs import QuantumCircuit
+        from qulacs.gate import X
+        circuit = QuantumCircuit(1)
+        gate = X(0)
+        circuit.add_gate(gate)
+        del gate
+        s = circuit.to_string()
+        del circuit
+
+    def test_add_gate_in_parametric_circuit(self):
+        from qulacs import ParametricQuantumCircuit
+        from qulacs.gate import X
+        circuit = ParametricQuantumCircuit(1)
+        gate = X(0)
+        circuit.add_gate(gate)
+        del gate
+        s = circuit.to_string()
+        del circuit
         
 
 if __name__ == "__main__":

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -59,5 +59,71 @@ class TestQuantumCircuit(unittest.TestCase):
         vector_ans[3] = np.sqrt(0.5)
         self.assertTrue(((vector-vector_ans)<1e-10).all(), msg = "check make bell state")
 
+class TestPointerHandling(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+    
+    def test_pointer_del(self):
+        from qulacs import QuantumCircuit
+        from qulacs.gate import X
+        qc = QuantumCircuit(1)
+        gate = X(0)
+        qc.add_gate(gate)
+        del gate
+        del qc
+
+    def test_internal_return_value_of_get_gate_is_valid(self):
+        from qulacs import QuantumCircuit, QuantumState
+        def func():
+            def copy_circuit(c):
+                ret = QuantumCircuit(2)
+                for i in range(c.get_gate_count()):
+                    gate = c.get_gate(i)
+                    ret.add_gate(gate)
+                return ret
+
+            circuit = QuantumCircuit(2)
+            circuit.add_X_gate(0)
+            circuit.add_Y_gate(1)
+            copied = copy_circuit(circuit)
+            return copied
+
+        def func2():
+            qs = QuantumState(2)
+            circuit = func()
+            circuit.update_quantum_state(qs)
+
+        func2()
+
+    def test_add_same_gate_multiple_time(self):
+        from qulacs import QuantumCircuit, QuantumState
+        from qulacs.gate import X, DepolarizingNoise, DephasingNoise, Probabilistic, RX
+        state = QuantumState(1)
+        circuit = QuantumCircuit(1)
+        noise = DepolarizingNoise(0,0)
+        circuit.add_gate(noise)
+        circuit.add_gate(noise.copy())
+        circuit.add_gate(DephasingNoise(0,0))
+        circuit.add_gate(Probabilistic([0.1],[RX(0,0)]))
+        gate = RX(0,0)
+        circuit.add_gate(gate)
+        circuit.add_gate(gate)
+        circuit.add_gate(gate)
+        circuit.add_gate(gate)
+        circuit.add_gate(gate)
+        del gate
+        circuit.update_quantum_state(state)
+        circuit.update_quantum_state(state)
+        circuit.update_quantum_state(state)
+        circuit.update_quantum_state(state)
+        circuit.update_quantum_state(state)
+        circuit.update_quantum_state(state)
+        circuit.update_quantum_state(state)
+        del circuit
+        del state
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -134,24 +134,12 @@ void QuantumCircuit::add_gate(QuantumGateBase* gate, UINT index){
     this->_gate_list.insert(this->_gate_list.begin() + index, gate);
 }
 
-void QuantumCircuit::add_gate_copy(const QuantumGateBase& gate){
-	if (!check_gate_index(this, &gate)) {
-		std::cerr << "Error: QuatnumCircuit::add_gate_copy(const QuantumGateBase&): gate must be applied to qubits of which the indices are smaller than qubit_count" << std::endl;
-		return;
-	}
-	this->_gate_list.push_back(gate.copy());
+void QuantumCircuit::add_gate_copy(const QuantumGateBase* gate){
+	this->add_gate(gate->copy());
 }
 
-void QuantumCircuit::add_gate_copy(const QuantumGateBase& gate, UINT index){
-	if (!check_gate_index(this, &gate)) {
-		std::cerr << "Error: QuatnumCircuit::add_gate_copy(const QuantumGateBase&, UINT): gate must be applied to qubits of which the indices are smaller than qubit_count" << std::endl;
-		return;
-	}
-	if (index > this->_gate_list.size()) {
-		std::cerr << "Error: QuantumCircuit::add_gate_copy(const QuantumGateBase*, UINT) : insert index must be smaller than or equal to gate_count" << std::endl;
-		return;
-	}
-	this->_gate_list.insert(this->_gate_list.begin() + index, gate.copy());
+void QuantumCircuit::add_gate_copy(const QuantumGateBase* gate, UINT index){
+	this->add_gate(gate->copy(), index);
 }
 
 void QuantumCircuit::remove_gate(UINT index){

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -96,7 +96,7 @@ public:
      * add_gateに比べコピーが発生する分低速な一方、引数で与えたゲートを再利用できる。
      * @param[in] gate 追加する量子ゲート
      */
-    virtual void add_gate_copy(const QuantumGateBase& gate);
+    virtual void add_gate_copy(const QuantumGateBase* gate);
 
     /**
      * \~japanese-en 量子ゲートを回路の指定位置に追加する。
@@ -105,7 +105,7 @@ public:
      * @param[in] gate 追加する量子ゲート
      * @param[in] index 追加する位置
      */
-    virtual void add_gate_copy(const QuantumGateBase& gate, UINT index);
+    virtual void add_gate_copy(const QuantumGateBase* gate, UINT index);
 
     /**
      * \~japanese-en 量子回路からゲートを削除する。

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -92,6 +92,13 @@ void ParametricQuantumCircuit::add_gate(QuantumGateBase* gate, UINT index) {
     QuantumCircuit::add_gate(gate, index);
     for (auto& val : _parametric_gate_position) if (val >= index)val++;
 }
+void ParametricQuantumCircuit::add_gate_copy(const QuantumGateBase* gate) {
+	QuantumCircuit::add_gate(gate->copy());
+}
+void ParametricQuantumCircuit::add_gate_copy(const QuantumGateBase* gate, UINT index) {
+	QuantumCircuit::add_gate(gate->copy(), index);
+	for (auto& val : _parametric_gate_position) if (val >= index)val++;
+}
 
 void ParametricQuantumCircuit::remove_gate(UINT index) {
     auto ite = std::find(_parametric_gate_position.begin(), _parametric_gate_position.end(), (unsigned int)index);

--- a/src/vqcsim/parametric_circuit.hpp
+++ b/src/vqcsim/parametric_circuit.hpp
@@ -23,7 +23,9 @@ public:
     virtual UINT get_parametric_gate_position(UINT index) const;
     virtual void add_gate(QuantumGateBase* gate) override;
     virtual void add_gate(QuantumGateBase* gate, UINT index) override;
-    virtual void remove_gate(UINT index) override;
+	virtual void add_gate_copy(const QuantumGateBase* gate) override;
+	virtual void add_gate_copy(const QuantumGateBase* gate, UINT index) override;
+	virtual void remove_gate(UINT index) override;
 
     virtual std::string to_string() const;
     friend DllExport std::ostream& operator<<(std::ostream& os, const ParametricQuantumCircuit&);


### PR DESCRIPTION
- Update

Change return value policy of copy function and gate factory from automatic_reference to take_ownership.

For checking there is no segfault in typical codes, I have added some python tests on pointer handling.

- Reasons

When we use function such as <code>qulacs.gate.X(index)</code>, a new gate instance is created in C++ side, and python refers its pointer without ownership. Since this pointer is not released in C++, this causes memory leak. In particular, this problem is serious when we create a lot of heavy QuantumGate object because it eventually leads to out-of-memory error.

- Solution

By changing return value policy from automatic_reference to take_ownership, python-side is responsible for releasing given pointers.


- Note

QuantumCircuit is responsible for releasing added gate instances. To avoid double-free, <code>QuantumCircuit::add_gate</code> function called from python uses copied gate instance of arguments as default. Therefore, QuantumCircuit is (I hope) valid even if gate is released after <code>QuantumCircuit::add_gate</code>.

Though I carefully examined return value policies, I cannot cover all the possible pointer handling codes and there may be segfault scenarios. Reports on potentially-segfault-code are welcome.
