### PR TITLE
Parametric gate does not work with density matrix 

### DIFF
--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -4,6 +4,7 @@
 #ifndef _MSC_VER
 extern "C" {
 #include <csim/update_ops.h>
+#include <csim/update_ops_dm.h>
 }
 #else
 #include <csim/update_ops.h>

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <vqcsim/parametric_gate_factory.hpp>
+#include <cppsim/state_dm.hpp>
 #include <cppsim/gate_factory.hpp>
 #include <vqcsim/solver.hpp>
 #include <vqcsim/problem.hpp>
@@ -34,6 +35,37 @@ TEST(ParametricCircuit, GateApply) {
 	//std::cout << circuit << std::endl;
 	delete circuit;
 }
+
+
+TEST(ParametricCircuit, GateApplyDM) {
+	const UINT n = 3;
+	const UINT depth = 10;
+	ParametricQuantumCircuit* circuit = new ParametricQuantumCircuit(n);
+	Random random;
+	for (UINT d = 0; d < depth; ++d) {
+		for (UINT i = 0; i < n; ++i) {
+			circuit->add_parametric_RX_gate(i, random.uniform());
+			circuit->add_parametric_RY_gate(i, random.uniform());
+			circuit->add_parametric_RZ_gate(i, random.uniform());
+		}
+		for (UINT i = d % 2; i + 1 < n; i += 2) {
+			circuit->add_parametric_multi_Pauli_rotation_gate({ i,i + 1 }, { 3,3 }, random.uniform());
+		}
+	}
+
+	UINT param_count = circuit->get_parameter_count();
+	for (UINT p = 0; p < param_count; ++p) {
+		double current_angle = circuit->get_parameter(p);
+		circuit->set_parameter(p, current_angle + random.uniform());
+	}
+
+	DensityMatrix state(n);
+	circuit->update_quantum_state(&state);
+	//std::cout << state << std::endl;
+	//std::cout << circuit << std::endl;
+	delete circuit;
+}
+
 
 class MyRandomCircuit : public ParametricCircuitBuilder{
     ParametricQuantumCircuit* create_circuit(UINT output_dim, UINT param_count) const override{


### PR DESCRIPTION
Parametric quantum gates such as <code>ParametricRX</code> cannot update recently added <code>DensityMatrix</code>. I've added update codes and now it works. I also added some tests about this issue.
This bug is reported in slack community. Thanks!