### PR TITLE
Bugfix on gpu state load

### DIFF
--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -134,8 +134,14 @@ public:
 	/**
 	 * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
 	 */
-	virtual void load(const QuantumStateBase* _state) override{
-        copy_quantum_state_from_device_to_device(this->data(), _state->data(), dim);
+	virtual void load(const QuantumStateBase* _state) override {
+		if (_state->get_device_name() == "gpu") {
+			copy_quantum_state_from_device_to_device(this->data(), _state->data(), dim);
+		}
+		else {
+			this->load(_state->data_cpp());
+		}
+		this->_classical_register = _state->classical_register;
 	}
 
 	/**

--- a/test/gpusim/test_state.cpp
+++ b/test/gpusim/test_state.cpp
@@ -792,3 +792,38 @@ TEST(StateTest, MultiplyCoef) {
 		ASSERT_NEAR(state.data_cpp()[i].imag(), state_vector[i].imag(), eps);
 	}
 }
+
+
+TEST(StateTest, StateCPUtoGPU) {
+	const double eps = 1e-10;
+	const UINT n = 10;
+	const ITYPE dim = 1ULL << n;
+	const std::complex<double> coef(0.5, 0.2);
+
+	QuantumStateGpu state_gpu(n);
+	QuantumState state_cpu(n);
+	state_cpu.set_Haar_random_state();
+	state_gpu.load(&state_cpu);
+	auto gpu_state_vector = state_gpu.data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(state_cpu.data_cpp()[i].real(), gpu_state_vector[i].real(), eps);
+		ASSERT_NEAR(state_cpu.data_cpp()[i].imag(), gpu_state_vector[i].imag(), eps);
+	}
+}
+
+TEST(StateTest, StateGPUtoCPU) {
+	const double eps = 1e-10;
+	const UINT n = 10;
+	const ITYPE dim = 1ULL << n;
+	const std::complex<double> coef(0.5, 0.2);
+
+	QuantumStateGpu state_gpu(n);
+	QuantumState state_cpu(n);
+	state_gpu.set_Haar_random_state();
+	state_cpu.load(&state_gpu);
+	auto gpu_state_vector = state_gpu.data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(state_cpu.data_cpp()[i].real(), gpu_state_vector[i].real(), eps);
+		ASSERT_NEAR(state_cpu.data_cpp()[i].imag(), gpu_state_vector[i].imag(), eps);
+	}
+}


### PR DESCRIPTION
<code>QuantumStateGpu::load</code> only targeted <code>QuantumStateGpu</code>. Now <code>QuantumStateGpu</code> can load both <code>QuantumState</code> and <code>QuantumStateGpu</code>.
This bug is reported in slack community. Thanks for reporting!
