### PR TITLE
Bugfix of freeing unreleased memory in sampling gpu

### DIFF
--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -232,6 +232,7 @@ public:
 			auto index = std::distance(stacked_prob.begin(), ite) - 1;
 			result.push_back(index);
 		}
+		free(ptr);
 		return result;
 	}
 };


### PR DESCRIPTION
free unreleased memory in sampling function in state_gpu.hpp