### PR TITLE
Two qubit depolarizing gate

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -302,6 +302,7 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("DephasingNoise", &gate::DephasingNoise);
     mgate.def("IndependentXZNoise", &gate::IndependentXZNoise);
     mgate.def("DepolarizingNoise", &gate::DepolarizingNoise);
+	mgate.def("TwoQubitDepolarizingNoise", &gate::TwoQubitDepolarizingNoise);
 	mgate.def("AmplitudeDampingNoise", &gate::AmplitudeDampingNoise);
     mgate.def("Measurement", &gate::Measurement);
 

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -202,6 +202,27 @@ namespace gate{
 		delete gate2;
 		return new_gate;
 	}
+	QuantumGateBase* TwoQubitDepolarizingNoise(UINT target_index1, UINT target_index2, double prob) {
+		std::vector<QuantumGateBase*> gate_list;
+		for (int i = 0; i < 16; ++i) {
+			if (i != 0) {
+				UINT pauli_qubit1 = i % 4;
+				UINT pauli_qubit2 = i / 4;
+				auto gate = Pauli({ target_index1, target_index2 }, { pauli_qubit1, pauli_qubit2 });
+				gate_list.push_back(gate);
+			}
+			else {
+				gate_list.push_back(Identity(target_index1));
+			}
+		}
+		std::vector<double> probabilities(16, prob/15);
+		probabilities[0] = 1 - prob;
+		auto new_gate = new QuantumGate_Probabilistic(probabilities, gate_list);
+		for (UINT gate_index = 0; gate_index < 15; ++gate_index) {
+			delete gate_list[gate_index];
+		}
+		return new_gate;
+	}
 	QuantumGateBase* AmplitudeDampingNoise(UINT target_index, double prob) {
 		ComplexMatrix damping_matrix_0(2, 2), damping_matrix_1(2,2);
 		damping_matrix_0 << 1, 0, 0, sqrt(1 - prob);

--- a/src/cppsim/gate_factory.hpp
+++ b/src/cppsim/gate_factory.hpp
@@ -368,6 +368,17 @@ namespace gate{
     DllExport QuantumGateBase* DepolarizingNoise(UINT target_index, double prob);
 
 	/**
+	* Two-qubit depolarizin noiseを発生させるゲート
+	*
+	* IIを除くtwo qubit Pauli operationがそれぞれ<code>prob/15</code>の確率で生じる。
+	* @param[in] target_index1 ターゲットとなる量子ビットの添え字
+	* @param[in] target_index2 ターゲットとなる量子ビットの添え字
+	* @param[in] prob エラーが生じる確率
+	* @return 作成されたゲートのインスタンス
+	*/
+	DllExport QuantumGateBase* TwoQubitDepolarizingNoise(UINT target_index1, UINT target_index2, double prob);
+
+	/**
 	 * Amplitude damping noiseを発生させるゲート
 	 *
 	 * @param[in] target_index ターゲットとなる量子ビットの添え字


### PR DESCRIPTION
I've added <code>TwoQubitDepolarizingNoise</code>.
This applies two qubit pauli operators except identity to given two qubits with probability <code>prob/15</code> for each. This is equivalent to convert density matrix as rho -> (1-p)rho + p \* rho, where p = prob \* 15/16.

This feature is suggested in issue #146 .