### PR TITLE
Fix bugs in parametric gate on CPU

### DIFF
--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -56,7 +56,7 @@ public:
 			_update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
 		}
 #else
-
+		_update_func(this->_target_qubit_list[0].index(), _angle, state->data_c(), state->dim);
 #endif
     };
 };


### PR DESCRIPTION
In the PR #138 , state update operation of parametric gate on CPU is mistakenly removed. I added a line for this. This bug is reported by a user in slack community. Thanks for bug reports.


