### PR TITLE
Fix a problem in CMake script which didn't work when path contains "./src/"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ message(STATUS "USE_PYTHON = ${USE_PYTHON}")
 ##### configure include files #####
 file(GLOB_RECURSE header_files ${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp  ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h)
 foreach(path IN LISTS header_files)
-	string(REPLACE /src/ /include/ path_dst ${path})
+	string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/src/ ${CMAKE_CURRENT_SOURCE_DIR}/include/ path_dst ${path})
 	configure_file(${path} ${path_dst} COPYONLY)
 endforeach()
 


### PR DESCRIPTION
When qulacs is installed cmake, cmake will copy all the *.hpp and *.h files in ./qulacs/src/*/*.(hpp|h) to ./qulacs/include/*/*.(hpp|h) by replacing "/src/" to "/include/". This does not work when qulacs folder itself contains "/src/" in its full-path. This problem would happen not only in source build but also when we try to install qulacs with pip and python path contains "/src/". Now cmake build script is modified so that only replace src in source directory. 
This issue and patch is made by @miyo in issue #151 . Thanks for contribution!