### PR TITLE
Parametric gate bugs in gpu state

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include <cppsim/state_gpu.hpp>
 #endif
 
+#include <vqcsim/parametric_gate.hpp>
 #include <vqcsim/parametric_gate_factory.hpp>
 #include <vqcsim/parametric_circuit.hpp>
 
@@ -322,8 +323,11 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("Instrument", &gate::Instrument, pybind11::return_value_policy::take_ownership);
     mgate.def("Adaptive", &gate::Adaptive, pybind11::return_value_policy::take_ownership);
 
-    py::class_<QuantumGate_SingleParameter, QuantumGateBase>(m, "QuantumGate_SingleParameter");
-    mgate.def("ParametricRX", &gate::ParametricRX);
+	py::class_<QuantumGate_SingleParameter, QuantumGateBase>(m, "QuantumGate_SingleParameter")
+		.def("get_parameter_value", &QuantumGate_SingleParameter::get_parameter_value)
+		.def("set_parameter_value", &QuantumGate_SingleParameter::set_parameter_value)
+		;
+	mgate.def("ParametricRX", &gate::ParametricRX);
     mgate.def("ParametricRY", &gate::ParametricRY);
     mgate.def("ParametricRZ", &gate::ParametricRZ);
     mgate.def("ParametricPauliRotation", &gate::ParametricPauliRotation);

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -18,6 +18,10 @@ extern "C" {
 #include <complex.h>
 #endif
 
+#ifdef _USE_GPU
+#include <gpusim/update_ops_cuda.h>
+#endif
+
 
 class QuantumGate_SingleParameter : public QuantumGateBase {
 protected:
@@ -35,14 +39,25 @@ public:
 class QuantumGate_SingleParameterOneQubitRotation : public QuantumGate_SingleParameter {
 protected:
     typedef void (T_UPDATE_FUNC)(UINT, double, CTYPE*, ITYPE);
-    T_UPDATE_FUNC* _update_func;
+	typedef void (T_GPU_UPDATE_FUNC)(UINT, double, void*, ITYPE);
+	T_UPDATE_FUNC* _update_func;
+	T_GPU_UPDATE_FUNC* _update_func_gpu;
 
     QuantumGate_SingleParameterOneQubitRotation(double angle) : QuantumGate_SingleParameter(angle) {
         _angle = angle;
     };
 public:
     virtual void update_quantum_state(QuantumStateBase* state) override {
-        _update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
+#ifdef _USE_GPU
+		if (state->get_device_name() == "gpu") {
+			_update_func_gpu(this->_target_qubit_list[0].index(), _angle, state->data(), state->dim);
+		}
+		else {
+			_update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
+		}
+#else
+
+#endif
     };
 };
 
@@ -52,6 +67,9 @@ public:
 	ClsParametricRXGate(UINT target_qubit_index, double angle) : QuantumGate_SingleParameterOneQubitRotation(angle) {
 		this->_name = "ParametricRX";
 		this->_update_func = RX_gate;
+#ifdef _USE_GPU
+		this->_update_func_gpu = RX_gate_host;
+#endif
 		this->_target_qubit_list.push_back(TargetQubitInfo(target_qubit_index, FLAG_X_COMMUTE));
 	}
 	virtual void set_matrix(ComplexMatrix& matrix) const override {
@@ -68,6 +86,9 @@ public:
 	ClsParametricRYGate(UINT target_qubit_index, double angle) : QuantumGate_SingleParameterOneQubitRotation(angle) {
 		this->_name = "ParametricRY";
 		this->_update_func = RY_gate;
+#ifdef _USE_GPU
+		this->_update_func_gpu = RY_gate_host;
+#endif
 		this->_target_qubit_list.push_back(TargetQubitInfo(target_qubit_index, FLAG_Y_COMMUTE));
 	}
 	virtual void set_matrix(ComplexMatrix& matrix) const override {
@@ -84,6 +105,9 @@ public:
 	ClsParametricRZGate(UINT target_qubit_index, double angle) : QuantumGate_SingleParameterOneQubitRotation(angle) {
 		this->_name = "ParametricRZ";
 		this->_update_func = RZ_gate;
+#ifdef _USE_GPU
+		this->_update_func_gpu = RZ_gate_host;
+#endif
 		this->_target_qubit_list.push_back(TargetQubitInfo(target_qubit_index, FLAG_Z_COMMUTE));
 	}
 	virtual void set_matrix(ComplexMatrix& matrix) const override {
@@ -121,9 +145,22 @@ public:
     virtual void update_quantum_state(QuantumStateBase* state) override {
         auto target_index_list = _pauli->get_index_list();
         auto pauli_id_list = _pauli->get_pauli_id_list();
+#ifdef _USE_GPU
+		if (state->get_device_name() == "gpu") {
+			multi_qubit_Pauli_rotation_gate_partial_list_host(
+				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+				_angle, state->data(), state->dim);
+		}
+		else {
+			multi_qubit_Pauli_rotation_gate_partial_list(
+				target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
+				_angle, state->data_c(), state->dim);
+		}
+#else
         multi_qubit_Pauli_rotation_gate_partial_list(
             target_index_list.data(), pauli_id_list.data(), (UINT)target_index_list.size(),
             _angle, state->data_c(), state->dim);
+#endif
     };
     virtual QuantumGateBase* copy() const override {
         return new ClsParametricPauliRotationGate(_angle, _pauli->copy());


### PR DESCRIPTION
- Summary

Parametric gate such as ParametricRX or ParametricPauliRotation were not compatible with QuantumStateGpu. I've fixed this bugs.
In addition, I've exported two member function <code>set_parameter_value</code> and <code>get_parameter_value</code> for single parameter parametric gate class.