### PR TITLE
Remove unnecessary `chmod` in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,6 @@ install:
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       ./script/build_msvc.bat
     else
-      chmod +x ./script/build_gcc.sh
       ./script/build_gcc.sh
     fi
   # Check if `pip install` will be done successfully or not


### PR DESCRIPTION
- `build_gcc.sh` has been had executable permission so remove `chmod`

    ```console
    $ ls script
    total 48
    drwxr-xr-x   8 yyu  staff  256  8  7 19:18 .
    drwxr-xr-x  22 yyu  staff  704  8  7 19:19 ..
    -rwxr-xr-x   1 yyu  staff  583  8  7 19:18 build_gcc.sh
    -rwxr-xr-x   1 yyu  staff  602  8  7 19:18 build_gcc_with_gpu.sh
    -rw-r--r--   1 yyu  staff  211 12 31  2018 build_msvc.bat
    -rw-r--r--   1 yyu  staff  230 12 31  2018 build_msvc_with_gpu.bat
    -rw-r--r--   1 yyu  staff   83 12 31  2018 generate_msvc_project.bat
    -rw-r--r--   1 yyu  staff  102 12 31  2018 generate_msvc_project_with_gpu.bat
    ```