### PR TITLE
[Bugfix] fix bug in marginal probability

### DIFF
--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -322,9 +322,10 @@ public:
 		std::vector<UINT> target_index;
         std::vector<UINT> target_value;
         for (UINT i = 0; i < measured_values.size(); ++i) {
-            if (i == 0 || i == 1) {
+			UINT measured_value = measured_values[i];
+            if (measured_value== 0 || measured_value == 1) {
                 target_index.push_back(i);
-                target_value.push_back(measured_values[i]);
+                target_value.push_back(measured_value);
             }
         }
         return marginal_prob(target_index.data(), target_value.data(), (UINT)target_index.size(), this->data_c(), _dim);

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -75,7 +75,8 @@ public:
 		std::vector<UINT> target_index;
 		std::vector<UINT> target_value;
 		for (UINT i = 0; i < measured_values.size(); ++i) {
-			if (i == 0 || i == 1) {
+			UINT measured_value = measured_values[i];
+			if (measured_value == 0 || measured_value == 1) {
 				target_index.push_back(i);
 				target_value.push_back(measured_values[i]);
 			}

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -78,7 +78,7 @@ public:
 			UINT measured_value = measured_values[i];
 			if (measured_value == 0 || measured_value == 1) {
 				target_index.push_back(i);
-				target_value.push_back(measured_values[i]);
+				target_value.push_back(measured_value);
 			}
 		}
 		return marginal_prob_host(target_index.data(), target_value.data(), (UINT)target_index.size(), this->data(), _dim);

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -56,3 +56,24 @@ TEST(StateTest, SetState) {
 		ASSERT_NEAR(state.data_cpp()[i].imag(), state_vector[i].imag(), eps);
 	}
 }
+
+TEST(StateTest, GetMarginalProbability) {
+	const double eps = 1e-10;
+	const UINT n = 2;
+	const ITYPE dim = 1 << n;
+	QuantumState state(n);
+	state.set_Haar_random_state();
+	std::vector<double> probs;
+	for (ITYPE i = 0; i < dim; ++i) {
+		probs.push_back(pow(abs(state.data_cpp()[i]),2));
+	}
+	ASSERT_NEAR(state.get_marginal_probability({ 0,0 }), probs[0], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 1,0 }), probs[1], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 0,1 }), probs[2], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 1,1 }), probs[3], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 0,2 }), probs[0] + probs[2], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 1,2 }), probs[1] + probs[3], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 2,0 }), probs[0] + probs[1], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 2,1 }), probs[2] + probs[3], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 2,2 }), 1., eps);
+}


### PR DESCRIPTION
- Update

There was a bug in QuantumState::get_marginal_probability. This function returned wrong value for almost all the calls.
This bug was reported by @Yuya-O-Nakagawa .

- Detail

Though base function get_marginal_probability in C language code is correct, this base function is called from C++ code in a wrong way.

- Update

I've fixed bugs in C++ code both for CPU and GPU.
I also added test code for C++ get marginal probability.
