### PR TITLE
[Feature] Implementation of state reflection gate and sparse matrix gate

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -239,11 +239,13 @@ PYBIND11_MODULE(qulacs, m) {
     QuantumGateMatrix*(*ptr2)(std::vector<unsigned int>, ComplexMatrix) = &gate::DenseMatrix;
     mgate.def("DenseMatrix", ptr1, pybind11::return_value_policy::take_ownership);
     mgate.def("DenseMatrix", ptr2, pybind11::return_value_policy::take_ownership);
+	mgate.def("SparseMatrix", &gate::SparseMatrix, pybind11::return_value_policy::take_ownership);
 
   	mgate.def("RandomUnitary", &gate::RandomUnitary, pybind11::return_value_policy::take_ownership);
     mgate.def("ReversibleBoolean", [](std::vector<UINT> target_qubit_list, std::function<ITYPE(ITYPE,ITYPE)> function_py) {
         return gate::ReversibleBoolean(target_qubit_list, function_py);
     }, pybind11::return_value_policy::take_ownership);
+	mgate.def("StateReflection", &gate::StateReflection, pybind11::return_value_policy::take_ownership);
 
     mgate.def("BitFlipNoise", &gate::BitFlipNoise);
     mgate.def("DephasingNoise", &gate::DephasingNoise);

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -152,6 +152,36 @@ class TestPointerHandling(unittest.TestCase):
         s = circuit.to_string()
         del circuit
         
+    def test_state_reflection(self):
+        from qulacs import QuantumState
+        from qulacs.gate import StateReflection
+        n = 5
+        s1 = QuantumState(n)
+        def gen_gate():
+            s2 = QuantumState(n)
+            gate = StateReflection(s2)
+            del s2
+            return gate
+        gate = gen_gate()
+        gate.update_quantum_state(s1)
+        del gate
+        del s1
+
+    def test_sparse_matrix(self):
+        
+        from qulacs import QuantumState
+        from qulacs.gate import SparseMatrix
+        from scipy.sparse import lil_matrix
+        n = 5
+        state = QuantumState(n)
+        matrix = lil_matrix( (4,4) , dtype = np.complex128)
+        matrix[0,0] = 1 + 1.j
+        matrix[1,1] = 1. + 1.j
+        gate = SparseMatrix([0,1], matrix)
+        gate.update_quantum_state(state)
+        del gate
+        del state
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cppsim/gate.hpp
+++ b/src/cppsim/gate.hpp
@@ -67,6 +67,7 @@
 #define FLAG_PARAMETRIC 0x08
 
 class QuantumGateMatrix;
+class QuantumGateSparseMatrix;
 class QuantumStateBase;
 
 /**

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -12,7 +12,9 @@
 #include "gate_named_two.hpp"
 #include "gate_named_pauli.hpp"
 #include "gate_matrix.hpp"
+#include "gate_matrix_sparse.hpp"
 #include "gate_reversible.hpp"
+#include "gate_reflect.hpp"
 #include "type.hpp"
 #include <Eigen/QR>
 
@@ -134,6 +136,10 @@ namespace gate{
         return new QuantumGateMatrix(target_list, matrix);
     }
 
+	QuantumGateBase* SparseMatrix(std::vector<UINT> target_list, SparseComplexMatrix matrix) {
+		return new QuantumGateSparseMatrix(target_list, matrix);
+	}
+
 	QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
 		Random random;
 		UINT qubit_count = (UINT)target_list.size();
@@ -158,6 +164,9 @@ namespace gate{
 	}
 	QuantumGateBase* ReversibleBoolean(std::vector<UINT> target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)> function_ptr) {
 		return new ClsReversibleBooleanGate(target_qubit_index_list, function_ptr);
+	}
+	QuantumGateBase* StateReflection(const QuantumStateBase* reflection_state) {
+		return new ClsStateReflectionGate(reflection_state);
 	}
 
 

--- a/src/cppsim/gate_factory.hpp
+++ b/src/cppsim/gate_factory.hpp
@@ -295,6 +295,16 @@ namespace gate{
     DllExport QuantumGateMatrix* DenseMatrix(std::vector<UINT> target_qubit_index_list, ComplexMatrix matrix);
 
 	/**
+	 * \f$n\f$-qubit スパースな行列を用いてn-qubitゲートを生成する。
+	 *
+	 * <code>target_qubit_index_list</code>の要素数を\f$m\f$としたとき、<code>matrix</code>は\f$2^m \times 2^m \f$の複素行列でなくてはいけない。
+	 * @param[in] target_qubit_index_list ターゲットとなる量子ビットの添え字
+	 * @param[in] matrix 作用するゲートの複素行列。
+	 * @return 作成されたゲートのインスタンス
+	 */
+	DllExport QuantumGateBase* SparseMatrix(std::vector<UINT> target_qubit_index_list, SparseComplexMatrix matrix);
+
+	/**
 	 * \f$n\f$-qubit のランダムユニタリゲートを作成する。
 	 *
 	 * @param[in] target_qubit_index_list ターゲットとなる量子ビットの添え字
@@ -310,6 +320,14 @@ namespace gate{
 	 * @return 作成されたゲートのインスタンス
 	 */
 	DllExport QuantumGateBase* ReversibleBoolean(std::vector<UINT> target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)>);
+
+	/**
+	 * 量子状態に対して量子状態を反射する。
+	 *
+	 * @param[in] reflection_state 反射に用いられる量子状態
+	 * @return 作成されたゲートのインスタンス
+	 */
+	DllExport QuantumGateBase* StateReflection(const QuantumStateBase* reflection_state);
 
 
     /**

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -1,0 +1,110 @@
+
+#ifndef _MSC_VER
+extern "C" {
+#include <csim/utility.h>
+}
+#else
+#include <csim/utility.h>
+#endif
+#include <csim/update_ops_cpp.hpp>
+
+#include "state.hpp"
+#include "gate_matrix_sparse.hpp"
+#include "type.hpp"
+#include <numeric>
+#include <algorithm>
+#ifdef _USE_GPU
+#include <gpusim/update_ops_cuda.h>
+#endif
+
+// In construction, "copy" a given matrix. If a given matrix is large, use "move" constructor.
+QuantumGateSparseMatrix::QuantumGateSparseMatrix(const std::vector<UINT>& target_qubit_index_list_, const SparseComplexMatrix& matrix_element, const std::vector<UINT>& control_qubit_index_list_) {
+	for (auto val : target_qubit_index_list_) {
+		this->_target_qubit_list.push_back(TargetQubitInfo(val, 0));
+	}
+	for (auto val : control_qubit_index_list_) {
+		this->_control_qubit_list.push_back(ControlQubitInfo(val, 1));
+	}
+	this->_matrix_element = SparseComplexMatrix(matrix_element);
+	this->_name = "SparseMatrix";
+}
+QuantumGateSparseMatrix::QuantumGateSparseMatrix(const std::vector<TargetQubitInfo>& target_qubit_index_list_, const SparseComplexMatrix& matrix_element, const std::vector<ControlQubitInfo>& control_qubit_index_list_) {
+	this->_target_qubit_list = std::vector<TargetQubitInfo>(target_qubit_index_list_);
+	this->_control_qubit_list = std::vector<ControlQubitInfo>(control_qubit_index_list_);
+	this->_matrix_element = SparseComplexMatrix(matrix_element);
+	this->_name = "SparseMatrix";
+}
+
+// In construction, "move" a given matrix, which surpess the cost of copying large matrix element.
+QuantumGateSparseMatrix::QuantumGateSparseMatrix(const std::vector<UINT>& target_qubit_index_list_, SparseComplexMatrix* matrix_element, const std::vector<UINT>& control_qubit_index_list_) {
+	for (auto val : target_qubit_index_list_) {
+		this->_target_qubit_list.push_back(TargetQubitInfo(val, 0));
+	}
+	for (auto val : control_qubit_index_list_) {
+		this->_control_qubit_list.push_back(ControlQubitInfo(val, 1));
+	}
+	this->_matrix_element.swap(*matrix_element);
+	this->_name = "SparseMatrix";
+}
+QuantumGateSparseMatrix::QuantumGateSparseMatrix(const std::vector<TargetQubitInfo>& target_qubit_index_list_, SparseComplexMatrix* matrix_element, const std::vector<ControlQubitInfo>& control_qubit_index_list_) {
+	this->_target_qubit_list = std::vector<TargetQubitInfo>(target_qubit_index_list_);
+	this->_control_qubit_list = std::vector<ControlQubitInfo>(control_qubit_index_list_);
+	this->_matrix_element.swap(*matrix_element);
+	this->_name = "SparseMatrix";
+}
+
+
+
+void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
+	ITYPE dim = 1ULL << state->qubit_count;
+
+	if (this->_control_qubit_list.size() > 0) {
+		std::cerr << "Control qubit in sparse matrix gate is not supported" << std::endl;
+	}
+
+	std::vector<UINT> target_index;
+	std::vector<UINT> control_index;
+	std::vector<UINT> control_value;
+	for (auto val : this->_target_qubit_list) {
+		target_index.push_back(val.index());
+	}
+
+#ifdef _USE_GPU
+	if (state->get_device_name() == "gpu") {
+		std::cerr << "Sparse matrix gate is not supported on GPU" << std::end;
+	}
+	else {
+		multi_qubit_sparse_matrix_gate_eigen(
+			target_index.data(), (UINT)(target_index.size()),
+			this->_matrix_element, state->data_c(), dim);
+	}
+#else
+	multi_qubit_sparse_matrix_gate_eigen(
+		target_index.data(), (UINT)(target_index.size()),
+		this->_matrix_element, state->data_c(), dim);
+#endif
+}
+
+
+void QuantumGateSparseMatrix::add_control_qubit(UINT qubit_index, UINT control_value) {
+	this->_control_qubit_list.push_back(ControlQubitInfo(qubit_index, control_value));
+	this->_gate_property &= (~FLAG_PAULI);
+	this->_gate_property &= (~FLAG_GAUSSIAN);
+}
+
+std::string QuantumGateSparseMatrix::to_string() const {
+	std::stringstream os;
+	os << QuantumGateBase::to_string();
+	os << " * Matrix" << std::endl;
+	os << this->_matrix_element << std::endl;
+	return os.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const QuantumGateSparseMatrix& gate) {
+	os << gate.to_string();
+	return os;
+}
+std::ostream& operator<<(std::ostream& os, QuantumGateSparseMatrix* gate) {
+	os << *gate;
+	return os;
+}

--- a/src/cppsim/gate_matrix_sparse.hpp
+++ b/src/cppsim/gate_matrix_sparse.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "gate.hpp"
+#include "type.hpp"
+
+/**
+ * \~japanese-en 行列要素で自身が作用する内容を保持するクラス
+ */
+class DllExport QuantumGateSparseMatrix : public QuantumGateBase {
+private:
+	SparseComplexMatrix _matrix_element;     /**< list of elements of unitary matrix as 1D array with length dim*dim (only for dense gate))*/
+public:
+	/**
+	 * \~japanese-en コンストラクタ
+	 *
+	 * 行列要素はコピーされるため、matrixは再利用できるが低速である
+	 * @param target_qubit_index_list ターゲットとなる量子ビットの添え字のリスト
+	 * @param matrix_element 行列要素
+	 * @param control_qubit_index_list コントロールとなる量子ビットのリスト <code>control_value</code>はすべて1になる。
+	 */
+	QuantumGateSparseMatrix(const std::vector<UINT>& target_qubit_index_list, const SparseComplexMatrix& matrix_element, const std::vector<UINT>& control_qubit_index_list = {});
+
+	/**
+	 * \~japanese-en コンストラクタ
+	 *
+	 * 行列要素はswapされるため、matrixは再利用できないが高速である。
+	 * @param target_qubit_index_list ターゲットとなる量子ビットの添え字のリスト
+	 * @param matrix_element 行列要素
+	 * @param control_qubit_index_list コントロールとなる量子ビットのリスト <code>control_value</code>はすべて1になる。
+	 */
+	QuantumGateSparseMatrix(const std::vector<UINT>& target_qubit_index_list, SparseComplexMatrix* matrix_element, const std::vector<UINT>& control_qubit_index_list = {});
+
+	/**
+	 * \~japanese-en コンストラクタ
+	 *
+	 * 行列要素はコピーされるため、matrixは再利用できるが低速である
+	 * @param target_qubit_index_list ターゲットとなる量子ビットの情報のリスト
+	 * @param matrix_element 行列要素
+	 * @param control_qubit_index_list コントロールとなる量子ビットの情報のリスト
+	 */
+	QuantumGateSparseMatrix(const std::vector<TargetQubitInfo>& target_qubit_index_list, const SparseComplexMatrix& matrix_element, const std::vector<ControlQubitInfo>& control_qubit_index_list = {});
+
+	/**
+	 * \~japanese-en コンストラクタ
+	 *
+	 * 行列要素はswapされるため、matrixは再利用できないが高速である。
+	 * @param target_qubit_index_list ターゲットとなる量子ビットの情報のリスト
+	 * @param matrix_element 行列要素
+	 * @param control_qubit_index_list コントロールとなる量子ビットの情報のリスト
+	 */
+	QuantumGateSparseMatrix(const std::vector<TargetQubitInfo>& target_qubit_index_list, SparseComplexMatrix* matrix_element, const std::vector<ControlQubitInfo>& control_qubit_index_list = {});
+
+	/**
+	 * \~japanese-en デストラクタ
+	 */
+	virtual ~QuantumGateSparseMatrix() {};
+
+	/**
+	 * \~japanese-en コントロールの量子ビットを追加する
+	 *
+	 * <code>qubit_index</code>はゲートのターゲットやコントロールの値に含まれてはいけない。
+	 * @param[in] qubit_index コントロールの量子ビットの添え字
+	 * @param[in] control_value 基底の<code>qubit_index</code>が<code>control_value</code>である場合にのみゲートが作用する。
+	 */
+	virtual void add_control_qubit(UINT qubit_index, UINT control_value);
+
+	/**
+	 * \~japanese-en ゲート行列にスカラー値をかける
+	 *
+	 * @param[in] value かける値
+	 */
+	virtual void multiply_scalar(CPPCTYPE value) {
+		_matrix_element *= value;
+	}
+
+	/**
+	 * \~japanese-en ゲートのプロパティを設定する
+	 *
+	 * @param[in] gate_property_ ゲートのプロパティ値
+	 */
+	virtual void set_gate_property(UINT gate_property_) {
+		_gate_property = gate_property_;
+	}
+
+	/**
+	 * \~japanese-en 量子状態に作用する
+	 *
+	 * @param[in,out] state 更新する量子状態
+	 */
+	virtual void update_quantum_state(QuantumStateBase* state) override;
+
+	/**
+	 * \~japanese-en 自身のコピーを作成する
+	 *
+	 * @return コピーされたゲートのインスタンス
+	 */
+	virtual QuantumGateBase* copy() const override {
+		return new QuantumGateSparseMatrix(*this);
+	};
+
+	/**
+	 * \~japanese-en 自身の行列要素をセットする
+	 *
+	 * @param[out] matrix 行列要素をセットする行列の参照
+	 */
+	virtual void set_matrix(ComplexMatrix& matrix) const override {
+		matrix = this->_matrix_element.toDense();
+	}
+
+	/**
+	 * \~japanese-en 量子回路のデバッグ情報の文字列を生成する
+	 *
+	 * @return 生成した文字列
+	 */
+	virtual std::string to_string() const override;
+
+	/**
+	 * \~japanese-en ゲートの情報を文字列で出力する
+	 *
+	 * @param os 出力するストリーム
+	 * @param gate 情報の出力を行うゲート
+	 * @return 受け取ったストリーム
+	 */
+	friend DllExport std::ostream& operator<<(std::ostream& os, const QuantumGateSparseMatrix& gate);
+
+	/**
+	 * \~japanese-en ゲートの情報を文字列で出力する
+	 *
+	 * @param os 出力するストリーム
+	 * @param gate 情報の出力を行うゲート
+	 * @return 受け取ったストリーム
+	 */
+	friend DllExport std::ostream& operator<<(std::ostream& os, QuantumGateSparseMatrix* gate);
+
+};

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "gate.hpp"
+#include "state.hpp"
+#ifndef _MSC_VER
+extern "C" {
+#include <csim/update_ops.h>
+}
+#else
+#include <csim/update_ops.h>
+#endif
+#include <csim/update_ops_cpp.hpp>
+
+#include <cmath>
+
+#ifdef _USE_GPU
+#include <gpusim/update_ops_cuda.h>
+#endif
+#include <iostream>
+
+/**
+ * \~japanese-en 量子状態を、別の量子状態に対して反射するゲートのクラス
+ */
+class ClsStateReflectionGate : public QuantumGateBase {
+private:
+	QuantumStateBase* reflection_state;
+public:
+	ClsStateReflectionGate(const QuantumStateBase* _reflection_state) {
+		reflection_state = _reflection_state->copy();
+		UINT qubit_count = _reflection_state->qubit_count;
+		for (UINT qubit_index = 0; qubit_index < qubit_count; ++qubit_index) {
+			this->_target_qubit_list.push_back(TargetQubitInfo(qubit_index, 0));
+		}
+		this->_name = "Reflection";
+	};
+	virtual ~ClsStateReflectionGate() {
+		delete reflection_state;
+	}
+
+	/**
+	 * \~japanese-en 量子状態を更新する
+	 *
+	 * @param state 更新する量子状態
+	 */
+	virtual void update_quantum_state(QuantumStateBase* state) override {
+#ifdef _USE_GPU
+		if (state->get_device_name() != reflection_state->get_device_name()) {
+			std::cerr << "Quantum state on CPU (GPU) cannot be reflected using quantum state on GPU (CPU)" << std::endl;
+			return;
+		}
+		if (state->get_device_name() == "gpu") {
+			std::cerr << "Not Implemented" << std::endl;
+			exit(0);
+			//reversible_boolean_gate_gpu(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+		}
+		else {
+			reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+		}
+#else
+		reflection_gate(reflection_state->data_c(), state->data_c(), state->dim);
+#endif
+	};
+	/**
+	 * \~japanese-en 自身のディープコピーを生成する
+	 *
+	 * @return 自身のディープコピー
+	 */
+	virtual QuantumGateBase* copy() const override {
+		return new ClsStateReflectionGate(this->reflection_state);
+	};
+	/**
+	 * \~japanese-en 自身のゲート行列をセットする
+	 *
+	 * @param matrix 行列をセットする変数の参照
+	 */
+	virtual void set_matrix(ComplexMatrix& matrix) const override {
+		std::cerr << "ReflectionGate::set_matrix is not implemented" << std::endl;
+		exit(0);
+	}
+};
+
+

--- a/src/cppsim/type.hpp
+++ b/src/cppsim/type.hpp
@@ -10,11 +10,13 @@ extern "C" {
 
 #include <complex>
 #include <Eigen/Core>
+#include <Eigen/Sparse>
 typedef std::complex<double> CPPCTYPE;
 typedef Eigen::VectorXcd ComplexVector;
 
 // In order to use matrix raw-data without reordering, we use RowMajor as default.
 typedef Eigen::Matrix<CPPCTYPE, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> ComplexMatrix;
+typedef Eigen::SparseMatrix<CPPCTYPE> SparseComplexMatrix;
 
 #ifdef _MSC_VER
 inline static FILE* popen(const char* command, const char* mode) { return _popen(command, mode); }

--- a/src/csim/update_ops.h
+++ b/src/csim/update_ops.h
@@ -951,6 +951,31 @@ DllExport void multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* con
 
 
 
+/**
+ * \~english
+ * Reflect state according to another given state.
+ *
+ * Reflect state according to another given state. When reflect quantum state |a> to state |s>, unitary operator give by 2|s><s|-I is applied to |a>.
+ *
+ * @param[in] reflection_state quantum state to characterize reflection unitary operator
+ * @param[in,out] state quantum state to update
+ * @param[in] dim dimension
+ *
+ *
+ * \~japanese-en
+ * reflection gateを作用する。
+ *
+ * 与えられた状態にreflection gateを作用する。量子状態|a>を量子状態|s>に関してreflectするとは、量子状態|a>に対して2|s><s|-Iというユニタリ操作をすることに対応する。
+ *
+ * @param[in] reflection_state reflection gateのユニタリを特徴づける量子状態
+ * @param[in,out] state quantum 更新する量子状態
+ * @param[in] dim 次元
+ *
+ */
+DllExport void reflection_gate(const CTYPE* reflection_state, CTYPE* state, ITYPE dim);
+
+
+
 
 ////////////////////////////////
 

--- a/src/csim/update_ops_cpp.cpp
+++ b/src/csim/update_ops_cpp.cpp
@@ -128,6 +128,43 @@ void multi_qubit_dense_matrix_gate_eigen(const UINT* target_qubit_index_list, UI
     free((ITYPE*)matrix_mask_list);
 }
 
+void multi_qubit_sparse_matrix_gate_eigen(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const Eigen::SparseMatrix<std::complex<double>>& eigen_matrix, CTYPE* state, ITYPE dim) {
+	// matrix dim, mask, buffer
+	const ITYPE matrix_dim = 1ULL << target_qubit_index_count;
+	const ITYPE* matrix_mask_list = create_matrix_mask_list(target_qubit_index_list, target_qubit_index_count);
+	Eigen::VectorXcd buffer(matrix_dim);
+	std::complex<double>* eigen_state = reinterpret_cast<std::complex<double>*>(state);
+
+	// insert index
+	const UINT* sorted_insert_index_list = create_sorted_ui_list(target_qubit_index_list, target_qubit_index_count);
+
+	// loop variables
+	const ITYPE loop_dim = dim >> target_qubit_index_count;
+
+	ITYPE state_index;
+	for (state_index = 0; state_index < loop_dim; ++state_index) {
+		// create base index
+		ITYPE basis_0 = state_index;
+		for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+			UINT insert_index = sorted_insert_index_list[cursor];
+			basis_0 = insert_zero_to_basis_index(basis_0, 1ULL << insert_index, insert_index);
+		}
+
+		// fetch vector
+		for (ITYPE y = 0; y < matrix_dim; ++y) {
+			buffer[y] = eigen_state[basis_0 ^ matrix_mask_list[y]];
+		}
+
+		buffer = eigen_matrix * buffer;
+
+		// set result
+		for (ITYPE y = 0; y < matrix_dim; ++y) {
+			eigen_state[basis_0 ^ matrix_mask_list[y]] = buffer[y];
+		}
+	}
+	free((UINT*)sorted_insert_index_list);
+	free((ITYPE*)matrix_mask_list);
+}
 
 void reversible_boolean_gate(const UINT* target_qubit_index_list, UINT target_qubit_index_count, std::function<ITYPE(ITYPE,ITYPE)> function_ptr, CTYPE* state, ITYPE dim) {
 

--- a/src/csim/update_ops_cpp.hpp
+++ b/src/csim/update_ops_cpp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <Eigen/Sparse>
 #include <functional>
 #ifndef _MSC_VER
 extern "C"{
@@ -13,6 +14,8 @@ extern "C"{
 DllExport void multi_qubit_dense_matrix_gate_eigen(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim);
 DllExport void multi_qubit_dense_matrix_gate_eigen(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const Eigen::MatrixXcd& eigen_matrix, CTYPE* state, ITYPE dim);
 DllExport void multi_qubit_dense_matrix_gate_eigen(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const Eigen::Matrix<std::complex<double>,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor>& eigen_matrix, CTYPE* state, ITYPE dim);
+
+DllExport void multi_qubit_sparse_matrix_gate_eigen(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const Eigen::SparseMatrix<std::complex<double>>& eigen_matrix, CTYPE* state, ITYPE dim);
 
 /**
  * \~english

--- a/src/csim/update_ops_reflect.c
+++ b/src/csim/update_ops_reflect.c
@@ -1,0 +1,21 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "constant.h"
+#include "update_ops.h"
+#include "stat_ops.h"
+#include "utility.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+void reflection_gate(const CTYPE* reflection_state, CTYPE* state, ITYPE dim) {
+	CTYPE coef = state_inner_product(reflection_state, state, dim);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (ITYPE state_index = 0; state_index < dim; ++state_index) {
+		state[state_index] = 2.0 * coef * reflection_state[state_index] - state[state_index];
+	}
+}


### PR DESCRIPTION
- Update

I've added two gates, StateReflection and SparseMatrix.

<code>StateReflection</code> gate is characterized by quantum state |s><s|, and its unitary matrix is given by U = 2|s><s| - I. This gate is frequently used in algorithms such as Grover's search or HHL.

<code>SparseMatrix</code> gate is similar to DenseMatrix gate but it holds its matrix elements as sparse matrix. Simulation of this gate is much faster than DenseMatrix when a gate acts on many qubits and its gate matrix is sparse.

These features are proposed by @Yuya-O-Nakagawa .

- Usage

Reflection Gate
```python
from qulacs import QuantumState
from qulacs.gate import StateReflection

n = 3
state = QuantumState(n)
reflect = QuantumState(n)
gate = StateReflection(reflect)
# Note: QuantumState object is copied when gate instance is created. 
# Since it might consumes a lot of memory, delete reflection state after creating gate if you use large quantum state.
del reflect
gate.update_quantum_state(state)
```

SparseMatrix
```python
from qulacs import QuantumState
from qulacs.gate import SparseMatrix
import numpy as np
from scipy.sparse import lil_matrix

n = 3
state = QuantumState(n)

# Note: Unlike np.ndarray, real sparse matrix is not implicitly converted to complex sparse matrix. 
# Thus, we need to explicitly define complex sparse matrix. 
matrix = lil_matrix( (2**n, 2**n), dtype = np.complex128 )
matrix[0,1] = 1
matrix[1,0] = 1
gate = SparseMatrix([0,1], matrix)
gate.update_quantum_state(state)
print(state)
```
