### PR TITLE
Bugfix of two qubit gate in csim

### DIFF
--- a/src/csim/update_ops_multi.c
+++ b/src/csim/update_ops_multi.c
@@ -235,10 +235,10 @@ void two_qubit_dense_matrix_gate(UINT target_qubit_index1, UINT target_qubit_ind
 		CTYPE cval_3 = state[basis_3];
 
 		// set values
-		state[basis_0] = matrix[0] * cval_0 + matrix[1] * cval_1 + matrix[2] * cval_2 + matrix[3] + cval_3;
-		state[basis_1] = matrix[4] * cval_0 + matrix[5] * cval_1 + matrix[6] * cval_2 + matrix[7] + cval_3;
-		state[basis_2] = matrix[8] * cval_0 + matrix[9] * cval_1 + matrix[10] * cval_2 + matrix[11] + cval_3;
-		state[basis_3] = matrix[12] * cval_0 + matrix[13] * cval_1 + matrix[14] * cval_2 + matrix[15] + cval_3;
+		state[basis_0] = matrix[0] * cval_0 + matrix[1] * cval_1 + matrix[2] * cval_2 + matrix[3] * cval_3;
+		state[basis_1] = matrix[4] * cval_0 + matrix[5] * cval_1 + matrix[6] * cval_2 + matrix[7] * cval_3;
+		state[basis_2] = matrix[8] * cval_0 + matrix[9] * cval_1 + matrix[10] * cval_2 + matrix[11] * cval_3;
+		state[basis_3] = matrix[12] * cval_0 + matrix[13] * cval_1 + matrix[14] * cval_2 + matrix[15] * cval_3;
 	}
 }
 

--- a/test/csim/test_update.cpp
+++ b/test/csim/test_update.cpp
@@ -159,9 +159,6 @@ TEST(UpdateTest, SingleQubitRotationGateTest) {
 }
 
 
-
-
-
 TEST(UpdateTest, TwoQubitGateTest) {
     const UINT n = 6;
     const ITYPE dim = 1ULL << n;
@@ -570,6 +567,47 @@ TEST(UpdateTest, TwoQubitDenseMatrixTest) {
         state_equal(state, test_state, dim, "two-qubit separable dense gate");
     }
     release_quantum_state(state);
+}
+
+TEST(UpdateTest, TwoQubitDenseMatrixTest2) {
+	const UINT n = 6;
+	const ITYPE dim = 1ULL << n;
+	const UINT max_repeat = 10;
+
+	std::vector<UINT> index_list;
+	for (UINT i = 0; i < n; ++i) index_list.push_back(i);
+
+	Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U, U2;
+	Eigen::Matrix<std::complex<double>, 4, 4, Eigen::RowMajor> Umerge;
+
+	UINT targets[2];
+
+	auto state = allocate_quantum_state(dim);
+	initialize_Haar_random_state(state, dim);
+	Eigen::VectorXcd test_state = Eigen::VectorXcd::Zero(dim);
+	for (ITYPE i = 0; i < dim; ++i) test_state[i] = state[i];
+
+	Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
+
+	for (UINT rep = 0; rep < max_repeat; ++rep) {
+
+		// two qubit dense matrix gate
+		U = get_eigen_matrix_random_single_qubit_unitary();
+		U2 = get_eigen_matrix_random_single_qubit_unitary();
+
+		std::random_shuffle(index_list.begin(), index_list.end());
+
+		targets[0] = index_list[0];
+		targets[1] = index_list[1];
+		Umerge = kronecker_product(U2, U);
+		// the below two lines are equivalent to the above two line
+		//UINT targets_rev[2] = { targets[1], targets[0] };
+		//Umerge = kronecker_product(U, U2);
+		test_state = get_expanded_eigen_matrix_with_identity(targets[1], U2, n) * get_expanded_eigen_matrix_with_identity(targets[0], U, n) * test_state;
+		two_qubit_dense_matrix_gate(targets[0], targets[1], (CTYPE*)Umerge.data(), state, dim);
+		state_equal(state, test_state, dim, "two-qubit separable dense gate");
+	}
+	release_quantum_state(state);
 }
 
 


### PR DESCRIPTION
There was a bug in <code>two_qubit_dense_matrix_gate</code>.
I've fixed this bug and add test for this function.

Note that this function is currently not used from cppsim. Thus this is not tested and does not affect the behavior of C++/python libraries. 
This bug is reported in issue #145 by @k-ishizaka. Thanks for bug reporting!
