### PR TITLE
Add density matrix class / Bugfix for independent XZ noise

### DIFF
--- a/benchmark/libcppsim_benchmark.cpp
+++ b/benchmark/libcppsim_benchmark.cpp
@@ -130,5 +130,6 @@ int main() {
 		}
 	}
 	fout.close();
+	return 0;
 }
 

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include <cppsim/pauli_operator.hpp>
 #include <cppsim/general_quantum_operator.hpp>
 #include <cppsim/state.hpp>
+#include <cppsim/state_dm.hpp>
 #include <cppsim/gate_factory.hpp>
 #include <cppsim/gate_matrix.hpp>
 #include <cppsim/gate_merge.hpp>
@@ -135,6 +136,45 @@ PYBIND11_MODULE(qulacs, m) {
         })
         .def("__repr__", [](const QuantumState &p) {return p.to_string();});
         ;
+
+	py::class_<DensityMatrix, QuantumStateBase>(m, "DensityMatrix")
+		.def(py::init<unsigned int>())
+		.def("set_zero_state", &DensityMatrix::set_zero_state)
+		.def("set_computational_basis", &DensityMatrix::set_computational_basis)
+		.def("set_Haar_random_state", (void (DensityMatrix::*)(void))&DensityMatrix::set_Haar_random_state)
+		.def("set_Haar_random_state", (void (DensityMatrix::*)(UINT))&DensityMatrix::set_Haar_random_state)
+		.def("get_zero_probability", &DensityMatrix::get_zero_probability)
+		.def("get_marginal_probability", &DensityMatrix::get_marginal_probability)
+		.def("get_entropy", &DensityMatrix::get_entropy)
+		.def("get_norm", &DensityMatrix::get_norm)
+		.def("normalize", &DensityMatrix::normalize)
+		.def("allocate_buffer", &DensityMatrix::allocate_buffer, pybind11::return_value_policy::automatic_reference)
+		.def("copy", &DensityMatrix::copy)
+		.def("load", (void (DensityMatrix::*)(const QuantumStateBase*))&DensityMatrix::load)
+		.def("load", (void (DensityMatrix::*)(const std::vector<CPPCTYPE>&))&DensityMatrix::load)
+		.def("load", (void (DensityMatrix::*)(const ComplexMatrix&))&DensityMatrix::load)
+		.def("get_device_name", &DensityMatrix::get_device_name)
+		.def("data_cpp", &DensityMatrix::data_cpp)
+		.def("data_c", &DensityMatrix::data_c)
+		.def("add_state", &DensityMatrix::add_state)
+		.def("multiply_coef", &DensityMatrix::multiply_coef)
+		.def("get_classical_value", &DensityMatrix::get_classical_value)
+		.def("set_classical_value", &DensityMatrix::set_classical_value)
+		.def("to_string", &DensityMatrix::to_string)
+		.def("sampling", &DensityMatrix::sampling)
+
+		.def("get_matrix", [](const DensityMatrix& state) {
+			Eigen::MatrixXcd mat(state.dim, state.dim);
+			CTYPE* ptr = state.data_c();
+			for (ITYPE y = 0; y < state.dim; ++y) {
+				for (ITYPE x = 0; x < state.dim; ++x) {
+					mat(y, x) = ptr[y*state.dim + x];
+				}
+			}
+			return mat;
+		})
+		.def("__repr__", [](const DensityMatrix &p) {return p.to_string(); });
+		;
 
 #ifdef _USE_GPU
     py::class_<QuantumStateGpu, QuantumStateBase>(m, "QuantumStateGpu")

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -298,6 +298,7 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("DephasingNoise", &gate::DephasingNoise);
     mgate.def("IndependentXZNoise", &gate::IndependentXZNoise);
     mgate.def("DepolarizingNoise", &gate::DepolarizingNoise);
+	mgate.def("AmplitudeDampingNoise", &gate::AmplitudeDampingNoise);
     mgate.def("Measurement", &gate::Measurement);
 
     QuantumGateMatrix*(*ptr3)(const QuantumGateBase*, const QuantumGateBase*) = &gate::merge;

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -171,19 +171,55 @@ namespace gate{
 
 
     QuantumGateBase* BitFlipNoise(UINT target_index, double prob) {
-        return new QuantumGate_Probabilistic({ prob }, { X(target_index) });
+		auto gate = X(target_index);
+        auto new_gate = new QuantumGate_Probabilistic({ prob }, { gate });
+		delete gate;
+		return new_gate;
     }
     QuantumGateBase* DephasingNoise(UINT target_index, double prob) {
-        return new QuantumGate_Probabilistic({ prob }, { Z(target_index) });
+		auto gate = Z(target_index);
+		auto new_gate = new QuantumGate_Probabilistic({ prob }, { gate });
+		delete gate;
+		return new_gate;
     }
     QuantumGateBase* IndependentXZNoise(UINT target_index, double prob) {
-        return new QuantumGate_Probabilistic({ prob*(1-prob), prob*(1-prob), prob*prob }, { X(target_index), Z(target_index) });
-    }
+		auto gate0 = X(target_index);
+		auto gate1 = Z(target_index);
+		auto gate2 = Y(target_index);
+        auto new_gate = new QuantumGate_Probabilistic({ prob*(1-prob), prob*(1-prob), prob*prob }, { gate0, gate1, gate2});
+		delete gate0;
+		delete gate1;
+		delete gate2;
+		return new_gate;
+	}
     QuantumGateBase* DepolarizingNoise(UINT target_index, double prob) {
-        return new QuantumGate_Probabilistic({ prob / 3,prob / 3,prob / 3 }, {X(target_index),Y(target_index),Z(target_index) });
-    }
-    QuantumGateBase* Measurement(UINT target_index, UINT classical_register_address) {
-        return new QuantumGate_Instrument({P0(target_index),P1(target_index)},classical_register_address);
+		auto gate0 = X(target_index);
+		auto gate1 = Z(target_index);
+		auto gate2 = Y(target_index);
+		auto new_gate = new QuantumGate_Probabilistic({ prob / 3,prob / 3,prob / 3 }, { gate0, gate1, gate2 });
+		delete gate0;
+		delete gate1;
+		delete gate2;
+		return new_gate;
+	}
+	QuantumGateBase* AmplitudeDampingNoise(UINT target_index, double prob) {
+		ComplexMatrix damping_matrix_0(2, 2), damping_matrix_1(2,2);
+		damping_matrix_0 << 1, 0, 0, sqrt(1 - prob);
+		damping_matrix_1 << 0, sqrt(prob), 0, 0;
+		auto gate0 = DenseMatrix({ target_index }, damping_matrix_0);
+		auto gate1 = DenseMatrix({ target_index }, damping_matrix_1);
+		auto new_gate = new QuantumGate_CPTP({ gate0, gate1 });
+		delete gate0;
+		delete gate1;
+		return new_gate;
+	}
+	QuantumGateBase* Measurement(UINT target_index, UINT classical_register_address) {
+		auto gate0 = P0(target_index);
+		auto gate1 = P1(target_index);
+        auto new_gate = new QuantumGate_Instrument({ gate0, gate1},classical_register_address);
+		delete gate0;
+		delete gate1;
+		return new_gate;
     }
 
     QuantumGateBase* create_quantum_gate_from_string(std::string gate_string){

--- a/src/cppsim/gate_factory.hpp
+++ b/src/cppsim/gate_factory.hpp
@@ -367,6 +367,15 @@ namespace gate{
      */
     DllExport QuantumGateBase* DepolarizingNoise(UINT target_index, double prob);
 
+	/**
+	 * Amplitude damping noiseを発生させるゲート
+	 *
+	 * @param[in] target_index ターゲットとなる量子ビットの添え字
+	 * @param[in] prob エラーが生じる確率
+	 * @return 作成されたゲートのインスタンス
+	 */
+	DllExport QuantumGateBase* AmplitudeDampingNoise(UINT target_index, double prob);
+
     /**
      * 測定を行う
      *

--- a/src/cppsim/gate_matrix.cpp
+++ b/src/cppsim/gate_matrix.cpp
@@ -238,15 +238,15 @@ void QuantumGateMatrix::update_quantum_state(QuantumStateBase* state) {
 				dm_single_qubit_dense_matrix_gate(target_index[0], matrix_ptr, state->data_c(), dim);
 			}
 			else {
-				dm_multi_qubit_dense_matrix_gate(target_index.data(), target_index.size(), matrix_ptr, state->data_c(), dim);
+				dm_multi_qubit_dense_matrix_gate(target_index.data(), (UINT)target_index.size(), matrix_ptr, state->data_c(), dim);
 			}
 		}
 		else {
 			if (this->_target_qubit_list.size() == 1) {
-				dm_multi_qubit_control_single_qubit_dense_matrix_gate(control_index.data(), control_value.data(), control_index.size(), target_index[0], matrix_ptr, state->data_c(), dim);
+				dm_multi_qubit_control_single_qubit_dense_matrix_gate(control_index.data(), control_value.data(), (UINT)control_index.size(), target_index[0], matrix_ptr, state->data_c(), dim);
 			}
 			else {
-				dm_multi_qubit_control_multi_qubit_dense_matrix_gate(control_index.data(), control_value.data(), control_index.size(), target_index.data(), target_index.size(), matrix_ptr, state->data_c(), dim);
+				dm_multi_qubit_control_multi_qubit_dense_matrix_gate(control_index.data(), control_value.data(), (UINT)control_index.size(), target_index.data(), (UINT)target_index.size(), matrix_ptr, state->data_c(), dim);
 			}
 		}
 	}

--- a/src/cppsim/gate_matrix.cpp
+++ b/src/cppsim/gate_matrix.cpp
@@ -2,10 +2,12 @@
 #ifndef _MSC_VER
 extern "C" {
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 #include <csim/utility.h>
 }
 #else
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 #include <csim/utility.h>
 #endif
 
@@ -87,140 +89,167 @@ void QuantumGateMatrix::update_quantum_state(QuantumStateBase* state) {
         control_value.push_back(val.control_value());
     }
 
-    // single qubit dense matrix gate
-    if(this->_target_qubit_list.size() == 1){
 
-        // no control qubit
-        if(this->_control_qubit_list.size() == 0){
-#ifdef _USE_GPU
-	        if (state->get_device_name() == "gpu") {
-                single_qubit_dense_matrix_gate_host(
-                    target_index[0],
-                    (const CPPCTYPE*)matrix_ptr , state->data(), dim );
-                
-            }else{
-                single_qubit_dense_matrix_gate(
-                    target_index[0],
-                    matrix_ptr , state->data_c(), dim );
-            }
-#else
-            single_qubit_dense_matrix_gate(
-                target_index[0],
-                matrix_ptr , state->data_c(), dim );
-#endif
-        }
-        // single control qubit
-        else if(this->_control_qubit_list.size() == 1){
-#ifdef _USE_GPU
-	        if (state->get_device_name() == "gpu") {
-                single_qubit_control_single_qubit_dense_matrix_gate_host(
-                    control_index[0], control_value[0],
-                    target_index[0],
-                    (const CPPCTYPE*)matrix_ptr, state->data(), dim );
-            }else{
-                single_qubit_control_single_qubit_dense_matrix_gate(
-                    control_index[0], control_value[0],
-                    target_index[0],
-                    matrix_ptr, state->data_c(), dim );
-            }
-#else
-                single_qubit_control_single_qubit_dense_matrix_gate(
-                    control_index[0], control_value[0],
-                    target_index[0],
-                    matrix_ptr, state->data_c(), dim );
-#endif
-        }
-        // multiple control qubits
-        else{
-#ifdef _USE_GPU
-	        if (state->get_device_name() == "gpu") {
-				//
-				std::cerr << "This function is not implemented in GPU" << std::endl;
-				exit(0);
-				/*
-                multi_qubit_control_single_qubit_dense_matrix_gate_host(
-                    control_index.data(), control_value.data(), (UINT)(control_index.size()),
-                    target_index[0],
-                    matrix_ptr, state->data(), dim );
-					*/
-            }else{
-                multi_qubit_control_single_qubit_dense_matrix_gate(
-                    control_index.data(), control_value.data(), (UINT)(control_index.size()),
-                    target_index[0],
-                    matrix_ptr, state->data_c(), dim );
-            }
-#else
-            multi_qubit_control_single_qubit_dense_matrix_gate(
-                control_index.data(), control_value.data(), (UINT)(control_index.size()),
-                target_index[0],
-                matrix_ptr, state->data_c(), dim );
-#endif
-        }
-    }
+	if (state->is_state_vector()) {
+		// single qubit dense matrix gate
+		if (this->_target_qubit_list.size() == 1) {
 
-    // multi qubit dense matrix gate
-    else{
-        // no control qubit
-        if(this->_control_qubit_list.size() == 0){
+			// no control qubit
+			if (this->_control_qubit_list.size() == 0) {
 #ifdef _USE_GPU
-	        if (state->get_device_name() == "gpu") {
-                multi_qubit_dense_matrix_gate_host(
-                    target_index.data(), (UINT)(target_index.size()),
-                    (const CPPCTYPE*)matrix_ptr, state->data(), dim );
-            }else{
-                multi_qubit_dense_matrix_gate(
-                    target_index.data(), (UINT)(target_index.size()),
-                    matrix_ptr, state->data_c(), dim );
-            }
+				if (state->get_device_name() == "gpu") {
+					single_qubit_dense_matrix_gate_host(
+						target_index[0],
+						(const CPPCTYPE*)matrix_ptr, state->data(), dim);
+
+				}
+				else {
+					single_qubit_dense_matrix_gate(
+						target_index[0],
+						matrix_ptr, state->data_c(), dim);
+				}
 #else
-            multi_qubit_dense_matrix_gate(
-                target_index.data(), (UINT)(target_index.size()),
-                matrix_ptr, state->data_c(), dim );
+				single_qubit_dense_matrix_gate(
+					target_index[0],
+					matrix_ptr, state->data_c(), dim);
 #endif
-        }
-        // single control qubit
-        else if(this->_control_qubit_list.size() == 1){
+			}
+			// single control qubit
+			else if (this->_control_qubit_list.size() == 1) {
 #ifdef _USE_GPU
-	        if (state->get_device_name() == "gpu") {
-                single_qubit_control_multi_qubit_dense_matrix_gate_host(
-                    control_index[0], control_value[0],
-                    target_index.data(), (UINT)(target_index.size()),
-                    (const CPPCTYPE*)matrix_ptr, state->data(), dim );
-            }else{
-                single_qubit_control_multi_qubit_dense_matrix_gate(
-                    control_index[0], control_value[0],
-                    target_index.data(), (UINT)(target_index.size()),
-                    matrix_ptr, state->data_c(), dim );
-            }
+				if (state->get_device_name() == "gpu") {
+					single_qubit_control_single_qubit_dense_matrix_gate_host(
+						control_index[0], control_value[0],
+						target_index[0],
+						(const CPPCTYPE*)matrix_ptr, state->data(), dim);
+				}
+				else {
+					single_qubit_control_single_qubit_dense_matrix_gate(
+						control_index[0], control_value[0],
+						target_index[0],
+						matrix_ptr, state->data_c(), dim);
+				}
 #else
-            single_qubit_control_multi_qubit_dense_matrix_gate(
-                control_index[0], control_value[0],
-                target_index.data(), (UINT)(target_index.size()),
-                matrix_ptr, state->data_c(), dim );
+				single_qubit_control_single_qubit_dense_matrix_gate(
+					control_index[0], control_value[0],
+					target_index[0],
+					matrix_ptr, state->data_c(), dim);
 #endif
-        }
-        // multiple control qubit
-        else{
+			}
+			// multiple control qubits
+			else {
 #ifdef _USE_GPU
-	        if (state->get_device_name() == "gpu") {
-                multi_qubit_control_multi_qubit_dense_matrix_gate_host(
-                    control_index.data(), control_value.data(), (UINT)(control_index.size()),
-                    target_index.data(), (UINT)(target_index.size()),
-                    (const CPPCTYPE*)matrix_ptr, state->data(), dim);
-            }else{
-                multi_qubit_control_multi_qubit_dense_matrix_gate(
-                    control_index.data(), control_value.data(), (UINT)(control_index.size()),
-                    target_index.data(), (UINT)(target_index.size()),
-                    matrix_ptr, state->data_c(), dim);
-            }
+				if (state->get_device_name() == "gpu") {
+					//
+					std::cerr << "This function is not implemented in GPU" << std::endl;
+					exit(0);
+					/*
+					multi_qubit_control_single_qubit_dense_matrix_gate_host(
+						control_index.data(), control_value.data(), (UINT)(control_index.size()),
+						target_index[0],
+						matrix_ptr, state->data(), dim );
+						*/
+				}
+				else {
+					multi_qubit_control_single_qubit_dense_matrix_gate(
+						control_index.data(), control_value.data(), (UINT)(control_index.size()),
+						target_index[0],
+						matrix_ptr, state->data_c(), dim);
+				}
 #else
-            multi_qubit_control_multi_qubit_dense_matrix_gate(
-                control_index.data(), control_value.data(), (UINT)(control_index.size()),
-                target_index.data(), (UINT)(target_index.size()),
-                matrix_ptr, state->data_c(), dim);
+				multi_qubit_control_single_qubit_dense_matrix_gate(
+					control_index.data(), control_value.data(), (UINT)(control_index.size()),
+					target_index[0],
+					matrix_ptr, state->data_c(), dim);
 #endif
-        }
-    }
+			}
+		}
+
+		// multi qubit dense matrix gate
+		else {
+			// no control qubit
+			if (this->_control_qubit_list.size() == 0) {
+#ifdef _USE_GPU
+				if (state->get_device_name() == "gpu") {
+					multi_qubit_dense_matrix_gate_host(
+						target_index.data(), (UINT)(target_index.size()),
+						(const CPPCTYPE*)matrix_ptr, state->data(), dim);
+				}
+				else {
+					multi_qubit_dense_matrix_gate(
+						target_index.data(), (UINT)(target_index.size()),
+						matrix_ptr, state->data_c(), dim);
+				}
+#else
+				multi_qubit_dense_matrix_gate(
+					target_index.data(), (UINT)(target_index.size()),
+					matrix_ptr, state->data_c(), dim);
+#endif
+			}
+			// single control qubit
+			else if (this->_control_qubit_list.size() == 1) {
+#ifdef _USE_GPU
+				if (state->get_device_name() == "gpu") {
+					single_qubit_control_multi_qubit_dense_matrix_gate_host(
+						control_index[0], control_value[0],
+						target_index.data(), (UINT)(target_index.size()),
+						(const CPPCTYPE*)matrix_ptr, state->data(), dim);
+				}
+				else {
+					single_qubit_control_multi_qubit_dense_matrix_gate(
+						control_index[0], control_value[0],
+						target_index.data(), (UINT)(target_index.size()),
+						matrix_ptr, state->data_c(), dim);
+				}
+#else
+				single_qubit_control_multi_qubit_dense_matrix_gate(
+					control_index[0], control_value[0],
+					target_index.data(), (UINT)(target_index.size()),
+					matrix_ptr, state->data_c(), dim);
+#endif
+			}
+			// multiple control qubit
+			else {
+#ifdef _USE_GPU
+				if (state->get_device_name() == "gpu") {
+					multi_qubit_control_multi_qubit_dense_matrix_gate_host(
+						control_index.data(), control_value.data(), (UINT)(control_index.size()),
+						target_index.data(), (UINT)(target_index.size()),
+						(const CPPCTYPE*)matrix_ptr, state->data(), dim);
+				}
+				else {
+					multi_qubit_control_multi_qubit_dense_matrix_gate(
+						control_index.data(), control_value.data(), (UINT)(control_index.size()),
+						target_index.data(), (UINT)(target_index.size()),
+						matrix_ptr, state->data_c(), dim);
+				}
+#else
+				multi_qubit_control_multi_qubit_dense_matrix_gate(
+					control_index.data(), control_value.data(), (UINT)(control_index.size()),
+					target_index.data(), (UINT)(target_index.size()),
+					matrix_ptr, state->data_c(), dim);
+#endif
+			}
+		}
+	}
+	else {
+		if (this->_control_qubit_list.size() == 0) {
+			if (this->_target_qubit_list.size() == 1) {
+				dm_single_qubit_dense_matrix_gate(target_index[0], matrix_ptr, state->data_c(), dim);
+			}
+			else {
+				dm_multi_qubit_dense_matrix_gate(target_index.data(), target_index.size(), matrix_ptr, state->data_c(), dim);
+			}
+		}
+		else {
+			if (this->_target_qubit_list.size() == 1) {
+				dm_multi_qubit_control_single_qubit_dense_matrix_gate(control_index.data(), control_value.data(), control_index.size(), target_index[0], matrix_ptr, state->data_c(), dim);
+			}
+			else {
+				dm_multi_qubit_control_multi_qubit_dense_matrix_gate(control_index.data(), control_value.data(), control_index.size(), target_index.data(), target_index.size(), matrix_ptr, state->data_c(), dim);
+			}
+		}
+	}
 }
 
 

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -69,20 +69,26 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
 		target_index.push_back(val.index());
 	}
 
+	if (state->is_state_vector()) {
 #ifdef _USE_GPU
-	if (state->get_device_name() == "gpu") {
-		std::cerr << "Sparse matrix gate is not supported on GPU" << std::endl;
-	}
-	else {
+		if (state->get_device_name() == "gpu") {
+			std::cerr << "Sparse matrix gate is not supported on GPU" << std::endl;
+		}
+		else {
+			multi_qubit_sparse_matrix_gate_eigen(
+				target_index.data(), (UINT)(target_index.size()),
+				this->_matrix_element, state->data_c(), dim);
+		}
+#else
 		multi_qubit_sparse_matrix_gate_eigen(
 			target_index.data(), (UINT)(target_index.size()),
 			this->_matrix_element, state->data_c(), dim);
-	}
-#else
-	multi_qubit_sparse_matrix_gate_eigen(
-		target_index.data(), (UINT)(target_index.size()),
-		this->_matrix_element, state->data_c(), dim);
 #endif
+	}
+	else {
+		std::cerr << "not implemented" << std::endl;
+	}
+
 }
 
 

--- a/src/cppsim/gate_named.hpp
+++ b/src/cppsim/gate_named.hpp
@@ -26,15 +26,21 @@ public:
      * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override{
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-			_update_func_gpu(this->target_qubit_list[0].index(), state->data(), state->dim);
-		} else {
-			_update_func(this->_target_qubit_list[0].index(), state->data_c(), state->dim);
-		}
+			if (state->get_device_name() == "gpu") {
+				_update_func_gpu(this->target_qubit_list[0].index(), state->data(), state->dim);
+			}
+			else {
+				_update_func(this->_target_qubit_list[0].index(), state->data_c(), state->dim);
+			}
 #else
-        _update_func(this->_target_qubit_list[0].index(), state->data_c(), state->dim);
+			_update_func(this->_target_qubit_list[0].index(), state->data_c(), state->dim);
 #endif
+		}
+		else {
+			_update_func_dm(this->_target_qubit_list[0].index(), state->data_c(), state->dim);
+		}
     };
     /**
      * \~japanese-en 自身のディープコピーを生成する
@@ -74,16 +80,22 @@ public:
      * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override{
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-            _update_func_gpu(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data(), state->dim);
-		} else {
-        _update_func(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data_c(), state->dim);
-		}
+			if (state->get_device_name() == "gpu") {
+				_update_func_gpu(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data(), state->dim);
+			}
+			else {
+				_update_func(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data_c(), state->dim);
+			}
 #else
-        _update_func(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data_c(), state->dim);
+			_update_func(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data_c(), state->dim);
 #endif
-    };
+		}
+		else {
+			_update_func_dm(this->_target_qubit_list[0].index(), this->_target_qubit_list[1].index(), state->data_c(), state->dim);
+		}
+	};
     /**
      * \~japanese-en 自身のディープコピーを生成する
      * 
@@ -122,15 +134,21 @@ public:
      * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override {
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-            _update_func_gpu(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data(), state->dim);
-		} else {
-            _update_func(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data_c(), state->dim);
-		}
+			if (state->get_device_name() == "gpu") {
+				_update_func_gpu(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data(), state->dim);
+			}
+			else {
+				_update_func(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data_c(), state->dim);
+			}
 #else
-        _update_func(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data_c(), state->dim);
+			_update_func(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data_c(), state->dim);
 #endif
+		}
+		else {
+			_update_func_dm(this->_control_qubit_list[0].index(), this->_target_qubit_list[0].index(), state->data_c(), state->dim);
+		}
     };
     /**
      * \~japanese-en 自身のディープコピーを生成する
@@ -171,15 +189,21 @@ public:
      * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override{
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-            _update_func_gpu(this->_target_qubit_list[0].index(), _angle, state->data(), state->dim);
-		} else {
-            _update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
-		}
+			if (state->get_device_name() == "gpu") {
+				_update_func_gpu(this->_target_qubit_list[0].index(), _angle, state->data(), state->dim);
+}
+			else {
+				_update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
+			}
 #else
-        _update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
+			_update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
 #endif
+		}
+		else {
+			_update_func_dm(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
+		}
     };
     /**
      * \~japanese-en 自身のディープコピーを生成する

--- a/src/cppsim/gate_named.hpp
+++ b/src/cppsim/gate_named.hpp
@@ -14,6 +14,7 @@ protected:
     typedef void (T_UPDATE_FUNC)(UINT, CTYPE*, ITYPE);
 	typedef void (T_GPU_UPDATE_FUNC)(UINT, void*, ITYPE);
 	T_UPDATE_FUNC* _update_func;
+	T_UPDATE_FUNC* _update_func_dm;
 	T_GPU_UPDATE_FUNC* _update_func_gpu;
     ComplexMatrix _matrix_element;
 
@@ -61,6 +62,7 @@ protected:
     typedef void (T_UPDATE_FUNC)(UINT, UINT, CTYPE*, ITYPE);
 	typedef void (T_GPU_UPDATE_FUNC)(UINT, UINT, void*, ITYPE);
 	T_UPDATE_FUNC* _update_func;
+	T_UPDATE_FUNC* _update_func_dm;
 	T_GPU_UPDATE_FUNC* _update_func_gpu;
     ComplexMatrix _matrix_element;
 
@@ -108,6 +110,7 @@ protected:
     typedef void (T_UPDATE_FUNC)(UINT, UINT, CTYPE*, ITYPE);
 	typedef void (T_GPU_UPDATE_FUNC)(UINT, UINT, void*, ITYPE);
 	T_UPDATE_FUNC* _update_func;
+	T_UPDATE_FUNC* _update_func_dm;
 	T_GPU_UPDATE_FUNC* _update_func_gpu;
     ComplexMatrix _matrix_element;
 
@@ -155,6 +158,7 @@ protected:
 	typedef void (T_UPDATE_FUNC)(UINT, double, CTYPE*, ITYPE);
 	typedef void (T_GPU_UPDATE_FUNC)(UINT, double, void*, ITYPE);
 	T_UPDATE_FUNC* _update_func;
+	T_UPDATE_FUNC* _update_func_dm;
 	T_GPU_UPDATE_FUNC* _update_func_gpu;
     ComplexMatrix _matrix_element;
     double _angle;

--- a/src/cppsim/gate_named_one.hpp
+++ b/src/cppsim/gate_named_one.hpp
@@ -3,6 +3,7 @@
 #ifndef _MSC_VER
 extern "C"{
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 }
 #else
 #include <csim/update_ops.h>

--- a/src/cppsim/gate_named_one.hpp
+++ b/src/cppsim/gate_named_one.hpp
@@ -6,6 +6,7 @@ extern "C"{
 }
 #else
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 #endif
 
 #include "gate_named.hpp"
@@ -29,6 +30,7 @@ public:
      */
     ClsIGate(UINT target_qubit_index) {
         this->_update_func = ClsIGate::idling;
+		this->_update_func_dm = ClsIGate::idling;
 		this->_update_func_gpu = ClsIGate::idling_gpu;
 		this->_name = "I";
         this->_target_qubit_list.push_back(TargetQubitInfo(target_qubit_index, FLAG_X_COMMUTE | FLAG_Y_COMMUTE | FLAG_Z_COMMUTE ));
@@ -50,6 +52,7 @@ public:
      */
     ClsXGate(UINT target_qubit_index) {
         this->_update_func = X_gate;
+		this->_update_func_dm = dm_X_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = X_gate_host;
 #endif
@@ -73,6 +76,7 @@ public:
      */
     ClsYGate(UINT target_qubit_index) {
         this->_update_func = Y_gate;
+		this->_update_func_dm = dm_Y_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = Y_gate_host;
 #endif
@@ -96,6 +100,7 @@ public:
      */
     ClsZGate(UINT target_qubit_index){
         this->_update_func = Z_gate;
+		this->_update_func_dm = dm_Z_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = Z_gate_host;
 #endif
@@ -119,6 +124,7 @@ public:
      */
     ClsHGate(UINT target_qubit_index) {
         this->_update_func = H_gate;
+		this->_update_func_dm = dm_H_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = H_gate_host;
 #endif
@@ -143,6 +149,7 @@ public:
      */
     ClsSGate(UINT target_qubit_index){
         this->_update_func = S_gate;
+		this->_update_func_dm = dm_S_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = S_gate_host;
 #endif
@@ -166,6 +173,7 @@ public:
      */
     ClsSdagGate(UINT target_qubit_index){
         this->_update_func = Sdag_gate;
+		this->_update_func_dm = dm_Sdag_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = Sdag_gate_host;
 #endif
@@ -189,6 +197,7 @@ public:
      */
     ClsTGate(UINT target_qubit_index){
         this->_update_func = T_gate;
+		this->_update_func_dm = dm_T_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = T_gate_host;
 #endif
@@ -212,6 +221,7 @@ public:
      */
     ClsTdagGate(UINT target_qubit_index){
         this->_update_func = Tdag_gate;
+		this->_update_func_dm = dm_Tdag_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = Tdag_gate_host;
 #endif
@@ -235,6 +245,7 @@ public:
      */
     ClsSqrtXGate(UINT target_qubit_index) {
         this->_update_func = sqrtX_gate;
+		this->_update_func_dm = dm_sqrtX_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = sqrtX_gate_host;
 #endif
@@ -258,6 +269,7 @@ public:
      */
     ClsSqrtXdagGate(UINT target_qubit_index) {
         this->_update_func = sqrtXdag_gate;
+		this->_update_func_dm = dm_sqrtXdag_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = sqrtXdag_gate_host;
 #endif
@@ -281,6 +293,7 @@ public:
      */
     ClsSqrtYGate(UINT target_qubit_index) {
         this->_update_func = sqrtY_gate;
+		this->_update_func_dm = dm_sqrtY_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = sqrtY_gate_host;
 #endif
@@ -304,6 +317,7 @@ public:
      */
     ClsSqrtYdagGate(UINT target_qubit_index) {
         this->_update_func = sqrtYdag_gate;
+		this->_update_func_dm = dm_sqrtYdag_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = sqrtYdag_gate_host;
 #endif
@@ -327,6 +341,7 @@ public:
      */
     ClsP0Gate(UINT target_qubit_index){
         this->_update_func = P0_gate;
+		this->_update_func_dm = dm_P0_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = P0_gate_host;
 #endif
@@ -350,6 +365,7 @@ public:
      */
     ClsP1Gate(UINT target_qubit_index){
         this->_update_func = P1_gate;
+		this->_update_func_dm = dm_P1_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = P1_gate_host;
 #endif
@@ -374,6 +390,7 @@ public:
      */
     ClsRXGate(UINT target_qubit_index, double angle) : QuantumGate_OneQubitRotation(angle) {
         this->_update_func = RX_gate;
+		this->_update_func_dm = dm_RX_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = RX_gate_host;
 #endif
@@ -397,6 +414,7 @@ public:
      */
     ClsRYGate(UINT target_qubit_index, double angle): QuantumGate_OneQubitRotation(angle){
         this->_update_func = RY_gate;
+		this->_update_func_dm = dm_RY_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = RY_gate_host;
 #endif
@@ -420,6 +438,7 @@ public:
      */
     ClsRZGate(UINT target_qubit_index, double angle): QuantumGate_OneQubitRotation(angle){
         this->_update_func = RZ_gate;
+		this->_update_func_dm = dm_RZ_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = RZ_gate_host;
 #endif

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -53,22 +53,28 @@ public:
     virtual void update_quantum_state(QuantumStateBase* state)  override {
         auto target_index_list = _pauli->get_index_list();
         auto pauli_id_list = _pauli->get_pauli_id_list();
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-            multi_qubit_Pauli_gate_partial_list_host(
-			    target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
-                    state->data(), state->dim);
-            //_update_func_gpu(this->_target_qubit_list[0].index(), _angle, state->data(), state->dim);
-		} else {
-            multi_qubit_Pauli_gate_partial_list(
-			    target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
-			    state->data_c(), state->dim);
-		}
+			if (state->get_device_name() == "gpu") {
+				multi_qubit_Pauli_gate_partial_list_host(
+					target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+					state->data(), state->dim);
+				//_update_func_gpu(this->_target_qubit_list[0].index(), _angle, state->data(), state->dim);
+			}
+			else {
+				multi_qubit_Pauli_gate_partial_list(
+					target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+					state->data_c(), state->dim);
+			}
 #else
-        multi_qubit_Pauli_gate_partial_list(
-            target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
-            state->data_c(), state->dim);
+			multi_qubit_Pauli_gate_partial_list(
+				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+				state->data_c(), state->dim);
 #endif
+		}
+		else {
+			std::cerr << "not implemented" << std::endl;
+		}
     };
     /**
      * \~japanese-en 自身のディープコピーを生成する
@@ -133,18 +139,24 @@ public:
     virtual void update_quantum_state(QuantumStateBase* state) override {
         auto target_index_list = _pauli->get_index_list();
         auto pauli_id_list = _pauli->get_pauli_id_list();
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-            multi_qubit_Pauli_rotation_gate_partial_list_host(
-			    target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
-			    _angle, state->data(), state->dim);
-        }
+			if (state->get_device_name() == "gpu") {
+				multi_qubit_Pauli_rotation_gate_partial_list_host(
+					target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+					_angle, state->data(), state->dim);
+			}
 #else
-        multi_qubit_Pauli_rotation_gate_partial_list(
-            target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
-            _angle, state->data_c(), state->dim);
+			multi_qubit_Pauli_rotation_gate_partial_list(
+				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+				_angle, state->data_c(), state->dim);
 #endif
-    };
+
+		}
+		else {
+			std::cerr << "not implemented" << std::endl;
+		}
+	};
     /**
      * \~japanese-en 自身のディープコピーを生成する
      * 

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -3,9 +3,11 @@
 #ifndef _MSC_VER
 extern "C" {
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 }
 #else
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 #endif
 
 #include "gate.hpp"
@@ -73,7 +75,9 @@ public:
 #endif
 		}
 		else {
-			std::cerr << "not implemented" << std::endl;
+			dm_multi_qubit_Pauli_gate_partial_list(
+				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+				state->data_c(), state->dim);
 		}
     };
     /**
@@ -151,10 +155,11 @@ public:
 				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
 				_angle, state->data_c(), state->dim);
 #endif
-
 		}
 		else {
-			std::cerr << "not implemented" << std::endl;
+			dm_multi_qubit_Pauli_rotation_gate_partial_list(
+				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+				_angle, state->data_c(), state->dim);
 		}
 	};
     /**

--- a/src/cppsim/gate_named_two.hpp
+++ b/src/cppsim/gate_named_two.hpp
@@ -24,7 +24,7 @@ public:
      */
     ClsCNOTGate(UINT control_qubit_index, UINT target_qubit_index) {
         this->_update_func = CNOT_gate;
-		this->_update_func = dm_CNOT_gate;
+		this->_update_func_dm = dm_CNOT_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = CNOT_gate_host;
 #endif
@@ -50,7 +50,7 @@ public:
      */
     ClsCZGate(UINT control_qubit_index, UINT target_qubit_index) {
         this->_update_func = CZ_gate;
-		this->_update_func = dm_CZ_gate;
+		this->_update_func_dm = dm_CZ_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = CZ_gate_host;
 #endif
@@ -76,7 +76,7 @@ public:
      */
     ClsSWAPGate(UINT target_qubit_index1, UINT target_qubit_index2) {
         this->_update_func = SWAP_gate;
-		this->_update_func = dm_SWAP_gate;
+		this->_update_func_dm = dm_SWAP_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = SWAP_gate_host;
 #endif

--- a/src/cppsim/gate_named_two.hpp
+++ b/src/cppsim/gate_named_two.hpp
@@ -24,6 +24,7 @@ public:
      */
     ClsCNOTGate(UINT control_qubit_index, UINT target_qubit_index) {
         this->_update_func = CNOT_gate;
+		this->_update_func = dm_CNOT_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = CNOT_gate_host;
 #endif
@@ -49,6 +50,7 @@ public:
      */
     ClsCZGate(UINT control_qubit_index, UINT target_qubit_index) {
         this->_update_func = CZ_gate;
+		this->_update_func = dm_CZ_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = CZ_gate_host;
 #endif
@@ -74,6 +76,7 @@ public:
      */
     ClsSWAPGate(UINT target_qubit_index1, UINT target_qubit_index2) {
         this->_update_func = SWAP_gate;
+		this->_update_func = dm_SWAP_gate;
 #ifdef _USE_GPU
 		this->_update_func_gpu = SWAP_gate_host;
 #endif

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -43,22 +43,27 @@ public:
 	 * @param state 更新する量子状態
 	 */
 	virtual void update_quantum_state(QuantumStateBase* state) override {
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() != reflection_state->get_device_name()) {
-			std::cerr << "Quantum state on CPU (GPU) cannot be reflected using quantum state on GPU (CPU)" << std::endl;
-			return;
-		}
-		if (state->get_device_name() == "gpu") {
-			std::cerr << "Not Implemented" << std::endl;
-			exit(0);
-			//reversible_boolean_gate_gpu(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			if (state->get_device_name() != reflection_state->get_device_name()) {
+				std::cerr << "Quantum state on CPU (GPU) cannot be reflected using quantum state on GPU (CPU)" << std::endl;
+				return;
+			}
+			if (state->get_device_name() == "gpu") {
+				std::cerr << "Not Implemented" << std::endl;
+				exit(0);
+				//reversible_boolean_gate_gpu(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			}
+			else {
+				reflection_gate(reflection_state->data_c(), state->data_c(), state->dim);
+			}
+#else
+			reflection_gate(reflection_state->data_c(), state->data_c(), state->dim);
+#endif
 		}
 		else {
-			reflection_gate(reflection_state->data_c(), state->data_c(), state->dim);
+			std::cerr << "not implemented" << std::endl;
 		}
-#else
-		reflection_gate(reflection_state->data_c(), state->data_c(), state->dim);
-#endif
 	};
 	/**
 	 * \~japanese-en 自身のディープコピーを生成する

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -42,18 +42,24 @@ public:
 		for (auto val : this->_target_qubit_list) {
 			target_index.push_back(val.index());
 		}
+		if (state->is_state_vector()) {
 #ifdef _USE_GPU
-		if (state->get_device_name() == "gpu") {
-			std::cerr << "Not Implemented" << std::endl;
-			exit(0);
-			//reversible_boolean_gate_gpu(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			if (state->get_device_name() == "gpu") {
+				std::cerr << "Not Implemented" << std::endl;
+				exit(0);
+				//reversible_boolean_gate_gpu(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			}
+			else {
+				reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			}
+#else
+			reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+#endif
 		}
 		else {
-			reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			std::cerr << "not implemented" << std::endl;
 		}
-#else
-		reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
-#endif
+
 	};
 	/**
 	 * \~japanese-en 自身のディープコピーを生成する

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -53,7 +53,7 @@ public:
 				reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
 			}
 #else
-			reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+			reversible_boolean_gate(target_index.data(), (UINT)target_index.size(), function_ptr, state->data_c(), state->dim);
 #endif
 		}
 		else {

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -90,36 +90,45 @@ void PauliOperator::add_single_Pauli(UINT qubit_index, UINT pauli_type){
 }
 
 CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) const {
+	if(state->is_state_vector()){
 #ifdef _USE_GPU
-    if(state->get_device_name() == "gpu"){
-        return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list_host(
-            this->get_index_list().data(),
-            this->get_pauli_id_list().data(),
-            (UINT)this->get_index_list().size(),
-            state->data(),
-            state->dim
-        );
-    }else{
-        return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
-            this->get_index_list().data(),
-            this->get_pauli_id_list().data(),
-            (UINT)this->get_index_list().size(),
-            state->data_c(),
-            state->dim
-        );
-    }
+		if (state->get_device_name() == "gpu") {
+			return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list_host(
+				this->get_index_list().data(),
+				this->get_pauli_id_list().data(),
+				(UINT)this->get_index_list().size(),
+				state->data(),
+				state->dim
+			);
+		}
+		else {
+			return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
+				this->get_index_list().data(),
+				this->get_pauli_id_list().data(),
+				(UINT)this->get_index_list().size(),
+				state->data_c(),
+				state->dim
+			);
+		}
 #else
-    return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
-        this->get_index_list().data(),
-        this->get_pauli_id_list().data(),
-        (UINT)this->get_index_list().size(),
-        state->data_c(),
-        state->dim
-    );
+		return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
+			this->get_index_list().data(),
+			this->get_pauli_id_list().data(),
+			(UINT)this->get_index_list().size(),
+			state->data_c(),
+			state->dim
+		);
 #endif
+	}
+	else {
+		std::cerr << "not implemented" << std::endl;
+	}
 }
 
 CPPCTYPE PauliOperator::get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const {
+	if ((!state_bra->is_state_vector()) || (!state_ket->is_state_vector())) {
+		std::cerr << "get_transition_amplitude for density matrix is not implemented" << std::endl;
+	}
 #ifdef _USE_GPU
     if(state_ket->get_device_name()=="gpu" && state_bra->get_device_name()=="gpu"){
         return _coef * (CPPCTYPE)transition_amplitude_multi_qubit_Pauli_operator_partial_list_host(

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -19,9 +19,11 @@
 #ifndef _MSC_VER
 extern "C"{
 #include <csim/stat_ops.h>
+#include <csim/stat_ops_dm.h>
 }
 #else
 #include <csim/stat_ops.h>
+#include <csim/stat_ops_dm.h>
 #endif
 #include "pauli_operator.hpp"
 #include "state.hpp"
@@ -121,7 +123,13 @@ CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) con
 #endif
 	}
 	else {
-		std::cerr << "not implemented" << std::endl;
+		return _coef * dm_expectation_value_multi_qubit_Pauli_operator_partial_list(
+			this->get_index_list().data(),
+			this->get_pauli_id_list().data(),
+			(UINT)this->get_index_list().size(),
+			state->data_c(),
+			state->dim
+		);
 	}
 }
 

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -269,7 +269,7 @@ public:
      * 
      * @param qubit_count_ 量子ビット数
      */
-    QuantumStateCpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, false){
+    QuantumStateCpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, true){
         this->_state_vector = reinterpret_cast<CPPCTYPE*>(allocate_quantum_state(this->_dim));
         initialize_quantum_state(this->data_c(), _dim);
     }

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -25,6 +25,7 @@ class QuantumStateBase{
 protected:
     ITYPE _dim;
     UINT _qubit_count;
+	bool _is_state_vector;
     std::vector<UINT> _classical_register;
 public:
     const UINT& qubit_count; /**< \~japanese-en 量子ビット数 */
@@ -36,16 +37,24 @@ public:
      * 
      * @param qubit_count_ 量子ビット数
      */
-    QuantumStateBase(UINT qubit_count_):
+    QuantumStateBase(UINT qubit_count_, bool is_state_vector):
         qubit_count(_qubit_count), dim(_dim), classical_register(_classical_register)
     {
         this->_qubit_count = qubit_count_;
         this->_dim = 1ULL << qubit_count_;
+		this->_is_state_vector = is_state_vector;
     }
     /**
      * \~japanese-en デストラクタ
      */
     virtual ~QuantumStateBase(){}
+
+	/**
+	 * \~japanese-en 量子状態が状態ベクトルか密度行列かを判定する
+	 */
+	virtual bool is_state_vector() const {
+		return this->_is_state_vector;
+	}
 
     /**
      * \~japanese-en 量子状態を計算基底の0状態に初期化する
@@ -260,7 +269,7 @@ public:
      * 
      * @param qubit_count_ 量子ビット数
      */
-    QuantumStateCpu(UINT qubit_count_) : QuantumStateBase(qubit_count_){
+    QuantumStateCpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, false){
         this->_state_vector = reinterpret_cast<CPPCTYPE*>(allocate_quantum_state(this->_dim));
         initialize_quantum_state(this->data_c(), _dim);
     }

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -180,7 +180,7 @@ public:
             return;
         }
 		if (_state.size() == _dim) {
-			dm_initialize_with_pure_state(this->data_c(), _state.data(), dim);
+			dm_initialize_with_pure_state(this->data_c(), (const CTYPE*)_state.data(), dim);
 		}
 		else {
 			memcpy(this->data_cpp(), _state.data(), (size_t)(sizeof(CPPCTYPE)*_dim*_dim));

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -1,0 +1,293 @@
+
+#pragma once
+
+#ifndef _MSC_VER
+extern "C" {
+#include <csim/memory_ops_dm.h>
+#include <csim/stat_ops_dm.h>
+#include <csim/update_ops_dm.h>
+}
+#else
+#include <csim/memory_ops_dm.h>
+#include <csim/stat_ops_dm.h>
+#include <csim/update_ops_dm.h>
+#endif
+
+#include "state.hpp"
+
+class DensityMatrixCpu : public QuantumStateBase{
+private:
+    CPPCTYPE* _density_matrix;
+    Random random;
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     * 
+     * @param qubit_count_ 量子ビット数
+     */
+    DensityMatrixCpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, false){
+        this->_density_matrix = reinterpret_cast<CPPCTYPE*>(dm_allocate_quantum_state(this->_dim));
+        dm_initialize_quantum_state(this->data_c(), _dim);
+    }
+    /**
+     * \~japanese-en デストラクタ
+     */
+    virtual ~DensityMatrixCpu(){
+        dm_release_quantum_state(this->data_c());
+    }
+    /**
+     * \~japanese-en 量子状態を計算基底の0状態に初期化する
+     */
+    virtual void set_zero_state() override{
+        dm_initialize_quantum_state(this->data_c(), _dim);
+    }
+    /**
+     * \~japanese-en 量子状態を<code>comp_basis</code>の基底状態に初期化する
+     * 
+     * @param comp_basis 初期化する基底を表す整数
+     */
+    virtual void set_computational_basis(ITYPE comp_basis)  override {
+        if (comp_basis >= (ITYPE)(1ULL << this->qubit_count)) {
+            std::cerr << "Error: DensityMatrixCpu::set_computational_basis(ITYPE): index of computational basis must be smaller than 2^qubit_count" << std::endl;
+            return;
+        }
+        set_zero_state();
+		_density_matrix[0] = 0.;
+        _density_matrix[comp_basis*dim+comp_basis] = 1.;
+    }
+    /**
+     * \~japanese-en 量子状態をHaar randomにサンプリングされた量子状態に初期化する
+     */
+    virtual void set_Haar_random_state() override{
+		this->set_Haar_random_state(random.int32());
+    }
+    /**
+     * \~japanese-en 量子状態をシードを用いてHaar randomにサンプリングされた量子状態に初期化する
+     */
+    virtual void set_Haar_random_state(UINT seed) override {
+		QuantumStateCpu* pure_state = new QuantumStateCpu(qubit_count);
+		pure_state->set_Haar_random_state(seed);
+		dm_initialize_with_pure_state(this->data_c(), pure_state->data_c(), _dim);
+		delete pure_state;
+    }
+    /**
+     * \~japanese-en <code>target_qubit_index</code>の添え字の量子ビットを測定した時、0が観測される確率を計算する。
+     * 
+     * 量子状態は変更しない。
+     * @param target_qubit_index 
+     * @return double 
+     */
+    virtual double get_zero_probability(UINT target_qubit_index) const override {
+        if (target_qubit_index >= this->qubit_count) {
+            std::cerr << "Error: DensityMatrixCpu::get_zero_probability(UINT): index of target qubit must be smaller than qubit_count" << std::endl;
+            return 0.;
+        }
+        return dm_M0_prob(target_qubit_index, this->data_c(), _dim);
+    }
+    /**
+     * \~japanese-en 複数の量子ビットを測定した時の周辺確率を計算する
+     * 
+     * @param measured_values 量子ビット数と同じ長さの0,1,2の配列。0,1はその値が観測され、2は測定をしないことを表す。
+     * @return 計算された周辺確率
+     */
+    virtual double get_marginal_probability(std::vector<UINT> measured_values) const override {
+        if (measured_values.size() != this->qubit_count) {
+            std::cerr << "Error: DensityMatrixCpu::get_marginal_probability(vector<UINT>): the length of measured_values must be equal to qubit_count" << std::endl;
+            return 0.;
+        }
+        
+        std::vector<UINT> target_index;
+        std::vector<UINT> target_value;
+        for (UINT i = 0; i < measured_values.size(); ++i) {
+            UINT measured_value = measured_values[i];
+            if (measured_value== 0 || measured_value == 1) {
+                target_index.push_back(i);
+                target_value.push_back(measured_value);
+            }
+        }
+        return dm_marginal_prob(target_index.data(), target_value.data(), (UINT)target_index.size(), this->data_c(), _dim);
+    }
+    /**
+     * \~japanese-en 計算基底で測定した時得られる確率分布のエントロピーを計算する。
+     * 
+     * @return エントロピー
+     */
+    virtual double get_entropy() const override{
+        return dm_measurement_distribution_entropy(this->data_c(), _dim);
+    }
+
+    /**
+     * \~japanese-en 量子状態のノルムを計算する
+     * 
+     * 量子状態のノルムは非ユニタリなゲートを作用した時に小さくなる。
+     * @return ノルム
+     */
+    virtual double get_norm() const override {
+        return dm_state_norm(this->data_c(),_dim);
+    }
+
+    /**
+     * \~japanese-en 量子状態を正規化する
+     *
+     * @param norm 自身のノルム
+     */
+    virtual void normalize(double norm) override{
+        dm_normalize(norm, this->data_c(), _dim);
+    }
+
+
+    /**
+     * \~japanese-en バッファとして同じサイズの量子状態を作成する。
+     * 
+     * @return 生成された量子状態
+     */
+    virtual QuantumStateBase* allocate_buffer() const override {
+        DensityMatrixCpu* new_state = new DensityMatrixCpu(this->_qubit_count);
+        return new_state;
+    }
+    /**
+     * \~japanese-en 自身の状態のディープコピーを生成する
+     * 
+     * @return 自身のディープコピー
+     */
+    virtual QuantumStateBase* copy() const override {
+        DensityMatrixCpu* new_state = new DensityMatrixCpu(this->_qubit_count);
+        memcpy(new_state->data_cpp(), _density_matrix, (size_t)(sizeof(CPPCTYPE)*_dim*_dim));
+        for(UINT i=0;i<_classical_register.size();++i) new_state->set_classical_value(i,_classical_register[i]);
+        return new_state;
+    }
+    /**
+     * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
+     */
+    virtual void load(const QuantumStateBase* _state) {
+        if (_state->qubit_count != this->qubit_count) {
+            std::cerr << "Error: DensityMatrixCpu::load(const QuantumStateBase*): invalid qubit count" << std::endl;
+            return;
+        }
+		if (_state->is_state_vector()) {
+			dm_initialize_with_pure_state(this->data_c(), _state->data_c(), dim);
+		}else {
+			memcpy(this->data_cpp(), _state->data_cpp(), (size_t)(sizeof(CPPCTYPE)*_dim*_dim));
+		}
+		this->_classical_register = _state->classical_register;
+	}
+    /**
+     * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
+     */
+    virtual void load(const std::vector<CPPCTYPE>& _state) {
+        if (_state.size() != _dim && _state.size() != _dim*_dim) {
+            std::cerr << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid length of state" << std::endl;
+            return;
+        }
+		if (_state.size() == _dim) {
+			dm_initialize_with_pure_state(this->data_c(), _state.data(), dim);
+		}
+		else {
+			memcpy(this->data_cpp(), _state.data(), (size_t)(sizeof(CPPCTYPE)*_dim*_dim));
+		}
+    }
+
+	virtual void load(const ComplexMatrix& _state) {
+		if (_state.cols() != _dim && _state.rows() != _dim * _dim) {
+			std::cerr << "Error: DensityMatrixCpu::load(ComplexMatrix&): invalid length of state" << std::endl;
+			return;
+		}
+		memcpy(this->data_cpp(), _state.data(), (size_t)(sizeof(CPPCTYPE)*_dim*_dim));
+	}
+
+    /**
+     * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
+     */
+    virtual void load(const CPPCTYPE* _state) {
+        memcpy(this->data_cpp(), _state, (size_t)(sizeof(CPPCTYPE)*_dim*_dim));
+    }
+    
+    /**
+     * \~japanese-en 量子状態が配置されているメモリを保持するデバイス名を取得する。
+     */
+    virtual const std::string get_device_name() const override {return "cpu";}
+
+    /**
+     * \~japanese-en 量子状態のポインタをvoid*型として返す
+     */
+    virtual void* data() const override {
+        return reinterpret_cast<void*>(this->_density_matrix);
+    }
+    /**
+     * \~japanese-en 量子状態をC++の<code>std::complex\<double\></code>の配列として取得する
+     * 
+     * @return 複素ベクトルのポインタ
+     */
+    virtual CPPCTYPE* data_cpp() const override { return this->_density_matrix; }
+    /**
+     * \~japanese-en 量子状態をcsimのComplex型の配列として取得する
+     * 
+     * @return 複素ベクトルのポインタ
+     */
+    virtual CTYPE* data_c() const override {
+        return reinterpret_cast<CTYPE*>(this->_density_matrix);
+    }
+
+
+
+    /**
+     * \~japanese-en 量子状態を足しこむ
+     */
+    virtual void add_state(const QuantumStateBase* state) override{
+		std::cerr << "Not implemented" << std::endl;
+		exit(0);
+	}
+    /**
+     * \~japanese-en 複素数をかける
+     */
+    virtual void multiply_coef(CPPCTYPE coef) override{
+		std::cerr << "Not implemented" << std::endl;
+		exit(0);
+    }
+
+
+    /**
+     * \~japanese-en 量子状態を測定した際の計算基底のサンプリングを行う
+     *
+     * @param[in] sampling_count サンプリングを行う回数
+     * @return サンプルされた値のリスト
+     */
+    virtual std::vector<ITYPE> sampling(UINT sampling_count) override{
+        std::vector<double> stacked_prob;
+        std::vector<ITYPE> result;
+        double sum = 0.;
+        auto ptr = this->data_cpp();
+        stacked_prob.push_back(0.);
+        for (UINT i = 0; i < this->dim; ++i) {
+            sum += norm(ptr[i*dim+i]);
+            stacked_prob.push_back(sum);
+        }
+
+        for (UINT count = 0; count < sampling_count; ++count) {
+            double r = random.uniform();
+            auto ite = std::lower_bound(stacked_prob.begin(), stacked_prob.end(), r);
+            auto index = std::distance(stacked_prob.begin(), ite) - 1;
+            result.push_back(index);
+        }
+        return result;
+    }
+
+	virtual std::string to_string() const {
+		std::stringstream os;
+		ComplexMatrix eigen_state(this->dim, this->dim);
+		auto data = this->data_cpp();
+		for (UINT i = 0; i < this->dim; ++i) {
+			for (UINT j = 0; j < this->dim; ++j) {
+				eigen_state(i,j) = data[i*dim+j];
+			}
+		}
+		os << " *** Density Matrix ***" << std::endl;
+		os << " * Qubit Count : " << this->qubit_count << std::endl;
+		os << " * Dimension   : " << this->dim << std::endl;
+		os << " * Density matrix : \n" << eigen_state << std::endl;
+		return os.str();
+	}
+};
+
+typedef DensityMatrixCpu DensityMatrix; /**< QuantumState is an alias of QuantumStateCPU */
+

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -233,17 +233,20 @@ public:
     /**
      * \~japanese-en 量子状態を足しこむ
      */
-    virtual void add_state(const QuantumStateBase* state) override{
-		std::cerr << "Not implemented" << std::endl;
-		exit(0);
+	virtual void add_state(const QuantumStateBase* state) override {
+		dm_state_add(state->data_c(), this->data_c(), this->dim);
 	}
-    /**
-     * \~japanese-en 複素数をかける
-     */
-    virtual void multiply_coef(CPPCTYPE coef) override{
-		std::cerr << "Not implemented" << std::endl;
-		exit(0);
-    }
+	/**
+	 * \~japanese-en 複素数をかける
+	 */
+	virtual void multiply_coef(CPPCTYPE coef) override {
+#ifdef _MSC_VER
+		dm_state_multiply(coef, this->data_c(), this->dim);
+#else
+		CTYPE c_coef = { coef.real(), coef.imag() };
+		dm_state_multiply(c_coef, this->data_c(), this->dim);
+#endif
+	}
 
 
     /**

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -187,6 +187,19 @@ public:
 		}
     }
 
+	virtual void load(const Eigen::VectorXcd& _state) {
+		if (_state.size() != _dim && _state.size() != _dim * _dim) {
+			std::cerr << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid length of state" << std::endl;
+			return;
+		}
+		if (_state.size() == _dim) {
+			dm_initialize_with_pure_state(this->data_c(), (const CTYPE*)_state.data(), dim);
+		}
+		else {
+			memcpy(this->data_cpp(), _state.data(), (size_t)(sizeof(CPPCTYPE)*_dim*_dim));
+		}
+	}
+
 	virtual void load(const ComplexMatrix& _state) {
 		if (_state.cols() != _dim && _state.rows() != _dim * _dim) {
 			std::cerr << "Error: DensityMatrixCpu::load(ComplexMatrix&): invalid length of state" << std::endl;

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -19,7 +19,7 @@ public:
 	 *
 	 * @param qubit_count_ 量子ビット数
 	 */
-	QuantumStateGpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, false) {
+	QuantumStateGpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, true) {
 		this->_state_vector = reinterpret_cast<void*>(allocate_quantum_state_host(this->_dim));
 		initialize_quantum_state_host(this->data(), _dim);
 	}

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -19,7 +19,7 @@ public:
 	 *
 	 * @param qubit_count_ 量子ビット数
 	 */
-	QuantumStateGpu(UINT qubit_count_) : QuantumStateBase(qubit_count_) {
+	QuantumStateGpu(UINT qubit_count_) : QuantumStateBase(qubit_count_, false) {
 		this->_state_vector = reinterpret_cast<void*>(allocate_quantum_state_host(this->_dim));
 		initialize_quantum_state_host(this->data(), _dim);
 	}

--- a/src/csim/memory_ops_dm.c
+++ b/src/csim/memory_ops_dm.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "memory_ops.h"
+#include "utility.h"
+#include <time.h>
+#include <limits.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+CTYPE* dm_allocate_quantum_state(ITYPE dim) {
+    CTYPE* state = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*dim*dim));
+    if (!state){
+        fprintf(stderr,"Out of memory\n");
+        exit(1);
+    }
+    return state;
+}
+
+void dm_initialize_quantum_state(CTYPE *state, ITYPE dim) {
+    ITYPE index;
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+    for(index=0; index < dim*dim ; ++index){
+        state[index]=0;
+    }
+    state[0] = 1.0;
+}
+
+void dm_release_quantum_state(CTYPE* state){
+    free(state);
+}
+
+void dm_initialize_with_pure_state(CTYPE *state, const CTYPE *pure_state, ITYPE dim) {
+	ITYPE ind_y;
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (ind_y = 0; ind_y < dim; ++ind_y) {
+		ITYPE ind_x;
+		for (ind_x = 0; ind_x < dim; ++ind_x) {
+			state[ind_y*dim+ind_x] = pure_state[ind_y]*conj(pure_state[ind_x]);
+		}
+	}
+}

--- a/src/csim/memory_ops_dm.c
+++ b/src/csim/memory_ops_dm.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "memory_ops.h"
+#include "memory_ops_dm.h"
 #include "utility.h"
 #include <time.h>
 #include <limits.h>

--- a/src/csim/memory_ops_dm.h
+++ b/src/csim/memory_ops_dm.h
@@ -1,0 +1,45 @@
+
+/**
+ * @file state.h
+ * @brief Definition and basic functions for state vector
+ */
+
+#pragma once
+
+#include "type.h"
+
+/**
+ * allocate quantum state in memory
+ * 
+ * allocate quantum state in memory
+ * @param[in] dim dimension, i.e. size of vector
+ * @return pointer to allocated vector
+ */
+DllExport CTYPE* dm_allocate_quantum_state(ITYPE dim);
+
+/**
+ * intiialize quantum state to zero state
+ * 
+ * intiialize quantum state to zero state
+ * @param[out] state pointer of quantum state
+ * @param[in] dim dimension
+ */
+DllExport void dm_initialize_quantum_state(CTYPE *state, ITYPE dim);
+
+/**
+ * release allocated quantum state
+ * 
+ * release allocated quantum state
+ * @param[in] state quantum state
+ */
+DllExport void dm_release_quantum_state(CTYPE* state);
+
+/**
+ * initialize density matrix from pure state
+ *
+ * initialize density matrix from pure state
+ * @param[out] state pointer of quantum state
+ * @param[out] pure_state pointer of quantum state
+ * @param[in] dim dimension
+ */
+DllExport void dm_initialize_with_pure_state(CTYPE *state, const CTYPE *pure_state, ITYPE dim);

--- a/src/csim/stat_ops_dm.c
+++ b/src/csim/stat_ops_dm.c
@@ -1,0 +1,91 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "stat_ops.h"
+#include "utility.h"
+#include "constant.h"
+
+// calculate norm
+double dm_state_norm(const CTYPE *state, ITYPE dim) {
+    ITYPE index;
+    double norm = 0;
+#ifdef _OPENMP
+#pragma omp parallel for reduction(+:norm)
+#endif
+    for (index = 0; index < dim; ++index){
+        norm += creal(state[index*dim+index]);
+    }
+    return norm;
+}
+
+// calculate entropy of probability distribution of Z-basis measurements
+double dm_measurement_distribution_entropy(const CTYPE *state, ITYPE dim){
+    ITYPE index;
+    double ent=0;
+    const double eps = 1e-15;
+#ifdef _OPENMP
+#pragma omp parallel for reduction(+:ent)
+#endif
+    for(index = 0; index < dim; ++index){
+		double prob = creal(state[index*dim + index]);
+        if(prob > eps){
+            ent += -1.0*prob*log(prob);
+        } 
+    }
+    return ent;
+}
+
+// calculate probability with which we obtain 0 at target qubit
+double dm_M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim){
+    const ITYPE loop_dim = dim/2;
+    const ITYPE mask = 1ULL << target_qubit_index;
+    ITYPE state_index;
+    double sum =0.;
+#ifdef _OPENMP
+#pragma omp parallel for reduction(+:sum)
+#endif
+    for(state_index=0;state_index<loop_dim;++state_index){
+        ITYPE basis_0 = insert_zero_to_basis_index(state_index,mask,target_qubit_index);
+        sum += creal(state[basis_0*dim+basis_0]);
+    }
+    return sum;
+}
+
+// calculate probability with which we obtain 1 at target qubit
+double dm_M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim){
+    const ITYPE loop_dim = dim/2;
+    const ITYPE mask = 1ULL << target_qubit_index;
+    ITYPE state_index;
+    double sum =0.;
+#ifdef _OPENMP
+#pragma omp parallel for reduction(+:sum)
+#endif
+    for(state_index=0;state_index<loop_dim;++state_index){
+        ITYPE basis_1 = insert_zero_to_basis_index(state_index,mask,target_qubit_index) ^ mask;
+		sum += creal(state[basis_1*dim + basis_1]);
+	}
+    return sum;
+}
+
+// calculate merginal probability with which we obtain the set of values measured_value_list at sorted_target_qubit_index_list
+// warning: sorted_target_qubit_index_list must be sorted.
+double dm_marginal_prob(const UINT* sorted_target_qubit_index_list, const UINT* measured_value_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim){
+    ITYPE loop_dim = dim >> target_qubit_index_count;
+    ITYPE state_index;
+    double sum=0.;
+#ifdef _OPENMP
+#pragma omp parallel for reduction(+:sum)
+#endif
+    for(state_index = 0;state_index < loop_dim; ++state_index){
+        ITYPE basis = state_index;
+        for(UINT cursor=0; cursor < target_qubit_index_count ; cursor++){
+            UINT insert_index = sorted_target_qubit_index_list[cursor];
+            ITYPE mask = 1ULL << insert_index;
+            basis = insert_zero_to_basis_index(basis, mask , insert_index );
+            basis ^= mask * measured_value_list[cursor];
+        }
+        sum += creal(state[basis*dim+basis]);
+    }
+    return sum;
+}

--- a/src/csim/stat_ops_dm.c
+++ b/src/csim/stat_ops_dm.c
@@ -96,9 +96,9 @@ double dm_expectation_value_multi_qubit_Pauli_operator_partial_list(const UINT* 
 	for (ITYPE y = 0; y < matrix_dim; ++y) {
 		for (ITYPE x = 0; x < matrix_dim; ++x) {
 			CTYPE coef = 1.0;
-			for (int i = 0; i < target_qubit_index_count; ++i) {
-				int xi = (x >> i) % 2;
-				int yi = (y >> i) % 2;
+			for (UINT i = 0; i < target_qubit_index_count; ++i) {
+				ITYPE xi = (x >> i) % 2;
+				ITYPE yi = (y >> i) % 2;
 				coef *= PAULI_MATRIX[Pauli_operator_type_list[i]][yi * 2 + xi];
 			}
 			matrix[y*matrix_dim + x] = coef;
@@ -110,11 +110,11 @@ double dm_expectation_value_multi_qubit_Pauli_operator_partial_list(const UINT* 
 	for (ITYPE state_index = 0; state_index< dim; ++state_index) {
 		ITYPE small_dim_index = 0;
 		ITYPE basis_0 = state_index;
-		for (int i = 0; i < target_qubit_index_count; ++i) {
+		for (UINT i = 0; i < target_qubit_index_count; ++i) {
 			UINT target_qubit_index = target_qubit_index_list[i];
-			if (state_index & (1 << target_qubit_index)) {
-				small_dim_index += (1 << i);
-				basis_0 ^= (1 << target_qubit_index);
+			if (state_index & (1ULL << target_qubit_index)) {
+				small_dim_index += (1ULL << i);
+				basis_0 ^= (1ULL << target_qubit_index);
 			}
 		}
 		for (int i = 0; i < matrix_dim; ++i) {

--- a/src/csim/stat_ops_dm.c
+++ b/src/csim/stat_ops_dm.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include "stat_ops.h"
+#include "stat_ops_dm.h"
 #include "utility.h"
 #include "constant.h"
 
@@ -117,8 +117,8 @@ double dm_expectation_value_multi_qubit_Pauli_operator_partial_list(const UINT* 
 				basis_0 ^= (1ULL << target_qubit_index);
 			}
 		}
-		for (int i = 0; i < matrix_dim; ++i) {
-			sum += matrix[small_dim_index*matrix_dim + i] * state[state_index*dim + basis_0 ^ matrix_mask_list[i]];
+		for (ITYPE i = 0; i < matrix_dim; ++i) {
+			sum += matrix[small_dim_index*matrix_dim + i] * state[state_index*dim + (basis_0 ^ matrix_mask_list[i])];
 		}
 	}
 

--- a/src/csim/stat_ops_dm.c
+++ b/src/csim/stat_ops_dm.c
@@ -90,6 +90,28 @@ double dm_marginal_prob(const UINT* sorted_target_qubit_index_list, const UINT* 
     return sum;
 }
 
+
+void dm_state_add(const CTYPE *state_added, CTYPE *state, ITYPE dim) {
+	ITYPE index;
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < dim*dim; ++index) {
+		state[index] += state_added[index];
+	}
+}
+
+void dm_state_multiply(CTYPE coef, CTYPE *state, ITYPE dim) {
+	ITYPE index;
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < dim*dim; ++index) {
+		state[index] *= coef;
+	}
+}
+
+
 double dm_expectation_value_multi_qubit_Pauli_operator_partial_list(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim) {
 	const ITYPE matrix_dim = 1ULL << target_qubit_index_count;
 	CTYPE* matrix = (CTYPE*)malloc(sizeof(CTYPE)*matrix_dim*matrix_dim);

--- a/src/csim/stat_ops_dm.h
+++ b/src/csim/stat_ops_dm.h
@@ -4,6 +4,8 @@
 
 DllExport double dm_state_norm(const CTYPE *state, ITYPE dim) ;
 DllExport double dm_measurement_distribution_entropy(const CTYPE *state, ITYPE dim);
+DllExport void dm_state_add(const CTYPE *state_added, CTYPE *state, ITYPE dim);
+DllExport void dm_state_multiply(CTYPE coef, CTYPE *state, ITYPE dim);
 
 DllExport double dm_M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double dm_M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);

--- a/src/csim/stat_ops_dm.h
+++ b/src/csim/stat_ops_dm.h
@@ -8,3 +8,5 @@ DllExport double dm_measurement_distribution_entropy(const CTYPE *state, ITYPE d
 DllExport double dm_M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double dm_M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double dm_marginal_prob(const UINT* sorted_target_qubit_index_list, const UINT* measured_value_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim);
+
+DllExport double dm_expectation_value_multi_qubit_Pauli_operator_partial_list(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim);

--- a/src/csim/stat_ops_dm.h
+++ b/src/csim/stat_ops_dm.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "type.h"
+
+DllExport double dm_state_norm(const CTYPE *state, ITYPE dim) ;
+DllExport double dm_measurement_distribution_entropy(const CTYPE *state, ITYPE dim);
+
+DllExport double dm_M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
+DllExport double dm_M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
+DllExport double dm_marginal_prob(const UINT* sorted_target_qubit_index_list, const UINT* measured_value_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim);

--- a/src/csim/update_ops_dm.c
+++ b/src/csim/update_ops_dm.c
@@ -24,7 +24,6 @@ void dm_normalize(double norm, CTYPE* state, ITYPE dim) {
 	}
 }
 
-
 void dm_single_qubit_dense_matrix_gate(UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim) {
 
 	// target mask
@@ -45,9 +44,9 @@ void dm_single_qubit_dense_matrix_gate(UINT target_qubit_index, const CTYPE matr
 		}
 	}
 
-	ITYPE state_index_y;
+	ITYPE state_index_x, state_index_y;
 #ifdef _OPENMP
-#pragma omp parallel for
+#pragma omp parallel for private(state_index_x)
 #endif
 	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
 
@@ -56,7 +55,6 @@ void dm_single_qubit_dense_matrix_gate(UINT target_qubit_index, const CTYPE matr
 		// flip target bit
 		ITYPE basis_1_y = basis_0_y ^ target_mask;
 
-		ITYPE state_index_x;
 		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
 
 			// create vertical index
@@ -84,6 +82,7 @@ void dm_single_qubit_dense_matrix_gate(UINT target_qubit_index, const CTYPE matr
 	}
 }
 
+
 void dm_multi_qubit_control_single_qubit_dense_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count,
 	UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim) {
 
@@ -100,37 +99,51 @@ void dm_multi_qubit_control_single_qubit_dense_matrix_gate(const UINT* control_q
 	// loop variables
 	const ITYPE loop_dim = dim >> insert_index_list_count;
 
-	// create extended matrix
-	CTYPE ext_matrix[16];
-	for (int y = 0; y < 4; ++y) {
-		int y1 = y / 2;
-		int y2 = y % 2;
-		for (int x = 0; x < 4; ++x) {
-			int x1 = x / 2;
-			int x2 = x % 2;
-			ext_matrix[y * 4 + x] = matrix[y1 * 2 + x1] * conj(matrix[y2 * 2 + x2]);
+	CTYPE adjoint_matrix[4];
+	adjoint_matrix[0] = conj(matrix[0]);
+	adjoint_matrix[1] = conj(matrix[2]);
+	adjoint_matrix[2] = conj(matrix[1]);
+	adjoint_matrix[3] = conj(matrix[3]);
+
+	ITYPE state_index_x, state_index_y;
+#ifdef _OPENMP
+#pragma omp parallel for private(state_index_y)
+#endif
+	for (state_index_x = 0; state_index_x < dim; ++state_index_x) {
+
+		for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+
+			// create base index
+			ITYPE basis_c_t0_y = state_index_y;
+			for (UINT cursor = 0; cursor < insert_index_list_count; ++cursor) {
+				basis_c_t0_y = insert_zero_to_basis_index(basis_c_t0_y, 1ULL << insert_index_list[cursor], insert_index_list[cursor]);
+			}
+
+			// flip controls
+			basis_c_t0_y ^= control_mask;
+
+			// gather target
+			ITYPE basis_c_t1_y = basis_c_t0_y ^ target_mask;
+
+			// set index
+			ITYPE basis_0 = basis_c_t0_y * dim + state_index_x;
+			ITYPE basis_1 = basis_c_t1_y * dim + state_index_x;
+
+			// fetch values
+			CTYPE cval_0 = state[basis_0];
+			CTYPE cval_1 = state[basis_1];
+
+			// set values
+			state[basis_0] = matrix[0] * cval_0 + matrix[1] * cval_1;
+			state[basis_1] = matrix[2] * cval_0 + matrix[3] * cval_1;
 		}
 	}
 
-	ITYPE state_index_y;
 #ifdef _OPENMP
-#pragma omp parallel for
+#pragma omp parallel for private(state_index_x)
 #endif
-	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+	for (state_index_y = 0; state_index_y < dim; ++state_index_y) {
 
-		// create base index
-		ITYPE basis_c_t0_y = state_index_y;
-		for (UINT cursor = 0; cursor < insert_index_list_count; ++cursor) {
-			basis_c_t0_y = insert_zero_to_basis_index(basis_c_t0_y, 1ULL << insert_index_list[cursor], insert_index_list[cursor]);
-		}
-
-		// flip controls
-		basis_c_t0_y ^= control_mask;
-
-		// gather target
-		ITYPE basis_c_t1_y = basis_c_t0_y ^ target_mask;
-
-		ITYPE state_index_x;
 		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
 
 			// create base index
@@ -146,29 +159,24 @@ void dm_multi_qubit_control_single_qubit_dense_matrix_gate(const UINT* control_q
 			ITYPE basis_c_t1_x = basis_c_t0_x ^ target_mask;
 
 			// set index
-			ITYPE basis_00 = basis_c_t0_y * dim + basis_c_t0_x;
-			ITYPE basis_01 = basis_c_t0_y * dim + basis_c_t1_x;
-			ITYPE basis_10 = basis_c_t1_y * dim + basis_c_t0_x;
-			ITYPE basis_11 = basis_c_t1_y * dim + basis_c_t1_x;
+			ITYPE basis_0 = state_index_y * dim + basis_c_t0_x;
+			ITYPE basis_1 = state_index_y * dim + basis_c_t1_x;
 
 			// fetch values
-			CTYPE cval_00 = state[basis_00];
-			CTYPE cval_01 = state[basis_01];
-			CTYPE cval_10 = state[basis_10];
-			CTYPE cval_11 = state[basis_11];
+			CTYPE cval_0 = state[basis_0];
+			CTYPE cval_1 = state[basis_1];
 
 			// set values
-			state[basis_00] = ext_matrix[0] * cval_00 + ext_matrix[1] * cval_01 + ext_matrix[2] * cval_10 + ext_matrix[3] * cval_11;
-			state[basis_01] = ext_matrix[4] * cval_00 + ext_matrix[5] * cval_01 + ext_matrix[6] * cval_10 + ext_matrix[7] * cval_11;
-			state[basis_10] = ext_matrix[8] * cval_00 + ext_matrix[9] * cval_01 + ext_matrix[10] * cval_10 + ext_matrix[11] * cval_11;
-			state[basis_11] = ext_matrix[12] * cval_00 + ext_matrix[13] * cval_01 + ext_matrix[14] * cval_10 + ext_matrix[15] * cval_11;
+			state[basis_0] = cval_0 * adjoint_matrix[0] + cval_1 * adjoint_matrix[2];
+			state[basis_1] = cval_0 * adjoint_matrix[1] + cval_1 * adjoint_matrix[3];
 		}
 	}
 
 	free(insert_index_list);
 }
 
-
+/*
+// inefficient implementation
 void dm_multi_qubit_dense_matrix_gate(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim) {
 
 	// matrix dim, mask, buffer
@@ -291,7 +299,142 @@ void dm_multi_qubit_dense_matrix_gate(const UINT* target_qubit_index_list, UINT 
 	free((UINT*)sorted_insert_index_list);
 	free((ITYPE*)matrix_mask_list);
 }
+*/
 
+
+void dm_multi_qubit_dense_matrix_gate(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim) {
+
+	// matrix dim, mask, buffer
+	const ITYPE matrix_dim = 1ULL << target_qubit_index_count;
+	const ITYPE* matrix_mask_list = create_matrix_mask_list(target_qubit_index_list, target_qubit_index_count);
+
+	// create extended matrix
+	CTYPE* adjoint_matrix = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*(matrix_dim * matrix_dim)));
+	for (ITYPE y = 0; y < matrix_dim; ++y) {
+		for (ITYPE x = 0; x < matrix_dim; ++x) {
+			adjoint_matrix[y*matrix_dim + x] = conj(matrix[x*matrix_dim + y]);
+		}
+	}
+
+	// insert index
+	const UINT* sorted_insert_index_list = create_sorted_ui_list(target_qubit_index_list, target_qubit_index_count);
+
+	// loop variables
+	const ITYPE loop_dim = dim >> target_qubit_index_count;
+
+#ifndef _OPENMP
+	CTYPE* buffer = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*matrix_dim*matrix_dim));
+	ITYPE state_index_y;
+	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+		// create base index
+		ITYPE basis_0_y = state_index_y;
+		for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+			UINT insert_index = sorted_insert_index_list[cursor];
+			basis_0_y = insert_zero_to_basis_index(basis_0_y, 1ULL << insert_index, insert_index);
+		}
+
+		ITYPE state_index_x;
+		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+			// create base index
+			ITYPE basis_0_x = state_index_x;
+			for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+				UINT insert_index = sorted_insert_index_list[cursor];
+				basis_0_x = insert_zero_to_basis_index(basis_0_x, 1ULL << insert_index, insert_index);
+			}
+
+			// compute matrix-matrix multiply
+			// TODO: improve matmul
+			for (ITYPE y = 0; y < matrix_dim; ++y) {
+				for (ITYPE x = 0; x < matrix_dim; ++x) {
+					buffer[y*matrix_dim + x] = 0;
+					for (ITYPE k = 0; k < matrix_dim; ++k) {
+						ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x];
+						ITYPE dm_index_k = basis_0_y ^ matrix_mask_list[k];
+						buffer[y*matrix_dim+x] += matrix[y*matrix_dim + k] * state[ dm_index_k * dim + dm_index_x];
+					}
+				}
+			}
+
+			for (ITYPE y = 0; y < matrix_dim; ++y) {
+				for (ITYPE x = 0; x < matrix_dim; ++x) {
+					ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x];
+					ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y];
+					ITYPE dm_index = dm_index_y * dim + dm_index_x;
+					state[dm_index] = 0;
+					for (ITYPE k = 0; k < matrix_dim; ++k) {
+						state[dm_index] += buffer[y*matrix_dim + k] * adjoint_matrix[k*matrix_dim + x];
+					}
+				}
+			}
+		}
+	}
+	free(buffer);
+#else
+	const UINT thread_count = omp_get_max_threads();
+	CTYPE* buffer_list = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*matrix_dim*matrix_dim*thread_count));
+
+	const ITYPE block_size = loop_dim / thread_count;
+	const ITYPE residual = loop_dim % thread_count;
+
+#pragma omp parallel
+	{
+		UINT thread_id = omp_get_thread_num();
+		ITYPE start_index = block_size * thread_id + (residual > thread_id ? thread_id : residual);
+		ITYPE end_index = block_size * (thread_id + 1) + (residual > (thread_id + 1) ? (thread_id + 1) : residual);
+		CTYPE* buffer = buffer_list + thread_id * matrix_dim*matrix_dim;
+
+		ITYPE state_index_y;
+		for (state_index_y = start_index; state_index_y < end_index; ++state_index_y) {
+
+			// create base index
+			ITYPE basis_0_y = state_index_y;
+			for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+				UINT insert_index = sorted_insert_index_list[cursor];
+				basis_0_y = insert_zero_to_basis_index(basis_0_y, 1ULL << insert_index, insert_index);
+			}
+
+			ITYPE state_index_x;
+			for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+				// create base index
+				ITYPE basis_0_x = state_index_x;
+				for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+					UINT insert_index = sorted_insert_index_list[cursor];
+					basis_0_x = insert_zero_to_basis_index(basis_0_x, 1ULL << insert_index, insert_index);
+				}
+
+				// compute matrix-matrix multiply
+				// TODO: improve matmul
+				for (ITYPE y = 0; y < matrix_dim; ++y) {
+					for (ITYPE x = 0; x < matrix_dim; ++x) {
+						buffer[y*matrix_dim + x] = 0;
+						for (ITYPE k = 0; k < matrix_dim; ++k) {
+							ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x];
+							ITYPE dm_index_k = basis_0_y ^ matrix_mask_list[k];
+							buffer[y*matrix_dim + x] += matrix[y*matrix_dim + k] * state[dm_index_k * dim + dm_index_x];
+						}
+					}
+				}
+
+				for (ITYPE y = 0; y < matrix_dim; ++y) {
+					for (ITYPE x = 0; x < matrix_dim; ++x) {
+						ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x];
+						ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y];
+						ITYPE dm_index = dm_index_y * dim + dm_index_x;
+						state[dm_index] = 0;
+						for (ITYPE k = 0; k < matrix_dim; ++k) {
+							state[dm_index] += buffer[y*matrix_dim + k] * adjoint_matrix[k*matrix_dim + x];
+						}
+					}
+				}
+			}
+		}
+	}
+	free(buffer_list);
+#endif
+	free(adjoint_matrix);
+	free((UINT*)sorted_insert_index_list);
+	free((ITYPE*)matrix_mask_list);
+}
 
 
 void dm_multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim) {
@@ -310,84 +453,18 @@ void dm_multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* control_qu
 	// loop varaibles
 	const ITYPE loop_dim = dim >> (target_qubit_index_count + control_qubit_index_count);
 
-
-	// create extended matrix
-	const ITYPE ext_matrix_dim = matrix_dim * matrix_dim;
-	CTYPE* ext_matrix = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*(ext_matrix_dim * ext_matrix_dim)));
-	for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
-		ITYPE y1 = y / matrix_dim;
-		ITYPE y2 = y % matrix_dim;
-		for (ITYPE x = 0; x < ext_matrix_dim; ++x) {
-			ITYPE x1 = x / matrix_dim;
-			ITYPE x2 = x % matrix_dim;
-			ext_matrix[y*ext_matrix_dim + x] = matrix[y1*matrix_dim + x1] * conj(matrix[y2*matrix_dim + x2]);
+	CTYPE* adjoint_matrix = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*matrix_dim*matrix_dim));
+	for (ITYPE y = 0; y < matrix_dim; ++y) {
+		for (ITYPE x = 0; x < matrix_dim; ++x) {
+			adjoint_matrix[y*matrix_dim + x] = conj(matrix[x*matrix_dim + y]);
 		}
 	}
 
 #ifndef _OPENMP
-	CTYPE* buffer = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*ext_matrix_dim));
-	ITYPE state_index_y;
-	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
-
-		// create base index
-		ITYPE basis_0_y = state_index_y;
-		for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
-			UINT insert_index = sorted_insert_index_list[cursor];
-			basis_0_y = insert_zero_to_basis_index(basis_0_y, 1ULL << insert_index, insert_index);
-		}
-
-		// flip control masks
-		basis_0_y ^= control_mask;
-
-		ITYPE state_index_x;
-		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
-
-			// create base index
-			ITYPE basis_0_x = state_index_x;
-			for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
-				UINT insert_index = sorted_insert_index_list[cursor];
-				basis_0_x = insert_zero_to_basis_index(basis_0_x, 1ULL << insert_index, insert_index);
-			}
-
-			// flip control masks
-			basis_0_x ^= control_mask;
-
-			// compute matrix-vector multiply
-			for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
-				buffer[y] = 0;
-				for (ITYPE x = 0; x < ext_matrix_dim; ++x) {
-					ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x%matrix_dim];
-					ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[x / matrix_dim];
-					buffer[y] += ext_matrix[y*ext_matrix_dim + x] * state[dm_index_y * dim + dm_index_x];
-				}
-			}
-
-			// set result
-			for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
-				ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[y % matrix_dim];
-				ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y / matrix_dim];
-				state[dm_index_y * dim + dm_index_x] = buffer[y];
-			}
-		}
-	}
-	free(buffer);
-#else
-	const UINT thread_count = omp_get_max_threads();
-	CTYPE* buffer_list = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*ext_matrix_dim*thread_count));
-
-	const ITYPE block_size = loop_dim / thread_count;
-	const ITYPE residual = loop_dim % thread_count;
-
-#pragma omp parallel
-	{
-		UINT thread_id = omp_get_thread_num();
-		ITYPE start_index = block_size * thread_id + (residual > thread_id ? thread_id : residual);
-		ITYPE end_index = block_size * (thread_id + 1) + (residual > (thread_id + 1) ? (thread_id + 1) : residual);
-		CTYPE* buffer = buffer_list + thread_id * ext_matrix_dim;
-
-		ITYPE state_index_y;
-		for (state_index_y = start_index; state_index_y < end_index; ++state_index_y) {
-
+	CTYPE* buffer = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*matrix_dim));
+	ITYPE state_index_x, state_index_y;
+	for (state_index_x = 0; state_index_x < dim; ++state_index_x) {
+		for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
 			// create base index
 			ITYPE basis_0_y = state_index_y;
 			for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
@@ -398,9 +475,95 @@ void dm_multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* control_qu
 			// flip control masks
 			basis_0_y ^= control_mask;
 
-			ITYPE state_index_x;
-			for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+			// compute matrix vector mul
+			for (ITYPE y = 0; y < matrix_dim; ++y) {
+				buffer[y] = 0;
+				for (ITYPE x = 0; x < matrix_dim; ++x) {
+					ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[x];
+					buffer[y] += matrix[y*matrix_dim + x] * state[dm_index_y*dim + state_index_x];
+				}
+			}
 
+			// set result
+			for (ITYPE y = 0; y < matrix_dim; ++y) {
+				ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y];
+				state[dm_index_y*dim + state_index_x] = buffer[y];
+			}
+		}
+	}
+	for (state_index_y = 0; state_index_y < dim; ++state_index_y) {
+		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+			// create base index
+			ITYPE basis_0_x = state_index_x;
+			for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
+				UINT insert_index = sorted_insert_index_list[cursor];
+				basis_0_x = insert_zero_to_basis_index(basis_0_x, 1ULL << insert_index, insert_index);
+			}
+
+			// flip control masks
+			basis_0_x ^= control_mask;
+
+			// compute matrix vector mul
+			for (ITYPE y = 0; y < matrix_dim; ++y) {
+				buffer[y] = 0;
+				for (ITYPE x = 0; x < matrix_dim; ++x) {
+					ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x];
+					buffer[y] += state[state_index_y*dim + dm_index_x] * adjoint_matrix[x*matrix_dim + y];
+				}
+			}
+
+			// set result
+			for (ITYPE y = 0; y < matrix_dim; ++y) {
+				ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[y];
+				state[state_index_y*dim + dm_index_x] = buffer[y];
+			}
+		}
+	}
+	free(buffer);
+#else
+	const UINT thread_count = omp_get_max_threads();
+	CTYPE* buffer_list = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*matrix_dim*thread_count));
+	const ITYPE block_size = dim / thread_count;
+	const ITYPE residual = dim % thread_count;
+#pragma omp parallel
+	{
+		UINT thread_id = omp_get_thread_num();
+		ITYPE start_index = block_size * thread_id + (residual > thread_id ? thread_id : residual);
+		ITYPE end_index = block_size * (thread_id + 1) + (residual > (thread_id + 1) ? (thread_id + 1) : residual);
+		CTYPE* buffer = buffer_list + thread_id * matrix_dim;
+
+		ITYPE state_index_y, state_index_x;
+		for (state_index_x = start_index; state_index_x < end_index; ++state_index_x) {
+			for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+				// create base index
+				ITYPE basis_0_y = state_index_y;
+				for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
+					UINT insert_index = sorted_insert_index_list[cursor];
+					basis_0_y = insert_zero_to_basis_index(basis_0_y, 1ULL << insert_index, insert_index);
+				}
+
+				// flip control masks
+				basis_0_y ^= control_mask;
+
+				// compute matrix vector mul
+				for (ITYPE y = 0; y < matrix_dim; ++y) {
+					buffer[y] = 0;
+					for (ITYPE x = 0; x < matrix_dim; ++x) {
+						ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[x];
+						buffer[y] += matrix[y*matrix_dim + x] * state[dm_index_y*dim + state_index_x];
+					}
+				}
+
+				// set result
+				for (ITYPE y = 0; y < matrix_dim; ++y) {
+					ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y];
+					state[dm_index_y*dim + state_index_x] = buffer[y];
+				}
+			}
+		}
+#pragma omp barrier
+		for (state_index_y = start_index; state_index_y < end_index; ++state_index_y) {
+			for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
 				// create base index
 				ITYPE basis_0_x = state_index_x;
 				for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
@@ -411,27 +574,26 @@ void dm_multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* control_qu
 				// flip control masks
 				basis_0_x ^= control_mask;
 
-				// compute matrix-vector multiply
-				for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
+				// compute matrix vector mul
+				for (ITYPE y = 0; y < matrix_dim; ++y) {
 					buffer[y] = 0;
-					for (ITYPE x = 0; x < ext_matrix_dim; ++x) {
-						ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x%matrix_dim];
-						ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[x / matrix_dim];
-						buffer[y] += ext_matrix[y*ext_matrix_dim + x] * state[dm_index_y * dim + dm_index_x];
+					for (ITYPE x = 0; x < matrix_dim; ++x) {
+						ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x];
+						buffer[y] += state[state_index_y*dim + dm_index_x] * adjoint_matrix[x*matrix_dim + y];
 					}
 				}
 
 				// set result
-				for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
-					ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[y % matrix_dim];
-					ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y / matrix_dim];
-					state[dm_index_y * dim + dm_index_x] = buffer[y];
+				for (ITYPE y = 0; y < matrix_dim; ++y) {
+					ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[y];
+					state[state_index_y*dim + dm_index_x] = buffer[y];
 				}
 			}
 		}
 	}
-	free(buffer_list);
+	free(buffer_list); 
 #endif
+	free(adjoint_matrix);
 	free(sorted_insert_index_list);
 	free(matrix_mask_list);
 }
@@ -561,7 +723,12 @@ void dm_multi_qubit_Pauli_rotation_gate_partial_list(const UINT* target_qubit_in
 				UINT yi = (y >> i) % 2;
 				coef *= PAULI_MATRIX[Pauli_operator_type_list[i]][yi*2+xi];
 			}
-			matrix[y*matrix_dim + x] = cos(angle/2) *1.0  + 1.0i * sin(angle/2)*coef;
+			if (y == x) {
+				matrix[y*matrix_dim + x] = cos(angle / 2) *1.0 + 1.0i * sin(angle / 2)*coef;
+			}
+			else {
+				matrix[y*matrix_dim + x] = 1.0i * sin(angle / 2)*coef;
+			}
 		}
 	}
 	dm_multi_qubit_dense_matrix_gate(target_qubit_index_list, target_qubit_index_count, matrix, state, dim);

--- a/src/csim/update_ops_dm.c
+++ b/src/csim/update_ops_dm.c
@@ -1,0 +1,376 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "constant.h"
+#include "update_ops_dm.h"
+#include "utility.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+void dm_normalize(double norm, CTYPE* state, ITYPE dim) {
+	const ITYPE loop_dim = dim;
+	const double normalize_factor = 1. / norm;
+	ITYPE state_index_y;
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+		ITYPE state_index_x;
+		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+			state[state_index_y * dim + state_index_x] *= normalize_factor;
+		}
+	}
+}
+
+
+void dm_single_qubit_dense_matrix_gate(UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim) {
+
+	// target mask
+	const ITYPE target_mask = 1ULL << target_qubit_index;
+
+	// loop variables
+	const ITYPE loop_dim = dim / 2;
+
+	// create extended matrix
+	CTYPE ext_matrix[16];
+	for (int y = 0; y < 4; ++y) {
+		int y1 = y / 2;
+		int y2 = y % 2;
+		for (int x = 0; x < 4; ++x) {
+			int x1 = x / 2;
+			int x2 = x % 2;
+			ext_matrix[y * 4 + x] = matrix[y1 * 2 + x1] * conj(matrix[y2 * 2 + x2]);
+		}
+	}
+
+	ITYPE state_index_y;
+	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+
+		// create vertical index
+		ITYPE basis_0_y = insert_zero_to_basis_index(state_index_y, target_mask, target_qubit_index);
+		// flip target bit
+		ITYPE basis_1_y = basis_0_y ^ target_mask;
+
+		ITYPE state_index_x;
+		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+
+			// create vertical index
+			ITYPE basis_0_x = insert_zero_to_basis_index(state_index_x, target_mask, target_qubit_index);
+			// flip target bit
+			ITYPE basis_1_x = basis_0_x ^ target_mask;
+
+			ITYPE basis_00 = basis_0_y * dim + basis_0_x;
+			ITYPE basis_01 = basis_0_y * dim + basis_1_x;
+			ITYPE basis_10 = basis_1_y * dim + basis_0_x;
+			ITYPE basis_11 = basis_1_y * dim + basis_1_x;
+
+			// fetch values
+			CTYPE cval_00 = state[basis_00];
+			CTYPE cval_01 = state[basis_01];
+			CTYPE cval_10 = state[basis_10];
+			CTYPE cval_11 = state[basis_11];
+
+			// set values
+			state[basis_00] = ext_matrix[0] * cval_00 + ext_matrix[1] * cval_01 + ext_matrix[2] * cval_10 + ext_matrix[3] * cval_11;
+			state[basis_01] = ext_matrix[4] * cval_00 + ext_matrix[5] * cval_01 + ext_matrix[6] * cval_10 + ext_matrix[7] * cval_11;
+			state[basis_10] = ext_matrix[8] * cval_00 + ext_matrix[9] * cval_01 + ext_matrix[10] * cval_10 + ext_matrix[11] * cval_11;
+			state[basis_11] = ext_matrix[12] * cval_00 + ext_matrix[13] * cval_01 + ext_matrix[14] * cval_10 + ext_matrix[15] * cval_11;
+		}
+	}
+}
+
+void dm_multi_qubit_control_single_qubit_dense_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count,
+	UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim) {
+
+	// insert index list
+	const UINT insert_index_list_count = control_qubit_index_count + 1;
+	UINT* insert_index_list = create_sorted_ui_list_value(control_qubit_index_list, control_qubit_index_count, target_qubit_index);
+
+	// target mask
+	const ITYPE target_mask = 1ULL << target_qubit_index;
+
+	// control mask
+	ITYPE control_mask = create_control_mask(control_qubit_index_list, control_value_list, control_qubit_index_count);
+
+	// loop variables
+	const ITYPE loop_dim = dim >> insert_index_list_count;
+
+	// create extended matrix
+	CTYPE ext_matrix[16];
+	for (int y = 0; y < 4; ++y) {
+		int y1 = y / 2;
+		int y2 = y % 2;
+		for (int x = 0; x < 4; ++x) {
+			int x1 = x / 2;
+			int x2 = x % 2;
+			ext_matrix[y * 4 + x] = matrix[y1 * 2 + x1] * conj(matrix[y2 * 2 + x2]);
+		}
+	}
+
+	ITYPE state_index_y;
+	for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+
+		// create base index
+		ITYPE basis_c_t0_y = state_index_y;
+		for (UINT cursor = 0; cursor < insert_index_list_count; ++cursor) {
+			basis_c_t0_y = insert_zero_to_basis_index(basis_c_t0_y, 1ULL << insert_index_list[cursor], insert_index_list[cursor]);
+		}
+
+		// flip controls
+		basis_c_t0_y ^= control_mask;
+
+		// gather target
+		ITYPE basis_c_t1_y = basis_c_t0_y ^ target_mask;
+
+		ITYPE state_index_x;
+		for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+
+			// create base index
+			ITYPE basis_c_t0_x = state_index_x;
+			for (UINT cursor = 0; cursor < insert_index_list_count; ++cursor) {
+				basis_c_t0_x = insert_zero_to_basis_index(basis_c_t0_x, 1ULL << insert_index_list[cursor], insert_index_list[cursor]);
+			}
+
+			// flip controls
+			basis_c_t0_x ^= control_mask;
+
+			// gather target
+			ITYPE basis_c_t1_x = basis_c_t0_x ^ target_mask;
+
+			// set index
+			ITYPE basis_00 = basis_c_t0_y * dim + basis_c_t0_x;
+			ITYPE basis_01 = basis_c_t0_y * dim + basis_c_t1_x;
+			ITYPE basis_10 = basis_c_t1_y * dim + basis_c_t0_x;
+			ITYPE basis_11 = basis_c_t1_y * dim + basis_c_t1_x;
+
+			// fetch values
+			CTYPE cval_00 = state[basis_00];
+			CTYPE cval_01 = state[basis_01];
+			CTYPE cval_10 = state[basis_10];
+			CTYPE cval_11 = state[basis_11];
+
+			// set values
+			state[basis_00] = ext_matrix[0] * cval_00 + ext_matrix[1] * cval_01 + ext_matrix[2] * cval_10 + ext_matrix[3] * cval_11;
+			state[basis_01] = ext_matrix[4] * cval_00 + ext_matrix[5] * cval_01 + ext_matrix[6] * cval_10 + ext_matrix[7] * cval_11;
+			state[basis_10] = ext_matrix[8] * cval_00 + ext_matrix[9] * cval_01 + ext_matrix[10] * cval_10 + ext_matrix[11] * cval_11;
+			state[basis_11] = ext_matrix[12] * cval_00 + ext_matrix[13] * cval_01 + ext_matrix[14] * cval_10 + ext_matrix[15] * cval_11;
+		}
+	}
+
+	free(insert_index_list);
+}
+
+
+void dm_multi_qubit_dense_matrix_gate(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim) {
+
+	// matrix dim, mask, buffer
+	const ITYPE matrix_dim = 1ULL << target_qubit_index_count;
+	const ITYPE* matrix_mask_list = create_matrix_mask_list(target_qubit_index_list, target_qubit_index_count);
+
+	// create extended matrix
+	const ITYPE ext_matrix_dim = matrix_dim*matrix_dim;
+	CTYPE* ext_matrix = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*(1ULL << (target_qubit_index_count*4))));
+	for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
+		int y1 = y / matrix_dim;
+		int y2 = y % matrix_dim;
+		for (ITYPE x = 0; x < ext_matrix_dim; ++x) {
+			int x1 = x / matrix_dim;
+			int x2 = x % matrix_dim;
+			ext_matrix[y*ext_matrix_dim + x] = matrix[y1*matrix_dim + x1] * conj(matrix[y2*matrix_dim + x2]);
+		}
+	}
+
+	// insert index
+	const UINT* sorted_insert_index_list = create_sorted_ui_list(target_qubit_index_list, target_qubit_index_count);
+
+	// loop variables
+	const ITYPE loop_dim = dim >> target_qubit_index_count;
+
+	CTYPE* buffer = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*ext_matrix_dim));
+	ITYPE state_index_x;
+	for (state_index_x = 0; state_index_x < loop_dim; ++state_index_x) {
+		// create base index
+		ITYPE basis_0_x = state_index_x;
+		for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+			UINT insert_index = sorted_insert_index_list[cursor];
+			basis_0_x = insert_zero_to_basis_index(basis_0_x, 1ULL << insert_index, insert_index);
+		}
+
+		ITYPE state_index_y;
+		for (state_index_y = 0; state_index_y < loop_dim; ++state_index_y) {
+			// create base index
+			ITYPE basis_0_y = state_index_y;
+			for (UINT cursor = 0; cursor < target_qubit_index_count; cursor++) {
+				UINT insert_index = sorted_insert_index_list[cursor];
+				basis_0_y = insert_zero_to_basis_index(basis_0_y, 1ULL << insert_index, insert_index);
+			}
+
+			// compute matrix-vector multiply
+			for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
+				buffer[y] = 0;
+				for (ITYPE x = 0; x < ext_matrix_dim; ++x) {
+					ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[x%matrix_dim];
+					ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[x/matrix_dim];
+					buffer[y] += ext_matrix[y*ext_matrix_dim + x] * state[ dm_index_y * dim + dm_index_x];
+				}
+			}
+
+			// set result
+			for (ITYPE y = 0; y < ext_matrix_dim; ++y) {
+				ITYPE dm_index_x = basis_0_x ^ matrix_mask_list[y % matrix_dim];
+				ITYPE dm_index_y = basis_0_y ^ matrix_mask_list[y / matrix_dim];
+				state[dm_index_y * dim + dm_index_x] = buffer[y];
+			}
+		}
+	}
+	free(buffer);
+	free(ext_matrix);
+	free((UINT*)sorted_insert_index_list);
+	free((ITYPE*)matrix_mask_list);
+}
+
+
+
+void dm_multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim) {
+
+	// matrix dim, mask, buffer
+	const ITYPE matrix_dim = 1ULL << target_qubit_index_count;
+	ITYPE* matrix_mask_list = create_matrix_mask_list(target_qubit_index_list, target_qubit_index_count);
+	CTYPE* buffer = (CTYPE*)malloc((size_t)(sizeof(CTYPE)*matrix_dim));
+
+	// insert index
+	const UINT insert_index_count = target_qubit_index_count + control_qubit_index_count;
+	UINT* sorted_insert_index_list = create_sorted_ui_list_list(target_qubit_index_list, target_qubit_index_count, control_qubit_index_list, control_qubit_index_count);
+
+	// control mask
+	ITYPE control_mask = create_control_mask(control_qubit_index_list, control_value_list, control_qubit_index_count);
+
+	// loop varaibles
+	const ITYPE loop_dim = dim >> (target_qubit_index_count + control_qubit_index_count);
+	ITYPE state_index;
+
+	for (state_index = 0; state_index < loop_dim; ++state_index) {
+
+		// create base index
+		ITYPE basis_0 = state_index;
+		for (UINT cursor = 0; cursor < insert_index_count; cursor++) {
+			UINT insert_index = sorted_insert_index_list[cursor];
+			basis_0 = insert_zero_to_basis_index(basis_0, 1ULL << insert_index, insert_index);
+		}
+
+		// flip control masks
+		basis_0 ^= control_mask;
+
+		// compute matrix mul
+		for (ITYPE y = 0; y < matrix_dim; ++y) {
+			buffer[y] = 0;
+			for (ITYPE x = 0; x < matrix_dim; ++x) {
+				buffer[y] += matrix[y*matrix_dim + x] * state[basis_0 ^ matrix_mask_list[x]];
+			}
+		}
+
+		// set result
+		for (ITYPE y = 0; y < matrix_dim; ++y) {
+			state[basis_0 ^ matrix_mask_list[y]] = buffer[y];
+		}
+	}
+	free(sorted_insert_index_list);
+	free(buffer);
+	free(matrix_mask_list);
+}
+
+
+void dm_X_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, PAULI_MATRIX[1], state, dim);
+}
+void dm_Y_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, PAULI_MATRIX[2], state, dim);
+}
+void dm_Z_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, PAULI_MATRIX[3], state, dim);
+}
+void dm_S_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, S_GATE_MATRIX, state, dim);
+}
+void dm_Sdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, S_DAG_GATE_MATRIX, state, dim);
+}
+void dm_T_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim){
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, T_GATE_MATRIX, state, dim);
+}
+void dm_Tdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, T_DAG_GATE_MATRIX, state, dim);
+}
+void dm_sqrtX_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, SQRT_X_GATE_MATRIX, state, dim);
+}
+void dm_sqrtXdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, SQRT_X_DAG_GATE_MATRIX, state, dim);
+}
+void dm_sqrtY_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, SQRT_Y_GATE_MATRIX, state, dim);
+}
+void dm_sqrtYdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, SQRT_Y_DAG_GATE_MATRIX, state, dim);
+}
+void dm_H_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, HADAMARD_MATRIX, state, dim);
+}
+void dm_P0_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, PROJ_0_MATRIX, state, dim);
+}
+void dm_P1_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, PROJ_1_MATRIX, state, dim);
+}
+void dm_CNOT_gate(UINT control_qubit_index, UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	UINT control_index_list[1];
+	UINT control_value_list[1];
+	control_index_list[0] = control_qubit_index;
+	control_value_list[0] = 1;
+	dm_multi_qubit_control_single_qubit_dense_matrix_gate(control_index_list, control_value_list, 1, target_qubit_index, PAULI_MATRIX[1], state, dim);
+}
+void dm_CZ_gate(UINT control_qubit_index, UINT target_qubit_index, CTYPE *state, ITYPE dim) {
+	UINT control_index_list[1];
+	UINT control_value_list[1];
+	control_index_list[0] = control_qubit_index;
+	control_value_list[0] = 1;
+	dm_multi_qubit_control_single_qubit_dense_matrix_gate(control_index_list, control_value_list, 1, target_qubit_index, PAULI_MATRIX[3], state, dim);
+}
+void dm_SWAP_gate(UINT target_qubit_index_0, UINT target_qubit_index_1, CTYPE *state, ITYPE dim) {
+	CTYPE matrix[16];
+	memset(matrix, 0, sizeof(CTYPE) * 16);
+	matrix[0 * 4 + 0] = 1;
+	matrix[1 * 4 + 2] = 1;
+	matrix[2 * 4 + 1] = 1;
+	matrix[3 * 4 + 3] = 1;
+	UINT target_index[2];
+	target_index[0] = target_qubit_index_0;
+	target_index[1] = target_qubit_index_1;
+	dm_multi_qubit_dense_matrix_gate(target_index, 2, matrix, state, dim);
+}
+void dm_RX_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim) {
+	UINT i, j;
+	CTYPE rotation_gate[4];
+	for (i = 0; i < 2; ++i)
+		for (j = 0; j < 2; ++j)
+			rotation_gate[i * 2 + j] = cos(angle / 2) * PAULI_MATRIX[0][i * 2 + j] + sin(angle / 2) * 1.0i * PAULI_MATRIX[1][i * 2 + j];
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, rotation_gate, state, dim);
+}
+void dm_RY_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim) {
+	UINT i, j;
+	CTYPE rotation_gate[4];
+	for (i = 0; i < 2; ++i)
+		for (j = 0; j < 2; ++j)
+			rotation_gate[i * 2 + j] = cos(angle / 2) * PAULI_MATRIX[0][i * 2 + j] + sin(angle / 2) * 1.0i * PAULI_MATRIX[2][i * 2 + j];
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, rotation_gate, state, dim);
+}
+void dm_RZ_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim) {
+	UINT i, j;
+	CTYPE rotation_gate[4];
+	for (i = 0; i < 2; ++i)
+		for (j = 0; j < 2; ++j)
+			rotation_gate[i * 2 + j] = cos(angle / 2) * PAULI_MATRIX[0][i * 2 + j] + sin(angle / 2) * 1.0i * PAULI_MATRIX[3][i * 2 + j];
+	dm_single_qubit_dense_matrix_gate(target_qubit_index, rotation_gate, state, dim);
+}

--- a/src/csim/update_ops_dm.h
+++ b/src/csim/update_ops_dm.h
@@ -1,0 +1,45 @@
+/*
+ rules for arguments of update functions:
+   The order of arguments must be 
+      information_about_applying_qubits -> Pauli_operator -> information_about_applying_gate_matrix_elements -> a_kind_of_rotation_angle -> state_vector -> dimension
+   If there is control-qubit and target-qubit, control-qubit is the first argument.
+   If an array of which the size is not known comes, the size of that array follows.
+  
+  Definition of update function is divided to named_gates, single_target_qubit_gates, multiple_target_qubit_gates, QFT_gates
+ */
+
+
+#pragma once
+
+#include "type.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+DllExport void dm_normalize(double norm, CTYPE* state, ITYPE dim);
+DllExport void dm_single_qubit_dense_matrix_gate(UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim);
+DllExport void dm_multi_qubit_control_single_qubit_dense_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim);
+DllExport void dm_multi_qubit_dense_matrix_gate(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim);
+DllExport void dm_multi_qubit_control_multi_qubit_dense_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim);
+
+
+DllExport void dm_X_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_Y_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_Z_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_S_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_Sdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_T_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_Tdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_sqrtX_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_sqrtXdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_sqrtY_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_sqrtYdag_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim);
+DllExport void dm_H_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_CNOT_gate(UINT control_qubit_index, UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_CZ_gate(UINT control_qubit_index, UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_SWAP_gate(UINT target_qubit_index_0, UINT target_qubit_index_1, CTYPE *state, ITYPE dim);
+DllExport void dm_P0_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_P1_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
+DllExport void dm_RX_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim);
+DllExport void dm_RY_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim);
+DllExport void dm_RZ_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim);

--- a/src/csim/update_ops_dm.h
+++ b/src/csim/update_ops_dm.h
@@ -43,3 +43,5 @@ DllExport void dm_P1_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim);
 DllExport void dm_RX_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim);
 DllExport void dm_RY_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim);
 DllExport void dm_RZ_gate(UINT target_qubit_index, double angle, CTYPE* state, ITYPE dim);
+DllExport void dm_multi_qubit_Pauli_gate_partial_list(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, CTYPE* state, ITYPE dim);
+DllExport void dm_multi_qubit_Pauli_rotation_gate_partial_list(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, double angle, CTYPE* state, ITYPE dim);

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1117,3 +1117,27 @@ TEST(GateTest, ReversibleBooleanGate) {
 	std::cout << state.to_string() << std::endl;
 	*/
 }
+
+TEST(GateTest, TestNoise) {
+	const UINT n = 10;
+	QuantumState state(n);
+	Random random;
+	auto bitflip = gate::BitFlipNoise(0, random.uniform());
+	auto dephase = gate::DephasingNoise(0, random.uniform());
+	auto independetxz = gate::IndependentXZNoise(0, random.uniform());
+	auto depolarizing = gate::DepolarizingNoise(0, random.uniform());
+	auto amp_damp = gate::AmplitudeDampingNoise(0, random.uniform());
+	auto measurement = gate::Measurement(0, 0);
+	bitflip->update_quantum_state(&state);
+	dephase->update_quantum_state(&state);
+	independetxz->update_quantum_state(&state);
+	depolarizing->update_quantum_state(&state);
+	amp_damp->update_quantum_state(&state);
+	measurement->update_quantum_state(&state);
+	delete bitflip;
+	delete dephase;
+	delete independetxz;
+	delete depolarizing;
+	delete amp_damp;
+	delete measurement;
+}

--- a/test/cppsim/test_gate_dm.cpp
+++ b/test/cppsim/test_gate_dm.cpp
@@ -1,0 +1,915 @@
+#include <gtest/gtest.h>
+#include "../util/util.h"
+
+#include <cmath>
+#include <cppsim/state_dm.hpp>
+#include <cppsim/gate_factory.hpp>
+#include <cppsim/gate.hpp>
+#include <cppsim/gate_matrix.hpp>
+#include <cppsim/gate_merge.hpp>
+#include <cppsim/pauli_operator.hpp>
+
+#include <cppsim/utility.hpp>
+#include <csim/update_ops.h>
+#include <functional>
+
+
+
+TEST(DensityMatrixGateTest, ApplySingleQubitGate) {
+
+	Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2), H(2, 2), S(2, 2), T(2, 2), sqrtX(2, 2), sqrtY(2, 2), P0(2, 2), P1(2, 2);
+
+	Identity << 1, 0, 0, 1;
+	X << 0, 1, 1, 0;
+	Y << 0, -1.i, 1.i, 0;
+	Z << 1, 0, 0, -1;
+	H << 1, 1, 1, -1; H /= sqrt(2.);
+	S << 1, 0, 0, 1.i;
+	T << 1, 0, 0, (1. + 1.i) / sqrt(2.);
+	sqrtX << 0.5 + 0.5i, 0.5 - 0.5i, 0.5 - 0.5i, 0.5 + 0.5i;
+	sqrtY << 0.5 + 0.5i, -0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i;
+	P0 << 1, 0, 0, 0;
+	P1 << 0, 0, 0, 1;
+
+
+	const UINT n = 5;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+
+	Random random;
+	DensityMatrix state(n);
+	std::vector< std::pair< std::function<QuantumGateBase*(UINT)>, Eigen::MatrixXcd >> funclist;
+	funclist.push_back(std::make_pair(gate::Identity, Identity));
+	funclist.push_back(std::make_pair(gate::X, X));
+	funclist.push_back(std::make_pair(gate::Y, Y));
+	funclist.push_back(std::make_pair(gate::Z, Z));
+	funclist.push_back(std::make_pair(gate::H, H));
+	funclist.push_back(std::make_pair(gate::S, S));
+	funclist.push_back(std::make_pair(gate::Sdag, S.adjoint()));
+	funclist.push_back(std::make_pair(gate::T, T));
+	funclist.push_back(std::make_pair(gate::Tdag, T.adjoint()));
+	funclist.push_back(std::make_pair(gate::sqrtX, sqrtX));
+	funclist.push_back(std::make_pair(gate::sqrtXdag, sqrtX.adjoint()));
+	funclist.push_back(std::make_pair(gate::sqrtY, sqrtY));
+	funclist.push_back(std::make_pair(gate::sqrtYdag, sqrtY.adjoint()));
+	funclist.push_back(std::make_pair(gate::P0, P0));
+	funclist.push_back(std::make_pair(gate::P1, P1));
+
+	QuantumState test_state(n);
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		for (auto func_mat : funclist) {
+			auto func = func_mat.first;
+			auto mat = func_mat.second;
+			UINT target = random.int32() % n;
+
+			test_state.set_Haar_random_state();
+			state.load(&test_state);
+
+			auto gate = func(target);
+			gate->update_quantum_state(&state);
+			gate->update_quantum_state(&test_state);
+			ComplexMatrix small_mat;
+			gate->set_matrix(small_mat);
+
+			DensityMatrix dm_test(n);
+			dm_test.load(&test_state);
+			for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+		}
+	}
+}
+
+
+TEST(DensityMatrixGateTest, ApplySingleQubitRotationGate) {
+
+	Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
+
+	Identity << 1, 0, 0, 1;
+	X << 0, 1, 1, 0;
+	Y << 0, -1.i, 1.i, 0;
+	Z << 1, 0, 0, -1;
+
+	const UINT n = 5;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector< std::pair< std::function<QuantumGateBase*(UINT, double)>, Eigen::MatrixXcd >> funclist;
+	funclist.push_back(std::make_pair(gate::RX, X));
+	funclist.push_back(std::make_pair(gate::RY, Y));
+	funclist.push_back(std::make_pair(gate::RZ, Z));
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		for (auto func_mat : funclist) {
+			UINT target = random.int32() % n;
+			double angle = random.uniform() * 3.14159;
+
+			auto func = func_mat.first;
+			auto mat = cos(angle / 2) * Eigen::MatrixXcd::Identity(2, 2) + 1.i * sin(angle / 2)* func_mat.second;
+
+			test_state.set_Haar_random_state();
+			state.load(&test_state);
+
+			auto gate = func(target, angle);
+			gate->update_quantum_state(&state);
+			gate->update_quantum_state(&test_state);
+
+			DensityMatrix dm_test(n);
+			dm_test.load(&test_state);
+			for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+		}
+	}
+}
+
+TEST(DensityMatrixGateTest, ApplyTwoQubitGate) {
+
+	const UINT n = 5;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector< std::pair< std::function<QuantumGateBase*(UINT, UINT)>, std::function<Eigen::MatrixXcd(UINT, UINT, UINT)>>> funclist;
+	funclist.push_back(std::make_pair(gate::CNOT, get_eigen_matrix_full_qubit_CNOT));
+	funclist.push_back(std::make_pair(gate::CZ, get_eigen_matrix_full_qubit_CZ));
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		for (auto func_mat : funclist) {
+			UINT control = random.int32() % n;
+			UINT target = random.int32() % n;
+			if (target == control) target = (target + 1) % n;
+
+			auto func = func_mat.first;
+			auto func_eig = func_mat.second;
+
+			test_state.set_Haar_random_state();
+			state.load(&test_state);
+
+			// update state
+			auto gate = func(control, target);
+			gate->update_quantum_state(&state);
+			gate->update_quantum_state(&test_state);
+
+			DensityMatrix dm_test(n);
+			dm_test.load(&test_state);
+			for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+		}
+	}
+
+	funclist.clear();
+	funclist.push_back(std::make_pair(gate::SWAP, get_eigen_matrix_full_qubit_SWAP));
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		for (auto func_mat : funclist) {
+			UINT control = random.int32() % n;
+			UINT target = random.int32() % n;
+			if (target == control) target = (target + 1) % n;
+
+			auto func = func_mat.first;
+			auto func_eig = func_mat.second;
+
+			test_state.set_Haar_random_state();
+			state.load(&test_state);
+
+			auto gate = func(control, target);
+			gate->update_quantum_state(&state);
+			gate->update_quantum_state(&test_state);
+
+			DensityMatrix dm_test(n);
+			dm_test.load(&test_state);
+			for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+		}
+	}
+}
+
+
+TEST(DensityMatrixGateTest, ApplyMultiQubitGate) {
+
+	const UINT n = 1;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector< std::pair< std::function<QuantumGateBase*(UINT, UINT)>, std::function<Eigen::MatrixXcd(UINT, UINT, UINT)>>> funclist;
+
+	//gate::DenseMatrix
+	//gate::Pauli
+	//gate::PauliRotation
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		PauliOperator pauli(1.0);
+		for (UINT i = 0; i < n; ++i) {
+			pauli.add_single_Pauli(i, random.int32() % 4);
+		}
+		auto gate = gate::Pauli(pauli.get_index_list(), pauli.get_pauli_id_list());
+		gate->update_quantum_state(&state);
+		gate->update_quantum_state(&test_state);
+
+		DensityMatrix dm_test(n);
+		dm_test.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+	}
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		PauliOperator pauli(1.0);
+		for (UINT i = 0; i < n; ++i) {
+			pauli.add_single_Pauli(i, random.int32() % 4);
+		}
+		double angle = random.uniform()*3.14159;
+
+		auto gate = gate::PauliRotation(pauli.get_index_list(), pauli.get_pauli_id_list(), angle);
+
+		gate->update_quantum_state(&state);
+		gate->update_quantum_state(&test_state);
+
+		DensityMatrix dm_test(n);
+		dm_test.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+	}
+
+}
+
+
+TEST(DensityMatrixGateTest, MergeTensorProduct) {
+	UINT n = 2;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	auto x0 = gate::X(0);
+	auto y1 = gate::Y(1);
+	auto xy01 = gate::merge(x0, y1);
+
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	test_state.set_Haar_random_state();
+	state.load(&test_state);
+
+	xy01->update_quantum_state(&state);
+	xy01->update_quantum_state(&test_state);
+
+	DensityMatrix dm(n);
+	dm.load(&test_state);
+	for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim +j] - dm.data_cpp()[i*dim+j]), 0, eps);
+
+	delete x0;
+	delete y1;
+	delete xy01;
+}
+
+TEST(DensityMatrixGateTest, MergeMultiply) {
+	UINT n = 1;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+	auto x0 = gate::X(0);
+	auto y0 = gate::Y(0);
+
+	//  U_{z0} = YX = -iZ
+	auto xy00 = gate::merge(x0, y0);
+
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	Eigen::VectorXcd test_state_eigen(dim);
+	test_state.set_Haar_random_state();
+	state.load(&test_state);
+
+	xy00->update_quantum_state(&state);
+	xy00->update_quantum_state(&test_state);
+
+	DensityMatrix dm(n);
+	dm.load(&test_state);
+	for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+
+	delete x0;
+	delete y0;
+	delete xy00;
+}
+
+TEST(DensityMatrixGateTest, MergeTensorProductAndMultiply) {
+	UINT n = 2;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	auto x0 = gate::X(0);
+	auto y1 = gate::Y(1);
+	auto xy01 = gate::merge(x0, y1);
+	auto iy01 = gate::merge(xy01, x0);
+
+	// Expected : x_0 y_1 x_0 = y_1
+
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	test_state.set_Haar_random_state();
+	state.load(&test_state);
+
+	iy01->update_quantum_state(&state);
+	iy01->update_quantum_state(&test_state);
+
+	DensityMatrix dm(n);
+	dm.load(&test_state);
+	for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+
+	delete x0;
+	delete y1;
+	delete xy01;
+	delete iy01;
+}
+
+TEST(DensityMatrixGateTest, RandomPauliMerge) {
+	UINT n = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	UINT max_repeat = 3;
+	Random random;
+	random.set_seed(2);
+
+	std::vector<UINT> new_pauli_ids = { 0,0,0,1 };
+	std::vector<UINT> targets = { 0,1,2,2 };
+
+	// define states
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+
+	for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+		// pick random state and copy to test
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		auto merged_gate = gate::Identity(0);
+		QuantumGateMatrix* next_merged_gate = NULL;
+		QuantumGateBase* new_gate = NULL;
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+
+			// pick random pauli
+			UINT new_pauli_id = random.int32() % 4;
+			UINT target = random.int32() % n;
+			if (new_pauli_id == 0) new_gate = gate::Identity(target);
+			else if (new_pauli_id == 1) new_gate = gate::X(target);
+			else if (new_pauli_id == 2) new_gate = gate::Y(target);
+			else if (new_pauli_id == 3) new_gate = gate::Z(target);
+			else FAIL();
+
+			// create new gate with merge
+			next_merged_gate = gate::merge(merged_gate, new_gate);
+			delete merged_gate;
+			merged_gate = next_merged_gate;
+			next_merged_gate = NULL;
+
+			delete new_gate;
+		}
+		merged_gate->update_quantum_state(&state);
+		merged_gate->update_quantum_state(&test_state);
+
+		DensityMatrix dm(n);
+		dm.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+
+		delete merged_gate;
+
+	}
+}
+
+TEST(DensityMatrixGateTest, RandomPauliRotationMerge) {
+	UINT n = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	UINT max_repeat = 3;
+	Random random;
+	random.set_seed(2);
+
+	std::vector<UINT> new_pauli_ids = { 0,0,0,1 };
+	std::vector<UINT> targets = { 0,1,2,2 };
+
+	// define states
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+
+	for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+		// pick random state and copy to test
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		auto merged_gate = gate::Identity(0);
+		QuantumGateMatrix* next_merged_gate = NULL;
+		QuantumGateBase* new_gate = NULL;
+
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+
+			// pick random pauli
+			UINT new_pauli_id = (random.int32() % 3) + 1;
+			UINT target = random.int32() % n;
+			double angle = random.uniform() * 3.14159;
+			if (new_pauli_id == 1) new_gate = gate::RX(target, angle);
+			else if (new_pauli_id == 2) new_gate = gate::RY(target, angle);
+			else if (new_pauli_id == 3) new_gate = gate::RZ(target, angle);
+			else FAIL();
+
+			// create new gate with merge
+			next_merged_gate = gate::merge(merged_gate, new_gate);
+			delete merged_gate;
+			merged_gate = next_merged_gate;
+			next_merged_gate = NULL;
+			delete new_gate;
+		}
+		merged_gate->update_quantum_state(&state);
+		merged_gate->update_quantum_state(&test_state);
+		delete merged_gate;
+
+		DensityMatrix dm(n);
+		dm.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+TEST(DensityMatrixGateTest, RandomUnitaryMerge) {
+	UINT n = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	UINT max_repeat = 3;
+	Random random;
+	random.set_seed(2);
+
+	std::vector<UINT> new_pauli_ids = { 0,0,0,1 };
+	std::vector<UINT> targets = { 0,1,2,2 };
+
+	// define states
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+
+	for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+		// pick random state and copy to test
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		auto merged_gate = gate::Identity(0);
+		QuantumGateMatrix* next_merged_gate = NULL;
+		QuantumGateBase* new_gate = NULL;
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+
+			// pick random pauli
+			UINT new_pauli_id = (random.int32() % 3) + 1;
+			UINT target = random.int32() % n;
+			double di = random.uniform();
+			double dx = random.uniform();
+			double dy = random.uniform();
+			double dz = random.uniform();
+			double norm = sqrt(di * di + dx * dx + dy * dy + dz * dz);
+			di /= norm; dx /= norm; dy /= norm; dz /= norm;
+			ComplexMatrix mat = di * get_eigen_matrix_single_Pauli(0) + 1.i*(dx*get_eigen_matrix_single_Pauli(1) + dy * get_eigen_matrix_single_Pauli(2) + dz * get_eigen_matrix_single_Pauli(3));
+
+			auto new_gate = gate::DenseMatrix(target, mat);
+
+			// create new gate with merge
+			next_merged_gate = gate::merge(merged_gate, new_gate);
+			delete merged_gate;
+			merged_gate = next_merged_gate;
+			next_merged_gate = NULL;
+
+			// dispose picked pauli
+			delete new_gate;
+		}
+		merged_gate->update_quantum_state(&state);
+		merged_gate->update_quantum_state(&test_state);
+		delete merged_gate;
+
+		DensityMatrix dm(n);
+		dm.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+TEST(DensityMatrixGateTest, RandomUnitaryMergeLarge) {
+	UINT n = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 5;
+	UINT max_repeat = 2;
+	Random random;
+	random.set_seed(2);
+
+	std::vector<UINT> new_pauli_ids = { 0,0,0,1 };
+	std::vector<UINT> targets = { 0,1,2,2 };
+
+	// define states
+	DensityMatrix state(n),state2(n);
+	QuantumState test_state(n);
+	
+	for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+		// pick random state and copy to test
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+		state2.load(&test_state);
+
+		auto merged_gate1 = gate::Identity(0);
+		auto merged_gate2 = gate::Identity(0);
+		QuantumGateMatrix* next_merged_gate = NULL;
+		QuantumGateBase* new_gate = NULL;
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+			// pick random pauli
+			UINT new_pauli_id = (random.int32() % 3) + 1;
+			UINT target = random.int32() % n;
+			double di = random.uniform();
+			double dx = random.uniform();
+			double dy = random.uniform();
+			double dz = random.uniform();
+			double norm = sqrt(di * di + dx * dx + dy * dy + dz * dz);
+			di /= norm; dx /= norm; dy /= norm; dz /= norm;
+			ComplexMatrix mat = di * get_eigen_matrix_single_Pauli(0) + 1.i*(dx*get_eigen_matrix_single_Pauli(1) + dy * get_eigen_matrix_single_Pauli(2) + dz * get_eigen_matrix_single_Pauli(3));
+
+			auto new_gate = gate::DenseMatrix(target, mat);
+
+			// create new gate with merge
+			next_merged_gate = gate::merge(merged_gate1, new_gate);
+			delete merged_gate1;
+			merged_gate1 = next_merged_gate;
+			next_merged_gate = NULL;
+
+			// dispose picked pauli
+			delete new_gate;
+		}
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+			// pick random pauli
+			UINT new_pauli_id = (random.int32() % 3) + 1;
+			UINT target = random.int32() % n;
+			double di = random.uniform();
+			double dx = random.uniform();
+			double dy = random.uniform();
+			double dz = random.uniform();
+			double norm = sqrt(di * di + dx * dx + dy * dy + dz * dz);
+			di /= norm; dx /= norm; dy /= norm; dz /= norm;
+			ComplexMatrix mat = di * get_eigen_matrix_single_Pauli(0) + 1.i*(dx*get_eigen_matrix_single_Pauli(1) + dy * get_eigen_matrix_single_Pauli(2) + dz * get_eigen_matrix_single_Pauli(3));
+
+			auto new_gate = gate::DenseMatrix(target, mat);
+
+			// create new gate with merge
+			next_merged_gate = gate::merge(merged_gate2, new_gate);
+			delete merged_gate2;
+			merged_gate2 = next_merged_gate;
+			next_merged_gate = NULL;
+
+			// dispose picked pauli
+			delete new_gate;
+		}
+		auto merged_gate = gate::merge(merged_gate1, merged_gate2);
+		merged_gate->update_quantum_state(&state);
+		merged_gate->update_quantum_state(&test_state);
+		merged_gate1->update_quantum_state(&state2);
+		merged_gate2->update_quantum_state(&state2);
+
+		delete merged_gate;
+		delete merged_gate1;
+		delete merged_gate2;
+
+		// check equivalence
+		DensityMatrix dm(n);
+		dm.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - state2.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+
+TEST(DensityMatrixGateTest, RandomControlMergeSmall) {
+	UINT n = 4;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	Random random;
+
+	std::vector<UINT> arr;
+	for (UINT i = 0; i < n; ++i) arr.push_back(i);
+
+	for (gate_count = 1; gate_count < n * 2; ++gate_count) {
+		ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
+		DensityMatrix state(n);
+		QuantumState test_state(n);
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		auto merge_gate1 = gate::Identity(0);
+		auto merge_gate2 = gate::Identity(0);
+
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+			std::random_shuffle(arr.begin(), arr.end());
+			UINT target = arr[0];
+			UINT control = arr[1];
+			auto new_gate = gate::CNOT(control, target);
+			merge_gate1 = gate::merge(merge_gate1, new_gate);
+
+			auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
+			mat = cmat * mat;
+		}
+		merge_gate1->update_quantum_state(&state);
+		merge_gate1->update_quantum_state(&test_state);
+
+		DensityMatrix dm(n);
+		dm.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+
+TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
+	UINT n = 4;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	Random random;
+
+	std::vector<UINT> arr;
+	for (UINT i = 0; i < n; ++i) arr.push_back(i);
+
+	for (gate_count = 1; gate_count < n * 2; ++gate_count) {
+		ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
+		DensityMatrix state(n), state2(n);
+		QuantumState test_state(n);
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+		state2.load(&test_state);
+
+		auto merge_gate1 = gate::Identity(0);
+		auto merge_gate2 = gate::Identity(0);
+
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+			std::random_shuffle(arr.begin(), arr.end());
+			UINT target = arr[0];
+			UINT control = arr[1];
+			auto new_gate = gate::CNOT(control, target);
+			merge_gate1 = gate::merge(merge_gate1, new_gate);
+
+			auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
+			mat = cmat * mat;
+		}
+
+		for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+			std::random_shuffle(arr.begin(), arr.end());
+			UINT target = arr[0];
+			UINT control = arr[1];
+			auto new_gate = gate::CNOT(control, target);
+			merge_gate2 = gate::merge(merge_gate2, new_gate);
+
+			auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
+			mat = cmat * mat;
+		}
+
+		auto merge_gate = gate::merge(merge_gate1, merge_gate2);
+		merge_gate->update_quantum_state(&state);
+		merge_gate->update_quantum_state(&test_state);
+		merge_gate1->update_quantum_state(&state2);
+		merge_gate2->update_quantum_state(&state2);
+
+		DensityMatrix dm(n);
+		dm.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm.data_cpp()[i*dim + j]), 0, eps);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - state2.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+
+TEST(DensityMatrixGateTest, ProbabilisticGate) {
+	auto gate1 = gate::X(0);
+	auto gate2 = gate::X(1);
+	auto gate3 = gate::X(2);
+	auto prob_gate = gate::Probabilistic({ 0.25,0.25,0.25 }, { gate1, gate2, gate2 });
+	DensityMatrix s(3);
+	s.set_computational_basis(0);
+	prob_gate->update_quantum_state(&s);
+	delete gate1;
+	delete gate2;
+	delete gate3;
+	delete prob_gate;
+}
+
+TEST(DensityMatrixGateTest, CPTPGate) {
+	auto gate1 = gate::merge(gate::P0(0), gate::P0(1));
+	auto gate2 = gate::merge(gate::P0(0), gate::P1(1));
+	auto gate3 = gate::merge(gate::P1(0), gate::P0(1));
+	auto gate4 = gate::merge(gate::P1(0), gate::P1(1));
+
+	auto CPTP = gate::CPTP({ gate3, gate2, gate1, gate4 });
+	DensityMatrix s(3);
+	s.set_computational_basis(0);
+	CPTP->update_quantum_state(&s);
+	s.set_Haar_random_state();
+	CPTP->update_quantum_state(&s);
+	delete CPTP;
+}
+
+TEST(DensityMatrixGateTest, InstrumentGate) {
+	auto gate1 = gate::merge(gate::P0(0), gate::P0(1));
+	auto gate2 = gate::merge(gate::P0(0), gate::P1(1));
+	auto gate3 = gate::merge(gate::P1(0), gate::P0(1));
+	auto gate4 = gate::merge(gate::P1(0), gate::P1(1));
+
+	auto Inst = gate::Instrument({ gate3, gate2, gate1, gate4 }, 1);
+	DensityMatrix s(3);
+	s.set_computational_basis(0);
+	Inst->update_quantum_state(&s);
+	UINT res1 = s.get_classical_value(1);
+	ASSERT_EQ(res1, 2);
+	s.set_Haar_random_state();
+	Inst->update_quantum_state(&s);
+	UINT res2 = s.get_classical_value(1);
+	delete Inst;
+}
+
+TEST(DensityMatrixGateTest, AdaptiveGate) {
+	auto x = gate::X(0);
+	auto adaptive = gate::Adaptive(x, [](const std::vector<UINT>& vec) { return vec[2] == 1; });
+	DensityMatrix s(1);
+	s.set_computational_basis(0);
+	s.set_classical_value(2, 1);
+	adaptive->update_quantum_state(&s);
+	s.set_classical_value(2, 0);
+	adaptive->update_quantum_state(&s);
+	delete adaptive;
+}
+
+
+
+
+
+TEST(DensityMatrixGateTest, MultiTarget) {
+	const UINT n = 8;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+	const UINT target_count = 5;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector<UINT> arr;
+	for (UINT i = 0; i < n; ++i) arr.push_back(i);
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		std::random_shuffle(arr.begin(), arr.end());
+		std::vector<UINT> target_list;
+		for (UINT i = 0; i < target_count; ++i) target_list.push_back(arr[i]);
+		auto gate = gate::RandomUnitary(target_list);
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		// update state
+		gate->update_quantum_state(&state);
+		gate->update_quantum_state(&test_state);
+		delete gate;
+
+		DensityMatrix dm_test(n);
+		dm_test.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+
+TEST(DensityMatrixGateTest, MultiControlSingleTarget) {
+	const UINT n = 8;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+	const UINT control_count = 3;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector<UINT> arr;
+	for (UINT i = 0; i < n; ++i) arr.push_back(i);
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		std::random_shuffle(arr.begin(), arr.end());
+		std::vector<UINT> target_list;
+		target_list.push_back(arr[0]);
+		auto gate = gate::RandomUnitary(target_list);
+		for (UINT i = 0; i < control_count; ++i) {
+			gate->add_control_qubit(arr[i + 1], random.int32() % 2);
+		}
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		// update state
+		gate->update_quantum_state(&state);
+		gate->update_quantum_state(&test_state);
+		delete gate;
+
+		DensityMatrix dm_test(n);
+		dm_test.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+
+TEST(DensityMatrixGateTest, SingleControlMultiTarget) {
+	const UINT n = 8;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+	const UINT target_count = 3;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector<UINT> arr;
+	for (UINT i = 0; i < n; ++i) arr.push_back(i);
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		std::random_shuffle(arr.begin(), arr.end());
+		std::vector<UINT> target_list;
+		for (UINT i = 0; i < target_count; ++i) target_list.push_back(arr[i]);
+		UINT control = arr[target_count+1];
+		UINT control_value = random.int32() % 2;
+		auto gate = gate::RandomUnitary(target_list);
+		gate->add_control_qubit(control, control_value);
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		// update state
+		gate->update_quantum_state(&state);
+		gate->update_quantum_state(&test_state);
+		delete gate;
+
+		DensityMatrix dm_test(n);
+		dm_test.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+TEST(DensityMatrixGateTest, MultiControlMultiTarget) {
+	const UINT n = 8;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+	const UINT control_count = 3;
+	const UINT target_count = 3;
+
+	Random random;
+	DensityMatrix state(n);
+	QuantumState test_state(n);
+	std::vector<UINT> arr;
+	for (UINT i = 0; i < n; ++i) arr.push_back(i);
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		std::random_shuffle(arr.begin(), arr.end());
+		std::vector<UINT> target_list;
+		for (UINT i = 0; i < target_count; ++i) target_list.push_back(arr[i]);
+		auto gate = gate::RandomUnitary(target_list);
+		for (UINT i = 0; i < control_count; ++i) {
+			gate->add_control_qubit(arr[target_count + i], random.int32() % 2);
+		}
+
+		test_state.set_Haar_random_state();
+		state.load(&test_state);
+
+		// update state
+		gate->update_quantum_state(&state);
+		gate->update_quantum_state(&test_state);
+		delete gate;
+
+		DensityMatrix dm_test(n);
+		dm_test.load(&test_state);
+		for (ITYPE i = 0; i < dim; ++i) for (ITYPE j = 0; j < dim; ++j) ASSERT_NEAR(abs(state.data_cpp()[i*dim + j] - dm_test.data_cpp()[i*dim + j]), 0, eps);
+	}
+}
+
+/*
+// not implemented yet
+TEST(DensityMatrixGateTest, ReversibleBooleanGate) {
+	const double eps = 1e-14;
+	std::function<ITYPE(ITYPE, ITYPE)> func = [](ITYPE index, ITYPE dim) -> ITYPE {
+		return (index + 1) % dim;
+	};
+	std::vector<UINT> target_qubit = { 2,0 };
+	auto gate = gate::ReversibleBoolean(target_qubit, func);
+	ComplexMatrix cm;
+	gate->set_matrix(cm);
+	QuantumState state(3);
+	gate->update_quantum_state(&state);
+	ASSERT_NEAR(abs(state.data_cpp()[4] - 1.), 0, eps);
+	gate->update_quantum_state(&state);
+	ASSERT_NEAR(abs(state.data_cpp()[1] - 1.), 0, eps);
+	gate->update_quantum_state(&state);
+	ASSERT_NEAR(abs(state.data_cpp()[5] - 1.), 0, eps);
+	gate->update_quantum_state(&state);
+	ASSERT_NEAR(abs(state.data_cpp()[0] - 1.), 0, eps);
+}
+
+*/

--- a/test/cppsim/test_hamiltonian_dm.cpp
+++ b/test/cppsim/test_hamiltonian_dm.cpp
@@ -1,0 +1,161 @@
+#include <gtest/gtest.h>
+#include <csim/constant.h>
+#include <cppsim/type.hpp>
+#include "../util/util.h"
+#include <cppsim/state.hpp>
+#include <cppsim/state_dm.hpp>
+#include <cppsim/circuit.hpp>
+#include <cppsim/observable.hpp>
+#include <cppsim/pauli_operator.hpp>
+#include <cppsim/utility.hpp>
+#include <fstream>
+
+
+
+TEST(DensityMatrixObservableTest, CheckExpectationValue) {
+	const UINT n = 4;
+	const UINT dim = 1ULL << n;
+	const double eps = 1e-14;
+	double coef;
+	CPPCTYPE res_vec,res_mat;
+	CPPCTYPE test_res;
+	Random random;
+
+	Eigen::MatrixXcd X(2, 2);
+	X << 0, 1, 1, 0;
+
+	QuantumState vector_state(n);
+	DensityMatrix density_matrix(n);
+	vector_state.set_computational_basis(0);
+	density_matrix.load(&vector_state);
+
+	coef = random.uniform();
+	Observable observable(n);
+	observable.add_operator(coef, "X 0");
+
+	res_vec = observable.get_expectation_value(&vector_state);
+	res_mat = observable.get_expectation_value(&density_matrix);
+	ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
+	ASSERT_NEAR(res_vec.imag(), 0, eps);
+	ASSERT_NEAR(res_mat.imag(), 0, eps);
+
+	vector_state.set_Haar_random_state();
+	density_matrix.load(&vector_state);
+	res_vec = observable.get_expectation_value(&vector_state);
+	res_mat = observable.get_expectation_value(&density_matrix);
+	ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
+	ASSERT_NEAR(res_vec.imag(), 0, eps);
+	ASSERT_NEAR(res_mat.imag(), 0, eps);
+
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+
+		Observable rand_observable(n);
+		Eigen::MatrixXcd test_rand_observable = Eigen::MatrixXcd::Zero(dim, dim);
+
+		UINT term_count = random.int32() % 10 + 1;
+		for (UINT term = 0; term < term_count; ++term) {
+			std::vector<UINT> paulis(n, 0);
+			Eigen::MatrixXcd test_rand_observable_term = Eigen::MatrixXcd::Identity(dim, dim);
+			coef = random.uniform();
+			for (UINT i = 0; i < paulis.size(); ++i) {
+				paulis[i] = random.int32() % 4;
+
+				test_rand_observable_term *= get_expanded_eigen_matrix_with_identity(i, get_eigen_matrix_single_Pauli(paulis[i]), n);
+			}
+			test_rand_observable += coef * test_rand_observable_term;
+
+			std::string str = "";
+			for (UINT ind = 0; ind < paulis.size(); ind++) {
+				UINT val = paulis[ind];
+				if (val != 0) {
+					if (val == 1) str += " X";
+					else if (val == 2) str += " Y";
+					else if (val == 3) str += " Z";
+					str += " " + std::to_string(ind);
+				}
+			}
+			rand_observable.add_operator(coef, str.c_str());
+		}
+
+		vector_state.set_Haar_random_state();
+		density_matrix.load(&vector_state);
+
+		res_vec = observable.get_expectation_value(&vector_state);
+		res_mat = observable.get_expectation_value(&density_matrix);
+		ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
+		ASSERT_NEAR(res_vec.imag(), 0, eps);
+		ASSERT_NEAR(res_mat.imag(), 0, eps);
+	}
+}
+
+
+TEST(DensityMatrixObservableTest, CheckParsedObservableFromOpenFermionText) {
+	auto func = [](const std::string str, const QuantumStateBase* state) -> CPPCTYPE {
+		CPPCTYPE energy = 0;
+
+		std::vector<std::string> lines = split(str, "\n");
+
+		for (std::string line : lines) {
+			// std::cout << state->get_norm() << std::endl;
+
+			std::vector<std::string> elems;
+			elems = split(line, "()j[]+");
+
+			chfmt(elems[3]);
+
+			CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
+			// std::cout << elems[3].c_str() << std::endl;
+
+			PauliOperator mpt(elems[3].c_str(), coef.real());
+
+			// std::cout << mpt.get_coef() << " ";
+			// std::cout << elems[3].c_str() << std::endl;
+			energy += mpt.get_expectation_value(state);
+			// mpt.get_expectation_value(state);
+
+		}
+		return energy;
+	};
+
+	const double eps = 1e-14;
+	const std::string text = "(-0.8126100000000005+0j) [] +\n"
+		"(0.04532175+0j) [X0 Z1 X2] +\n"
+		"(0.04532175+0j) [X0 Z1 X2 Z3] +\n"
+		"(0.04532175+0j) [Y0 Z1 Y2] +\n"
+		"(0.04532175+0j) [Y0 Z1 Y2 Z3] +\n"
+		"(0.17120100000000002+0j) [Z0] +\n"
+		"(0.17120100000000002+0j) [Z0 Z1] +\n"
+		"(0.165868+0j) [Z0 Z1 Z2] +\n"
+		"(0.165868+0j) [Z0 Z1 Z2 Z3] +\n"
+		"(0.12054625+0j) [Z0 Z2] +\n"
+		"(0.12054625+0j) [Z0 Z2 Z3] +\n"
+		"(0.16862325+0j) [Z1] +\n"
+		"(-0.22279649999999998+0j) [Z1 Z2 Z3] +\n"
+		"(0.17434925+0j) [Z1 Z3] +\n"
+		"(-0.22279649999999998+0j) [Z2]";
+
+	CPPCTYPE res_vec, res_mat;
+
+	Observable* observable;
+	observable = observable::create_observable_from_openfermion_text(text);
+	ASSERT_NE(observable, (Observable*)NULL);
+	UINT qubit_count = observable->get_qubit_count();
+
+	QuantumState vector_state(qubit_count);
+	DensityMatrix density_matrix(qubit_count);
+
+	vector_state.set_computational_basis(0);
+	density_matrix.load(&vector_state);
+	res_vec = observable->get_expectation_value(&vector_state);
+	res_mat = observable->get_expectation_value(&density_matrix);
+	ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
+	ASSERT_NEAR(res_vec.imag(), res_mat.imag(), eps);
+
+
+	vector_state.set_Haar_random_state();
+	density_matrix.load(&vector_state);
+	res_vec = observable->get_expectation_value(&vector_state);
+	res_mat = observable->get_expectation_value(&density_matrix);
+	ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
+	ASSERT_NEAR(res_vec.imag(), res_mat.imag(), eps);
+}

--- a/test/cppsim/test_state_dm.cpp
+++ b/test/cppsim/test_state_dm.cpp
@@ -38,9 +38,9 @@ TEST(DensityMatrixTest, Sampling) {
 	UINT n = 5;
 	DensityMatrix state(n);
 	state.set_Haar_random_state();
-	state.set_computational_basis(100);
+	state.set_computational_basis(10);
 	auto res1 = state.sampling(1024);
-	state.set_computational_basis(100);
+	state.set_computational_basis(10);
 	auto res2 = state.sampling(1024);
 }
 

--- a/test/cppsim/test_state_dm.cpp
+++ b/test/cppsim/test_state_dm.cpp
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+#include "../util/util.h"
+#include <cppsim/state_dm.hpp>
+#include <cppsim/utility.hpp>
+
+TEST(DensityMatrixTest, GenerateAndRelease) {
+	UINT n = 5;
+	double eps = 1e-14;
+	const ITYPE dim = 1ULL << n;
+	DensityMatrix state(n);
+	ASSERT_EQ(state.qubit_count, n);
+	ASSERT_EQ(state.dim, dim);
+	state.set_zero_state();
+	for (UINT i = 0; i < state.dim; ++i) {
+		for (UINT j = 0; j < state.dim; ++j) {
+			if (i == 0 && j == 0) ASSERT_NEAR(abs(state.data_cpp()[i*dim+j] - 1.), 0, eps);
+			else ASSERT_NEAR(abs(state.data_cpp()[i*dim+j]), 0, eps);
+		}
+	}
+	Random random;
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		ITYPE basis = random.int64() % state.dim;
+		state.set_computational_basis(basis);
+		for (UINT i = 0; i < state.dim; ++i) {
+			for (UINT j = 0; j < state.dim; ++j) {
+				if (i == basis && j == basis) ASSERT_NEAR(abs(state.data_cpp()[i*dim+j] - 1.), 0, eps);
+				else ASSERT_NEAR(abs(state.data_cpp()[i*dim+j]), 0, eps);
+			}
+		}
+	}
+	for (UINT repeat = 0; repeat < 10; ++repeat) {
+		state.set_Haar_random_state();
+		ASSERT_NEAR(state.get_norm(), 1., eps);
+	}
+}
+
+TEST(DensityMatrixTest, Sampling) {
+	UINT n = 5;
+	DensityMatrix state(n);
+	state.set_Haar_random_state();
+	state.set_computational_basis(100);
+	auto res1 = state.sampling(1024);
+	state.set_computational_basis(100);
+	auto res2 = state.sampling(1024);
+}
+
+
+TEST(DensityMatrixTest, SetState) {
+	const double eps = 1e-10;
+	const UINT n = 5;
+	DensityMatrix state(n);
+	const ITYPE dim = 1ULL << n;
+	std::vector<std::complex<double>> state_vector(dim*dim);
+	for (ITYPE i = 0; i < dim; ++i) {
+		for (ITYPE j = 0; j < dim; ++j) {
+			double d = (double)(i*dim+j);
+			state_vector[j*dim + i] = d + std::complex<double>(0, 1)*(d + 0.1);
+		}
+	}
+	state.load(state_vector);
+	for (ITYPE i = 0; i < dim; ++i) {
+		for(ITYPE j=0;j<dim;++j){
+			ASSERT_NEAR(state.data_cpp()[i*dim + j].real(), state_vector[i*dim + j].real(), eps);
+			ASSERT_NEAR(state.data_cpp()[i*dim + j].imag(), state_vector[i*dim + j].imag(), eps);
+		}
+	}
+}
+
+TEST(DensityMatrixTest, GetMarginalProbability) {
+	const double eps = 1e-10;
+	const UINT n = 2;
+	const ITYPE dim = 1 << n;
+	DensityMatrix state(n);
+	state.set_Haar_random_state();
+	std::vector<double> probs;
+	for (ITYPE i = 0; i < dim; ++i) {
+		probs.push_back(real(state.data_cpp()[i*dim+i]));
+	}
+	ASSERT_NEAR(state.get_marginal_probability({ 0,0 }), probs[0], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 1,0 }), probs[1], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 0,1 }), probs[2], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 1,1 }), probs[3], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 0,2 }), probs[0] + probs[2], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 1,2 }), probs[1] + probs[3], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 2,0 }), probs[0] + probs[1], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 2,1 }), probs[2] + probs[3], eps);
+	ASSERT_NEAR(state.get_marginal_probability({ 2,2 }), 1., eps);
+}
+
+
+TEST(DensityMatrixTest, AddState) {
+	const double eps = 1e-10;
+	const UINT n = 5;
+	DensityMatrix state1(n);
+	DensityMatrix state2(n);
+	state1.set_Haar_random_state();
+	state2.set_Haar_random_state();
+
+	const ITYPE dim = 1ULL << n;
+	std::vector<std::complex<double>> state_vector1(dim*dim);
+	std::vector<std::complex<double>> state_vector2(dim*dim);
+	for (ITYPE i = 0; i < dim; ++i) {
+		for (ITYPE j = 0; j < dim; ++j) {
+			state_vector1[i*dim + j] = state1.data_cpp()[i*dim + j];
+			state_vector2[i*dim + j] = state2.data_cpp()[i*dim + j];
+		}
+	}
+
+	state1.add_state(&state2);
+
+	for (ITYPE i = 0; i < dim; ++i) {
+		for (ITYPE j = 0; j < dim; ++j) {
+			ASSERT_NEAR(state1.data_cpp()[i*dim+j].real(), state_vector1[i*dim + j].real() + state_vector2[i*dim + j].real(), eps);
+			ASSERT_NEAR(state1.data_cpp()[i*dim + j].imag(), state_vector1[i*dim + j].imag() + state_vector2[i*dim + j].imag(), eps);
+			ASSERT_NEAR(state2.data_cpp()[i*dim + j].real(), state_vector2[i*dim + j].real(), eps);
+			ASSERT_NEAR(state2.data_cpp()[i*dim + j].imag(), state_vector2[i*dim + j].imag(), eps);
+		}
+	}
+}
+
+TEST(DensityMatrixTest, MultiplyCoef) {
+	const double eps = 1e-10;
+	const UINT n = 10;
+	const std::complex<double> coef(0.5, 0.2);
+
+	DensityMatrix state(n);
+	state.set_Haar_random_state();
+
+	const ITYPE dim = 1ULL << n;
+	std::vector<std::complex<double>> state_vector(dim*dim);
+	for (ITYPE i = 0; i < dim; ++i) {
+		for (ITYPE j = 0; j < dim; ++j) {
+			state_vector[i*dim+j] = state.data_cpp()[i*dim+j] * coef;
+		}
+	}
+	state.multiply_coef(coef);
+
+	for (ITYPE i = 0; i < dim; ++i) {
+		for (ITYPE j = 0; j < dim; ++j) {
+			ASSERT_NEAR(state.data_cpp()[i*dim+j].real(), state_vector[i*dim+j].real(), eps);
+			ASSERT_NEAR(state.data_cpp()[i*dim+j].imag(), state_vector[i*dim+j].imag(), eps);
+		}
+	}
+}


### PR DESCRIPTION
# Overview
Added new class <code>DensityMatrix</code> to qulacs.
Add new noise template <code>AmplitudeDampingNoise</code>.
Bufgix for <code>IndependentXZNoise</code>.

# Amplitude damping noise
You can apply amplitude damping noise with the following codes.
```
state = qulacs.QuantumState(1)
qulacs.gate.X(0).update_quantum_state(state)
noise = qulacs.gate.AmplitudeDampingNoise(0, 0.2)
noise.update_quantum_state(state)
```

# Details of bugs in <code>IndependentXZNoise</code>.
This noise is intended to invoke <code>X</code> and <code>Z</code> with probability <code>p*(1-p)</code> and <code>Y</code> with probability <code>p*p</code>.
However, in the previous versions, the probability of <code>Y</code> was 0.
Now this bug is fixed.

# Usage for <code>DensityMatrix</code>
Replace <code>QuantumState</code> to <code>DensityMatrix</code>
```python
import qulacs
n = 3
dm = qulacs.DensityMatrix(n)
gate = qulacs.gate.X(0)
gate.update_quantum_state(dm)
obs = qulacs.Observable(n)
obs.add_operator(1.5, "Z 0")
res = obs.get_expectation_value(dm)
matrix = dm.get_matrix()
print(res)
print(dm)
```
The above code will output
```
-1.5
 *** Density Matrix ***
 * Qubit Count : 3
 * Dimension   : 8
 * Density matrix :
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (1,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
(0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0) (0,0)
```
Every feature for <code>QuantumState</code> can be used for <code>DensityMatrix</code> with few exceptions (e.g. some gates such as reflection gate and Sparse matrix gate, and functions such as inner_product, get_vector, or get_transition_amplitude).

# Note
- Density matrix simulation requires a few GB at n=15 or 16.
- Some implementations can be improved further. In particular, calculations related to Pauli ops are left inefficient for publishing first draft.
- To avoid name collision, I used prefix <code>dm_*</code> for functions related to density matrix. This may be ugly.
