### PR TITLE
Show error message, return NULL ptr, and raise exception for invalid gate instantiation

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -279,30 +279,83 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("RY", &gate::RY, pybind11::return_value_policy::take_ownership);
     mgate.def("RZ", &gate::RZ, pybind11::return_value_policy::take_ownership);
 
-    mgate.def("CNOT", &gate::CNOT, pybind11::return_value_policy::take_ownership);
-    mgate.def("CZ", &gate::CZ, pybind11::return_value_policy::take_ownership);
-    mgate.def("SWAP", &gate::SWAP, pybind11::return_value_policy::take_ownership);
+	mgate.def("CNOT", [](UINT control_qubit_index, UINT target_qubit_index) {
+		auto ptr = gate::CNOT(control_qubit_index, target_qubit_index);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to CNOT.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
+    mgate.def("CZ", [](UINT control_qubit_index, UINT target_qubit_index) {
+		auto ptr = gate::CZ(control_qubit_index, target_qubit_index);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to CZ.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
+    mgate.def("SWAP", [](UINT target_index1, UINT target_index2) {
+		auto ptr = gate::SWAP(target_index1, target_index2);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to SWAP.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership); 
 
-    mgate.def("Pauli", &gate::Pauli, pybind11::return_value_policy::take_ownership);
-    mgate.def("PauliRotation", &gate::PauliRotation, pybind11::return_value_policy::take_ownership);
+    mgate.def("Pauli", [](std::vector<unsigned int> target_qubit_index_list, std::vector<unsigned int> pauli_ids) {
+		if (target_qubit_index_list.size() != pauli_ids.size()) throw std::invalid_argument("Size of qubit list and pauli list must be equal.");
+		auto ptr = gate::Pauli(target_qubit_index_list, pauli_ids);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to Pauli.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
+    mgate.def("PauliRotation", [](std::vector<unsigned int> target_qubit_index_list, std::vector<unsigned int> pauli_ids, double angle) {
+		if (target_qubit_index_list.size() != pauli_ids.size()) throw std::invalid_argument("Size of qubit list and pauli list must be equal.");
+		auto ptr = gate::PauliRotation(target_qubit_index_list, pauli_ids, angle);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to PauliRotation.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
 
-    QuantumGateMatrix*(*ptr1)(unsigned int, ComplexMatrix) = &gate::DenseMatrix;
-    QuantumGateMatrix*(*ptr2)(std::vector<unsigned int>, ComplexMatrix) = &gate::DenseMatrix;
-    mgate.def("DenseMatrix", ptr1, pybind11::return_value_policy::take_ownership);
-    mgate.def("DenseMatrix", ptr2, pybind11::return_value_policy::take_ownership);
-	mgate.def("SparseMatrix", &gate::SparseMatrix, pybind11::return_value_policy::take_ownership);
+    //QuantumGateMatrix*(*ptr1)(unsigned int, ComplexMatrix) = &gate::DenseMatrix;
+    //QuantumGateMatrix*(*ptr2)(std::vector<unsigned int>, ComplexMatrix) = &gate::DenseMatrix;
+    mgate.def("DenseMatrix", [](unsigned int target_qubit_index, ComplexMatrix matrix) {
+		if (matrix.rows() != 2 || matrix.cols() != 2) throw std::invalid_argument("matrix dims is not 2x2.");
+		auto ptr = gate::DenseMatrix(target_qubit_index, matrix);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to DenseMatrix.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership); 
+    mgate.def("DenseMatrix", [](std::vector<unsigned int> target_qubit_index_list, ComplexMatrix matrix) {
+		const ITYPE dim = 1ULL << target_qubit_index_list.size();
+		if (matrix.rows() != dim || matrix.cols() != dim) throw std::invalid_argument("matrix dims is not consistent.");
+		auto ptr = gate::DenseMatrix(target_qubit_index_list, matrix);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to DenseMatrix.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership); 
+	mgate.def("SparseMatrix", [](std::vector<unsigned int> target_qubit_index_list, SparseComplexMatrix matrix) {
+		const ITYPE dim = 1ULL << target_qubit_index_list.size();
+		if (matrix.rows() != dim || matrix.cols() != dim) throw std::invalid_argument("matrix dims is not consistent.");
+		auto ptr = gate::SparseMatrix(target_qubit_index_list, matrix);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to SparseMatrix.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership); 
 
-    mgate.def("RandomUnitary", &gate::RandomUnitary, pybind11::return_value_policy::take_ownership);
+    mgate.def("RandomUnitary", [](std::vector<unsigned int> target_qubit_index_list) {
+		auto ptr = gate::RandomUnitary(target_qubit_index_list);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to RandomUnitary.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership); 
     mgate.def("ReversibleBoolean", [](std::vector<UINT> target_qubit_list, std::function<ITYPE(ITYPE,ITYPE)> function_py) {
-        return gate::ReversibleBoolean(target_qubit_list, function_py);
+		auto ptr = gate::ReversibleBoolean(target_qubit_list, function_py);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to ReversibleBoolean.");
+		return ptr;
     }, pybind11::return_value_policy::take_ownership);
-	mgate.def("StateReflection", &gate::StateReflection, pybind11::return_value_policy::take_ownership);
+	mgate.def("StateReflection", [](const QuantumStateBase* reflection_state) {
+		auto ptr = gate::StateReflection(reflection_state);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to StateReflection.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
 
     mgate.def("BitFlipNoise", &gate::BitFlipNoise);
     mgate.def("DephasingNoise", &gate::DephasingNoise);
     mgate.def("IndependentXZNoise", &gate::IndependentXZNoise);
     mgate.def("DepolarizingNoise", &gate::DepolarizingNoise);
-	mgate.def("TwoQubitDepolarizingNoise", &gate::TwoQubitDepolarizingNoise);
+	mgate.def("TwoQubitDepolarizingNoise", [](UINT target_index1, UINT target_index2, double probability) {
+		auto ptr = gate::TwoQubitDepolarizingNoise(target_index1, target_index2, probability);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to TwoQubitDepolarizingNoise.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
 	mgate.def("AmplitudeDampingNoise", &gate::AmplitudeDampingNoise);
     mgate.def("Measurement", &gate::Measurement);
 
@@ -331,7 +384,11 @@ PYBIND11_MODULE(qulacs, m) {
 	mgate.def("ParametricRX", &gate::ParametricRX);
     mgate.def("ParametricRY", &gate::ParametricRY);
     mgate.def("ParametricRZ", &gate::ParametricRZ);
-    mgate.def("ParametricPauliRotation", &gate::ParametricPauliRotation);
+    mgate.def("ParametricPauliRotation", [](std::vector<unsigned int> target_qubit_index_list, std::vector<unsigned int> pauli_ids, double angle) {
+		auto ptr = gate::ParametricPauliRotation(target_qubit_index_list, pauli_ids, angle);
+		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to ParametricPauliRotation.");
+		return ptr;
+	}, pybind11::return_value_policy::take_ownership);
 
 
     py::class_<QuantumCircuit>(m, "QuantumCircuit")

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -96,3 +96,12 @@ std::tuple<double, double, std::string> parse_openfermion_line(std::string line)
     return std::make_tuple(coef_real, coef_imag, str_buf);
 }
 
+bool check_is_unique_index_list(std::vector<UINT> index_list) {
+	sort(index_list.begin(), index_list.end());
+	bool flag = true;
+	for (UINT i = 0; i + 1 < index_list.size(); ++i) {
+		flag = flag & (index_list[i] != index_list[i + 1]);
+		if (!flag) break;
+	}
+	return flag;
+}

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -187,3 +187,11 @@ DllExport void chfmt(std::string& ops);
 
 
 DllExport std::tuple<double, double, std::string> parse_openfermion_line(std::string line);
+
+/**
+ * \~japanese-en 配列の中に重複する添え字があるかをチェックする。
+ *
+ * @param[in] index_list チェックする配列
+ * @return 重複がある場合にtrue、ない場合にfalse
+ */
+bool check_is_unique_index_list(std::vector<UINT> index_list);

--- a/src/vqcsim/parametric_gate_factory.cpp
+++ b/src/vqcsim/parametric_gate_factory.cpp
@@ -22,7 +22,11 @@ namespace gate {
         return new ClsParametricRZGate(target_qubit_index, initial_angle);
     }
     QuantumGate_SingleParameter* ParametricPauliRotation(std::vector<UINT> target, std::vector<UINT> pauli_id, double initial_angle) {
-        auto pauli = new PauliOperator(target, pauli_id, initial_angle);
+		if (!check_is_unique_index_list(target)) {
+			std::cerr << "Error: gate::ParametricPauliRotation(std::vector<UINT>, std::vector<UINT>, double): target qubit list contains duplicated values." << std::endl;
+			return NULL;
+		}
+		auto pauli = new PauliOperator(target, pauli_id, initial_angle);
         return new ClsParametricPauliRotationGate(initial_angle, pauli);
     }
 

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1141,3 +1141,79 @@ TEST(GateTest, TestNoise) {
 	delete amp_damp;
 	delete measurement;
 }
+
+TEST(GateTest, DuplicateIndex) {
+	{
+		auto gate1 = gate::CNOT(10,13);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::CNOT(21,21);
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::CZ(10, 13);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::CZ(21, 21);
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::SWAP(10, 13);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::SWAP(21, 21);
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::Pauli({ 2,1,0,3,7,9,4 }, { 0,0,0,0,0,0,0 });
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::Pauli({ 0,1,3,1,5,6,2 }, { 0,0,0,0,0,0,0 });
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::PauliRotation({ 2,1,0,3,7,9,4 }, { 0,0,0,0,0,0,0 }, 0.0);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::PauliRotation({ 0,1,3,1,5,6,2 }, { 0,0,0,0,0,0,0 }, 0.0);
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::DenseMatrix({ 10, 13 }, ComplexMatrix::Identity(4,4));
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::DenseMatrix({ 21, 21 }, ComplexMatrix::Identity(4, 4));
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto matrix = SparseComplexMatrix(4, 4);
+		matrix.setIdentity();
+		auto gate1 = gate::SparseMatrix({ 10, 13 }, matrix);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::SparseMatrix({ 21, 21 }, matrix);
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::RandomUnitary({ 10, 13 });
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::RandomUnitary({ 21, 21 });
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto ident = [](ITYPE a, ITYPE dim) {return a; };
+		auto gate1 = gate::ReversibleBoolean({ 10, 13 },ident);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::ReversibleBoolean({ 21, 21 },ident);
+		ASSERT_EQ(NULL, gate2);
+	}
+	{
+		auto gate1 = gate::TwoQubitDepolarizingNoise(10,13,0.1);
+		EXPECT_TRUE(gate1 != NULL);
+		delete gate1;
+		auto gate2 = gate::TwoQubitDepolarizingNoise(21,21,0.1);
+		ASSERT_EQ(NULL, gate2);
+	}
+}

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -192,3 +192,16 @@ TEST(EnergyMinimization, MultiQubit) {
 	ASSERT_GT(qc_loss, diag_loss);
     EXPECT_NEAR(qc_loss, diag_loss, 1e-1);
 }
+
+TEST(ParametricGate, DuplicateIndex) {
+	auto gate1 = gate::ParametricPauliRotation({ 0,1,2,3,4,5,6 }, { 0,0,0,0,0,0,0 }, 0.0);
+	EXPECT_TRUE(gate1 != NULL);
+	delete gate1;
+	auto gate2 = gate::ParametricPauliRotation({ 2,1,0,3,7,9,4 }, { 0,0,0,0,0,0,0 }, 0.0);
+	EXPECT_TRUE(gate2 != NULL);
+	delete gate2;
+	auto gate3 = gate::ParametricPauliRotation({ 0,1,3,1,5,6,2 }, { 0,0,0,0,0,0,0 }, 0.0);
+	ASSERT_EQ(NULL, gate3);
+	auto gate4 = gate::ParametricPauliRotation({ 0,3,5,2,5,6,2 }, { 0,0,0,0,0,0,0 }, 0.0);
+	ASSERT_EQ(NULL, gate4);
+}


### PR DESCRIPTION
# Overview
Add features to show message when gates act on the qubits with the same indices.
This feature is proposed at issue #158 by @kenjikun. Thanks for proposal!

# Detail
In quantum gates, we cannot mathematically define CNOT with same control and target, or unitary acts on the same indices twice.
```cpp
auto cnot = gate::CNOT(0,0);
auto random_unitary = gate::RandomUnitary({0,1,2,1})
```
In the previous implementation, however, the above codes will not check duplication and will gate-apply will work almost all the cases. Since this bug will not show segfault or nan/inf, once this kind of bug happens, it is hard to debug this.
With this PR, qulacs will show message in stderr and return null pointer. When you try to apply gate to state or add gate to circuit, null pointer segfault will happen.

In python case,
```cpp
cnot = qulacs.gate.CNOT(0,0);
random_unitary = qulacs.gate.RandomUnitary({0,1,2,1})
```
will raise ValueError exception through pybind11.

In the case of python, qulacs raises exception for the following cases.
- (multi-qubit gate) Qubit indices where gate acts on are duplicated.
- (matrix gate) Matrix dimension is not 2^(#qubit).
- (Pauli gate) Qubit count and Pauli-id count is not equal.

# Note
This is a common error since we tend to use the following codes when we try to choose indices randomly for m-qubit gate for n-qubit circuit.
```python
targets = np.random.randint(n ,size=m)
```
For removing duplication, one possible single-line code is 
```python
targets = np.random.permutation(np.arange(n))[:m]
```

