### PR TITLE
setup.py picks up gcc / g++ command from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
  
 # Qulacs
 [![Build Status](https://travis-ci.org/qulacs/qulacs.svg?branch=master)](https://travis-ci.org/qulacs/qulacs)
+[![Downloads](https://pepy.tech/badge/qulacs)](https://pepy.tech/project/qulacs)
 
 Qulacs is a python/C++ library for fast simulation of large, noisy, or parametric quantum circuits.
 

--- a/setup.py
+++ b/setup.py
@@ -47,22 +47,25 @@ class CMakeBuild(build_ext):
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:
+            env = os.environ.copy()
+            CC = env.get('CC', 'gcc')
+            CXX = env.get('CXX', 'g++')
             try:
-                gcc_out = subprocess.check_output(['gcc', '-dumpfullversion', '-dumpversion']).decode()
+                gcc_out = subprocess.check_output([CC, '-dumpfullversion', '-dumpversion']).decode()
                 gcc_version = LooseVersion(gcc_out)
-                gxx_out = subprocess.check_output(['g++', '-dumpfullversion', '-dumpversion']).decode()
+                gxx_out = subprocess.check_output([CXX, '-dumpfullversion', '-dumpversion']).decode()
                 gxx_version = LooseVersion(gxx_out)
             except OSError:
                 raise RuntimeError("gcc/g++ must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
             if(gcc_version >= LooseVersion('7.0.0')):
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc']
+                cmake_args += ['-DCMAKE_C_COMPILER={}'.format(CC)]
             else:
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc-7']
+                raise RuntimeError("gcc must be >= 7.0.0")
             if(gxx_version >= LooseVersion('7.0.0')):
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++']
+                cmake_args += ['-DCMAKE_CXX_COMPILER={}'.format(CXX)]
             else:
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++-7']
+                raise RuntimeError("g++ must be >= 7.0.0")
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
 


### PR DESCRIPTION
This may conflict with the effort in #121 , but this is a PR for setup.py to use gcc / g++ specified by environment variables.

With this, you can specify the compiler as follows,

```shell
CC=gcc-9 CXX=g++-9 python setup.py install
```

I haven't tried yet, but this should also work when installed through pip if it's ready in PyPI.

```shell
CC=gcc-9 CXX=g++-9 pip install qulacs
```

Because you can now specify the gcc / g++ command explicitly, setup.py will fail if the detected version is smaller than `7.0.0`. Please remove it if it is too much.