### PR TITLE
Change ownership of data_cpp

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -196,8 +196,8 @@ PYBIND11_MODULE(qulacs, m) {
         .def("load", (void (QuantumStateGpu::*)(const QuantumStateBase*))&QuantumStateGpu::load)
         .def("load", (void (QuantumStateGpu::*)(const std::vector<CPPCTYPE>&))&QuantumStateGpu::load)
         .def("get_device_name", &QuantumStateGpu::get_device_name)
-        .def("data_cpp", &QuantumStateGpu::data_cpp)
-        .def("data_c", &QuantumStateGpu::data_c)
+        //.def("data_cpp", &QuantumStateGpu::data_cpp)
+        //.def("data_c", &QuantumStateGpu::data_c)
         .def("add_state", &QuantumStateGpu::add_state)
         .def("multiply_coef", &QuantumStateGpu::multiply_coef)
         .def("get_classical_value", &QuantumStateGpu::get_classical_value)
@@ -206,9 +206,9 @@ PYBIND11_MODULE(qulacs, m) {
         .def("sampling", &QuantumStateGpu::sampling)
 
         .def("get_vector", [](const QuantumStateGpu& state) {
-        Eigen::VectorXcd vec = Eigen::Map<Eigen::VectorXcd>(state.data_cpp(), state.dim);
-        return vec;
-    })
+            Eigen::VectorXcd vec = Eigen::Map<Eigen::VectorXcd>(state.duplicate_data_cpp(), state.dim);
+            return vec;
+        }, pybind11::return_value_policy::take_ownership)
         .def("get_qubit_count", [](const QuantumStateGpu& state) -> unsigned int {return (unsigned int) state.qubit_count; })
         .def("__repr__", [](const QuantumStateGpu &p) {return p.to_string(); });
     ;

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -78,7 +78,7 @@ public:
 	 *
 	 * @param matrix 行列をセットする変数の参照
 	 */
-	virtual void set_matrix(ComplexMatrix& matrix) const override {
+	virtual void set_matrix(ComplexMatrix&) const override {
 		std::cerr << "ReflectionGate::set_matrix is not implemented" << std::endl;
 		exit(0);
 	}

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -50,7 +50,7 @@ public:
 				//reversible_boolean_gate_gpu(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
 			}
 			else {
-				reversible_boolean_gate(target_index.data(), target_index.size(), function_ptr, state->data_c(), state->dim);
+				reversible_boolean_gate(target_index.data(), (UINT)target_index.size(), function_ptr, state->data_c(), state->dim);
 			}
 #else
 			reversible_boolean_gate(target_index.data(), (UINT)target_index.size(), function_ptr, state->data_c(), state->dim);

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -168,9 +168,8 @@ public:
 	 * @return 複素ベクトルのポインタ
 	 */
 	virtual CPPCTYPE* data_cpp() const override { 
-		CPPCTYPE* _copy_state = (CPPCTYPE*)malloc(sizeof(CPPCTYPE)*dim);
-		get_quantum_state_host(this->_state_vector,_copy_state, dim);
-		return _copy_state;
+		std::cerr << "Cannot reinterpret state vector on GPU to cpp complex vector. Use duplicate_data_cpp instead." << std::endl;
+		return NULL;
 	}
 
 	/**
@@ -179,9 +178,8 @@ public:
 	* @return 複素ベクトルのポインタ
 	*/
 	virtual CTYPE* data_c() const override {
-		CTYPE* _copy_state = (CTYPE*)malloc(sizeof(CTYPE)*dim);
-		get_quantum_state_host(this->_state_vector, _copy_state, dim);
-		return _copy_state;
+		std::cerr << "Cannot reinterpret state vector on GPU to C complex vector. Use duplicate_data_cpp instead." << std::endl;
+		return NULL;
 	}
 
 	/**
@@ -193,6 +191,17 @@ public:
 		return reinterpret_cast<void*>(this->_state_vector);
 	}
 
+	virtual CTYPE* duplicate_data_c() const override {
+		CTYPE* _copy_state = (CTYPE*)malloc(sizeof(CTYPE)*dim);
+		get_quantum_state_host(this->_state_vector, _copy_state, dim);
+		return _copy_state;
+	}
+
+	virtual CPPCTYPE* duplicate_data_cpp() const override {
+		CPPCTYPE* _copy_state = (CPPCTYPE*)malloc(sizeof(CPPCTYPE)*dim);
+		get_quantum_state_host(this->_state_vector, _copy_state, dim);
+		return _copy_state;
+	}
 
 	/**
 	 * \~japanese-en 量子状態を足しこむ
@@ -219,7 +228,7 @@ public:
 		std::vector<double> stacked_prob;
 		std::vector<ITYPE> result;
 		double sum = 0.;
-		auto ptr = this->data_cpp();
+		auto ptr = this->duplicate_data_cpp();
 		stacked_prob.push_back(0.);
 		for (UINT i = 0; i < this->dim; ++i) {
 			sum += norm(ptr[i]);
@@ -234,6 +243,19 @@ public:
 		}
 		free(ptr);
 		return result;
+	}
+
+	virtual std::string to_string() const {
+		std::stringstream os;
+		ComplexVector eigen_state(this->dim);
+		auto data = this->duplicate_data_cpp();
+		for (UINT i = 0; i < this->dim; ++i) eigen_state[i] = data[i];
+		os << " *** Quantum State ***" << std::endl;
+		os << " * Qubit Count : " << this->qubit_count << std::endl;
+		os << " * Dimension   : " << this->dim << std::endl;
+		os << " * State vector : \n" << eigen_state << std::endl;
+		free(data);
+		return os.str();
 	}
 };
 

--- a/src/csim/constant.h
+++ b/src/csim/constant.h
@@ -10,10 +10,12 @@
 #include "type.h"
 
 //! PI value
+#ifndef PI
 #ifdef M_PI
 #define PI M_PI
 #else
 #define PI      3.141592653589793
+#endif
 #endif
 
 //! square root of 2

--- a/src/gpusim/memory_ops.cu
+++ b/src/gpusim/memory_ops.cu
@@ -23,14 +23,14 @@
 
 __host__ void* allocate_cuda_stream_host(unsigned int max_cuda_stream) {
 	cudaStream_t* stream = (cudaStream_t*)malloc(max_cuda_stream * sizeof(cudaStream_t));
-	for (int i = 0; i < max_cuda_stream; ++i) cudaStreamCreate(&stream[i]);
+	for (unsigned int i = 0; i < max_cuda_stream; ++i) cudaStreamCreate(&stream[i]);
 	void* cuda_stream = reinterpret_cast<void*>(stream);
 	return cuda_stream;
 }
 
 __host__ void release_cuda_stream_host(void* cuda_stream, unsigned int max_cuda_stream) {
 	cudaStream_t* stream = reinterpret_cast<cudaStream_t*>(cuda_stream);
-	for (int i = 0; i < max_cuda_stream; ++i) cudaStreamDestroy(stream[i]);
+	for (unsigned int i = 0; i < max_cuda_stream; ++i) cudaStreamDestroy(stream[i]);
 	free(stream);
 }
 
@@ -125,7 +125,7 @@ __global__ void rand_normal_xorwow(curandState* rnd_state, GTYPE* state, ITYPE d
 __host__ void initialize_Haar_random_state_with_seed_host(void *state, ITYPE dim, UINT seed, void* stream) {
 	GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
 	cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
-	const ITYPE ignore_first = 40;
+	//const ITYPE ignore_first = 40;
 	double norm = 0.;
 
 	curandState* rnd_state;

--- a/src/gpusim/stat_ops.cu
+++ b/src/gpusim/stat_ops.cu
@@ -503,7 +503,7 @@ __host__ void multi_Z_gate_host(int* gates, void *state, ITYPE dim, int n_qubits
 	cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
 	ITYPE bit_mask = 0;
 	for (int i = 0; i < n_qubits; ++i) {
-		if (gates[i] == 3) bit_mask ^= (1 << i);
+		if (gates[i] == 3) bit_mask ^= (1ULL << i);
 	}
 	cudaError_t cudaStatus;
 	unsigned int block = dim <= 1024 ? dim : 1024;
@@ -635,7 +635,7 @@ __host__ double multipauli_get_expectation_value_host(unsigned int* gates, void 
 	for (int i = 0; i < n_qubits; ++i) ++num_pauli_op[gates[i]];
 	ITYPE bit_mask[4] = { 0, 0, 0, 0 };
 	for (int i = 0; i < n_qubits; ++i) {
-		bit_mask[gates[i]] ^= (1 << i);
+		bit_mask[gates[i]] ^= (1ULL << i);
 	}
 	if (num_pauli_op[1] == 0 && num_pauli_op[2] == 0) {
 		multi_Z_get_expectation_value_gpu << <grid, block, 0, *cuda_stream >> > (ret_gpu, bit_mask[3], dim, state_gpu);

--- a/src/gpusim/update_ops_multi.cu
+++ b/src/gpusim/update_ops_multi.cu
@@ -663,7 +663,7 @@ __global__ void multi_qubit_dense_matrix_gate_half_shared_gpu(UINT target_qubit_
     ITYPE basis0, basis1;
     
     ITYPE matrix_len = 1ULL << target_qubit_index_count;
-    ITYPE half_matrix_len = 1ULL << (target_qubit_index_count-1);
+    //ITYPE half_matrix_len = 1ULL << (target_qubit_index_count-1);
 	if (basis < loop_dim){
         for(int j=0;j<target_qubit_index_count;++j) basis = insert_zero_to_basis_index_device(basis, sorted_insert_index_list_gpu[j] );
         for(int j=0;j<target_qubit_index_count-1;++j) basis += (1ULL << target_index_list_gpu[j+1])*((threadIdx.y>>j)&1);
@@ -789,14 +789,14 @@ __host__ void multi_qubit_dense_matrix_gate_small_qubit_host(UINT* target_qubit_
 __host__ void multi_qubit_dense_matrix_gate_11qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream){
     cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
     GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
-	cudaError cudaStatus;
+	//cudaError cudaStatus;
 
 	// matrix dim, mask, buffer
     ITYPE matrix_dim = 1ULL << target_qubit_index_count;
     UINT* h_sorted_insert_index_list = create_sorted_ui_list_gsim(target_qubit_index_list, target_qubit_index_count);
     
     // loop variables
-	ITYPE loop_dim = dim >> target_qubit_index_count;
+	//ITYPE loop_dim = dim >> target_qubit_index_count;
 	
     GTYPE *matrix_gpu;
     
@@ -829,7 +829,7 @@ __host__ void multi_qubit_dense_matrix_gate_11qubit_host(UINT* target_qubit_inde
 __host__ void multi_qubit_dense_matrix_gate_more_than_11qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream){
 	cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
 	GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
-	cudaError cudaStatus;
+	//cudaError cudaStatus;
 
 	// matrix dim, mask, buffer
     ITYPE matrix_dim = 1ULL << target_qubit_index_count;

--- a/test/gpusim/test_circuit.cpp
+++ b/test/gpusim/test_circuit.cpp
@@ -19,6 +19,43 @@
 #include <cppsim/pauli_operator.hpp>
 
 
+
+inline void set_eigen_from_gpu(ComplexVector& dst, QuantumStateGpu& src, ITYPE dim) {
+	auto ptr = src.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) dst[i] = ptr[i];
+	free(ptr);
+}
+
+inline void assert_eigen_eq_gpu(ComplexVector& v1, QuantumStateGpu& v2, ITYPE dim, double eps) {
+	auto ptr = v2.duplicate_data_cpp();
+	for (UINT i = 0; i < dim; ++i) {
+		ASSERT_NEAR(ptr[i].real(), v1[i].real(), eps);
+		ASSERT_NEAR(ptr[i].imag(), v1[i].imag(), eps);
+	}
+	free(ptr);
+}
+
+inline void assert_cpu_eq_gpu(QuantumStateCpu& state_cpu, QuantumStateGpu& state_gpu, ITYPE dim, double eps) {
+	auto gpu_state_vector = state_gpu.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(state_cpu.data_cpp()[i].real(), gpu_state_vector[i].real(), eps);
+		ASSERT_NEAR(state_cpu.data_cpp()[i].imag(), gpu_state_vector[i].imag(), eps);
+	}
+	free(gpu_state_vector);
+}
+
+inline void assert_gpu_eq_gpu(QuantumStateGpu& state_gpu1, QuantumStateGpu& state_gpu2, ITYPE dim, double eps) {
+	auto gpu_state_vector1 = state_gpu1.duplicate_data_cpp();
+	auto gpu_state_vector2 = state_gpu2.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(gpu_state_vector1[i].real(), gpu_state_vector2[i].real(), eps);
+		ASSERT_NEAR(gpu_state_vector1[i].imag(), gpu_state_vector2[i].imag(), eps);
+	}
+	free(gpu_state_vector1);
+	free(gpu_state_vector2);
+}
+
+
 TEST(CircuitTest, CircuitBasic) {
     Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2), H(2, 2), S(2, 2), T(2, 2), sqrtX(2, 2), sqrtY(2, 2), P0(2, 2), P1(2, 2);
 
@@ -43,7 +80,7 @@ TEST(CircuitTest, CircuitBasic) {
     ComplexVector state_eigen(dim);
 
     state.set_Haar_random_state();
-    for (ITYPE i = 0; i < dim; ++i) state_eigen[i] = state.data_cpp()[i];
+	set_eigen_from_gpu(state_eigen, state, dim);
 
     QuantumCircuit circuit(n);
     UINT target,target_sub;
@@ -139,7 +176,8 @@ TEST(CircuitTest, CircuitBasic) {
     state_eigen = get_eigen_matrix_full_qubit_SWAP(target, target_sub, n)*state_eigen;
 
     circuit.update_quantum_state(&state);
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state_eigen[i] - state.data_cpp()[i]), 0, eps);
+
+	assert_eigen_eq_gpu(state_eigen, state, dim, eps);
 }
 
 
@@ -167,8 +205,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -192,8 +230,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -218,8 +256,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -244,8 +282,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -270,8 +308,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -296,8 +334,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -322,8 +360,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -348,8 +386,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -375,8 +413,8 @@ TEST(CircuitTest, CircuitOptimize) {
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
         //std::cout << state << std::endl << test_state << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -401,8 +439,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -428,8 +466,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -455,8 +493,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -482,8 +520,8 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
         //std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
+		assert_gpu_eq_gpu(state, test_state, dim, eps);
+		ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
@@ -529,8 +567,8 @@ TEST(CircuitTest, RandomCircuitOptimize) {
             state.load(&org_state);
             copy_circuit->update_quantum_state(&state);
             //std::cout << copy_circuit << std::endl;
-            for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-            delete copy_circuit;
+			assert_gpu_eq_gpu(state, test_state, dim, eps);
+			delete copy_circuit;
         }
     }
 
@@ -576,7 +614,7 @@ TEST(CircuitTest, RandomCircuitOptimizeLarge) {
 			state.load(&org_state);
 			copy_circuit->update_quantum_state(&state);
 			//std::cout << copy_circuit << std::endl;
-			for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+			assert_gpu_eq_gpu(state, test_state, dim, eps);
 			delete copy_circuit;
 		}
 	}
@@ -658,7 +696,7 @@ TEST(CircuitTest, SuzukiTrotterExpansion) {
 
 
     state.set_Haar_random_state(seed);
-    for (ITYPE i = 0; i < dim; ++i) test_state[i] = state.data_cpp()[i];
+	set_eigen_from_gpu(test_state, state, dim);
 
     test_state = test_circuit * test_state;
     circuit.update_quantum_state(&state);
@@ -725,7 +763,7 @@ TEST(CircuitTest, RotateDiagonalObservable){
     ASSERT_NEAR(test_res.imag(), 0, eps);
 
     state.set_Haar_random_state();
-    for (ITYPE i = 0; i < dim; ++i) test_state[i] = state.data_cpp()[i];
+	set_eigen_from_gpu(test_state, state, dim);
 
     res = observable.get_expectation_value(&state).real();
     test_res = (test_state.adjoint() * test_observable * test_state);

--- a/test/gpusim/test_compat_cpu.cpp
+++ b/test/gpusim/test_compat_cpu.cpp
@@ -6,9 +6,20 @@
 #include <cppsim/gate_merge.hpp>
 #include <cppsim/pauli_operator.hpp>
 
+
+inline void assert_cpu_eq_gpu(QuantumStateCpu& state_cpu, QuantumStateGpu& state_gpu, ITYPE dim, double eps) {
+	auto gpu_state_vector = state_gpu.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(state_cpu.data_cpp()[i].real(), gpu_state_vector[i].real(), eps);
+		ASSERT_NEAR(state_cpu.data_cpp()[i].imag(), gpu_state_vector[i].imag(), eps);
+	}
+	delete gpu_state_vector;
+}
+
+
 TEST(CompatTest, ApplyRandomOrderUnitary) {
 	UINT n = 15;
-	UINT max_gate_count = 12;
+	UINT max_gate_count = 5;
 	ITYPE dim = 1ULL << n;
 	const double eps = 1e-14;
 
@@ -52,10 +63,8 @@ TEST(CompatTest, ApplyRandomOrderUnitary) {
 				gate->update_quantum_state(&state_gpu);
 				delete gate;
 			}
-			auto gpu_ptr = state_gpu.data_cpp();
-			auto cpu_ptr = state_cpu.data_cpp();
-			for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(cpu_ptr[i] - gpu_ptr[i]), 0, eps);
-			delete gpu_ptr;
+
+			assert_cpu_eq_gpu(state_cpu, state_gpu, dim, eps);
 		}
 	}
 }

--- a/test/gpusim/test_gate.cpp
+++ b/test/gpusim/test_gate.cpp
@@ -15,6 +15,42 @@
 
 
 
+inline void set_eigen_from_gpu(ComplexVector& dst, QuantumStateGpu& src, ITYPE dim) {
+	auto ptr = src.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) dst[i] = ptr[i];
+	free(ptr);
+}
+
+inline void assert_eigen_eq_gpu(ComplexVector& v1, QuantumStateGpu& v2, ITYPE dim, double eps) {
+	auto ptr = v2.duplicate_data_cpp();
+	for (UINT i = 0; i < dim; ++i) {
+		ASSERT_NEAR(ptr[i].real(), v1[i].real(), eps);
+		ASSERT_NEAR(ptr[i].imag(), v1[i].imag(), eps);
+	}
+	free(ptr);
+}
+
+inline void assert_cpu_eq_gpu(QuantumStateCpu& state_cpu, QuantumStateGpu& state_gpu, ITYPE dim, double eps) {
+	auto gpu_state_vector = state_gpu.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(state_cpu.data_cpp()[i].real(), gpu_state_vector[i].real(), eps);
+		ASSERT_NEAR(state_cpu.data_cpp()[i].imag(), gpu_state_vector[i].imag(), eps);
+	}
+	free(gpu_state_vector);
+}
+
+inline void assert_gpu_eq_gpu(QuantumStateGpu& state_gpu1, QuantumStateGpu& state_gpu2, ITYPE dim, double eps) {
+	auto gpu_state_vector1 = state_gpu1.duplicate_data_cpp();
+	auto gpu_state_vector2 = state_gpu2.duplicate_data_cpp();
+	for (ITYPE i = 0; i < dim; ++i) {
+		ASSERT_NEAR(gpu_state_vector1[i].real(), gpu_state_vector2[i].real(), eps);
+		ASSERT_NEAR(gpu_state_vector1[i].imag(), gpu_state_vector2[i].imag(), eps);
+	}
+	free(gpu_state_vector1);
+	free(gpu_state_vector2);
+}
+
+
 TEST(GateTest, ApplySingleQubitGate) {
 
     Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2), H(2, 2), S(2, 2), T(2, 2), sqrtX(2, 2), sqrtY(2, 2), P0(2, 2), P1(2, 2);
@@ -64,8 +100,8 @@ TEST(GateTest, ApplySingleQubitGate) {
             UINT target = random.int32() % n;
 
             state.set_Haar_random_state();
-            for (ITYPE i = 0; i < dim; ++i) test_state1[i] = state.data_cpp()[i];
-            for (ITYPE i = 0; i < dim; ++i) test_state2[i] = state.data_cpp()[i];
+			set_eigen_from_gpu(test_state1, state, dim);
+			set_eigen_from_gpu(test_state2, state, dim);
 
             auto gate = func(target);
             gate->update_quantum_state(&state);
@@ -74,9 +110,9 @@ TEST(GateTest, ApplySingleQubitGate) {
             test_state1 = get_expanded_eigen_matrix_with_identity(target, small_mat,n) * test_state1;
             test_state2 = get_expanded_eigen_matrix_with_identity(target, mat, n) * test_state2;
 
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state2[i]), 0, eps);
-        }
+			assert_eigen_eq_gpu(test_state1, state, dim, eps);
+			assert_eigen_eq_gpu(test_state2, state, dim, eps);
+		}
     }
 }
 
@@ -113,8 +149,8 @@ TEST(GateTest, ApplySingleQubitRotationGate) {
             auto mat = cos(angle/2) * Eigen::MatrixXcd::Identity(2,2) + 1.i * sin(angle/2)* func_mat.second;
 
             state.set_Haar_random_state();
-            for (ITYPE i = 0; i < dim; ++i) test_state1[i] = state.data_cpp()[i];
-            for (ITYPE i = 0; i < dim; ++i) test_state2[i] = state.data_cpp()[i];
+			set_eigen_from_gpu(test_state1, state, dim);
+			set_eigen_from_gpu(test_state2, state, dim);
 
             auto gate = func(target,angle);
             gate->update_quantum_state(&state);
@@ -123,9 +159,9 @@ TEST(GateTest, ApplySingleQubitRotationGate) {
             test_state1 = get_expanded_eigen_matrix_with_identity(target, small_mat, n) * test_state1;
             test_state2 = get_expanded_eigen_matrix_with_identity(target, mat, n) * test_state2;
 
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state2[i]), 0, eps);
-        }
+			assert_eigen_eq_gpu(test_state1, state, dim, eps);
+			assert_eigen_eq_gpu(test_state2, state, dim, eps);
+		}
     }
 }
 
@@ -154,7 +190,7 @@ TEST(GateTest, ApplyTwoQubitGate) {
 
             state.set_Haar_random_state();
             test_state.load(&state);
-            for (ITYPE i = 0; i < dim; ++i) test_state1[i] = state.data_cpp()[i];
+			set_eigen_from_gpu(test_state1, state, dim);
 
             // update state
             auto gate = func(control, target);
@@ -171,8 +207,8 @@ TEST(GateTest, ApplyTwoQubitGate) {
             gate_dense->update_quantum_state(&test_state);
             delete gate_dense;
 
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+			assert_eigen_eq_gpu(test_state1, state, dim, eps);
+			assert_gpu_eq_gpu(state, test_state, dim, eps);
         }
     }
 
@@ -189,7 +225,7 @@ TEST(GateTest, ApplyTwoQubitGate) {
 
             state.set_Haar_random_state();
             test_state.load(&state);
-            for (ITYPE i = 0; i < dim; ++i) test_state1[i] = state.data_cpp()[i];
+			set_eigen_from_gpu(test_state1, state, dim);
 
             auto gate = func(control, target);
             gate->update_quantum_state(&state);
@@ -204,9 +240,9 @@ TEST(GateTest, ApplyTwoQubitGate) {
             gate_dense->update_quantum_state(&test_state);
             delete gate_dense;
 
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-            for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        }
+			assert_eigen_eq_gpu(test_state1, state, dim, eps);
+			assert_gpu_eq_gpu(state, test_state, dim, eps);
+		}
     }
 }
 
@@ -231,7 +267,7 @@ TEST(GateTest, ApplyMultiQubitGate) {
 
         state.set_Haar_random_state();
         state.set_computational_basis(0);
-        for (ITYPE i = 0; i < dim; ++i) test_state1[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state1, state, dim);
 
         PauliOperator pauli(1.0);
         for (UINT i = 0; i < n; ++i) {
@@ -252,13 +288,13 @@ TEST(GateTest, ApplyMultiQubitGate) {
         //std::cout << small_mat << std::endl << large_mat << std::endl;
         //for (UINT i = 0; i < 4; ++i) std::cout << small_mat.data()[i] << std::endl;
 
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-    }
+		assert_eigen_eq_gpu(test_state1, state, dim, eps);
+	}
 
     for (UINT repeat = 0; repeat < 10; ++repeat) {
 
         state.set_Haar_random_state();
-        for (ITYPE i = 0; i < dim; ++i) test_state1[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state1, state, dim);
 
         PauliOperator pauli(1.0);
         for (UINT i = 0; i < n; ++i) {
@@ -277,8 +313,8 @@ TEST(GateTest, ApplyMultiQubitGate) {
         gate_dense->update_quantum_state(&state);
         delete gate_dense;
 
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-    }
+		assert_eigen_eq_gpu(test_state1, state, dim, eps);
+	}
 
 }
 
@@ -297,7 +333,7 @@ TEST(GateTest, MergeTensorProduct) {
     state.set_Haar_random_state();
 
     test_state.load(&state);
-    for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+	set_eigen_from_gpu(test_state_eigen, state, dim);
 
     xy01->update_quantum_state(&state);
     x0->update_quantum_state(&test_state);
@@ -305,8 +341,8 @@ TEST(GateTest, MergeTensorProduct) {
     Eigen::MatrixXcd mat = get_eigen_matrix_full_qubit_pauli({ 1,2 });
     test_state_eigen = mat * test_state_eigen;
 
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+	assert_eigen_eq_gpu(test_state_eigen, state, dim,eps);
+	assert_gpu_eq_gpu(state, test_state, dim, eps);
 
     delete x0;
     delete y1;
@@ -330,7 +366,7 @@ TEST(GateTest, MergeMultiply) {
     state.set_Haar_random_state();
 
     test_state.load(&state);
-    for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+	set_eigen_from_gpu(test_state_eigen, state, dim);
 
     xy00->update_quantum_state(&state);
     x0->update_quantum_state(&test_state);
@@ -338,8 +374,8 @@ TEST(GateTest, MergeMultiply) {
     Eigen::MatrixXcd mat = -1.i * get_eigen_matrix_full_qubit_pauli({ 3 });
     test_state_eigen = mat * test_state_eigen;
 
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+	assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+	assert_gpu_eq_gpu(state, test_state, dim, eps);
 
     delete x0;
     delete y0;
@@ -365,7 +401,7 @@ TEST(GateTest, MergeTensorProductAndMultiply) {
     state.set_Haar_random_state();
 
     test_state.load(&state);
-    for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+	set_eigen_from_gpu(test_state_eigen, state, dim);
 
     iy01->update_quantum_state(&state);
     y1->update_quantum_state(&test_state);
@@ -375,8 +411,8 @@ TEST(GateTest, MergeTensorProductAndMultiply) {
     //std::cout << iy01 << std::endl << std::endl;
     //std::cout << mat << std::endl;
 
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-    for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+	assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+	assert_gpu_eq_gpu(state, test_state, dim, eps);
 
     delete x0;
     delete y1;
@@ -405,11 +441,11 @@ TEST(GateTest, RandomPauliMerge) {
         // pick random state and copy to test
         state.set_Haar_random_state();
         test_state.load(&state);
-        for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state_eigen, state, dim);
 
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
 
         auto merged_gate = gate::Identity(0);
         QuantumGateMatrix* next_merged_gate = NULL;
@@ -467,9 +503,9 @@ TEST(GateTest, RandomPauliMerge) {
         merged_gate->update_quantum_state(&state);
         delete merged_gate;
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-    }
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
+	}
 }
 
 
@@ -494,11 +530,11 @@ TEST(GateTest, RandomPauliRotationMerge) {
         // pick random state and copy to test
         state.set_Haar_random_state();
         test_state.load(&state);
-        for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state_eigen, state, dim);
 
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
 
         auto merged_gate = gate::Identity(0);
         QuantumGateMatrix* next_merged_gate = NULL;
@@ -552,9 +588,9 @@ TEST(GateTest, RandomPauliRotationMerge) {
         merged_gate->update_quantum_state(&state);
         delete merged_gate;
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-    }
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
+	}
 }
 
 
@@ -579,11 +615,11 @@ TEST(GateTest, RandomUnitaryMerge) {
         // pick random state and copy to test
         state.set_Haar_random_state();
         test_state.load(&state);
-        for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state_eigen, state, dim);
 
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
 
         auto merged_gate = gate::Identity(0);
         QuantumGateMatrix* next_merged_gate = NULL;
@@ -636,9 +672,9 @@ TEST(GateTest, RandomUnitaryMerge) {
         merged_gate->update_quantum_state(&state);
         delete merged_gate;
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-    }
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
+	}
 }
 
 
@@ -664,11 +700,11 @@ TEST(GateTest, RandomUnitaryMergeLarge) {
         // pick random state and copy to test
         state.set_Haar_random_state();
         test_state.load(&state);
-        for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state_eigen, state, dim);
 
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
 
         auto merged_gate1 = gate::Identity(0);
         auto merged_gate2 = gate::Identity(0);
@@ -729,8 +765,8 @@ TEST(GateTest, RandomUnitaryMergeLarge) {
         delete merged_gate1;
         delete merged_gate2;
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-    }
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
+	}
 }
 
 TEST(GateTest, U3MergeIBMQGate) {
@@ -894,7 +930,7 @@ TEST(GateTest, RandomControlMergeSmall) {
         ComplexVector test_state_eigen(dim);
         state.set_Haar_random_state();
         test_state.load(&state);
-        for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
+		set_eigen_from_gpu(test_state_eigen, state, dim);
         auto merge_gate1 = gate::Identity(0);
         auto merge_gate2 = gate::Identity(0);
 
@@ -913,9 +949,9 @@ TEST(GateTest, RandomControlMergeSmall) {
         merge_gate1->update_quantum_state(&state);
         test_state_eigen = mat * test_state_eigen;
 
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps) << state << "\n\n" << test_state_eigen << "\n";
-    }
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
+	}
 }
 
 
@@ -936,8 +972,8 @@ TEST(GateTest, RandomControlMergeLarge) {
         ComplexVector test_state_eigen(dim);
         state.set_Haar_random_state();
         test_state.load(&state);
-        for (ITYPE i = 0; i < dim; ++i) test_state_eigen[i] = state.data_cpp()[i];
-        auto merge_gate1 = gate::Identity(0);
+		set_eigen_from_gpu(test_state_eigen, state, dim);
+		auto merge_gate1 = gate::Identity(0);
         auto merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
@@ -968,9 +1004,9 @@ TEST(GateTest, RandomControlMergeLarge) {
         merge_gate2->update_quantum_state(&test_state);
         test_state_eigen = mat * test_state_eigen;
 
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps) << state << "\n\n" << test_state_eigen << "\n";
-    }
+		assert_eigen_eq_gpu(test_state_eigen, state, dim, eps);
+		assert_gpu_eq_gpu(test_state, state, dim, eps);
+	}
 }
 
 TEST(GateTest, ProbabilisticGate) {
@@ -1046,4 +1082,3 @@ TEST(GateTest, GateAdd) {
     auto a6 = gate::add(gate::merge(gate::P0(0), gate::P0(1)), gate::merge(gate::P1(0), gate::P1(1)));
     // TODO assert matrix element
 }
-


### PR DESCRIPTION
# Update

<code>QuantumStateBase::data(), data_c(), data_cpp()</code> return references to raw array of quantum state as a pointer of void, C99 complex, std::complex, respectively. Since this is a pointer to array managed inside of library, user MUST NOT release this.

However, in the case of GPU, we cannot obtain c/cpp array without copying data from GPU to main RAM. Previous qulacs copy device_to_host and then return pointer to array. Since copied array is not managed in library, user MUST release this in the case of GPU. 
Since python's get_vector() function is redirected to this feature, this means user must be careful whether the state is on CPU or GPU. This was very confusing.

In this update, data_c and data_cpp in GPU state will return NULL pointer with sending warning message to stderr, and new functions duplicate_data_cpp() and duplicate_data_c() are added, which return duplicated copy of array.
Independent of CPU or GPU (state vector or density matrix), user must release returned values of duplicate_data_hoge(), and must not release returned values of data_hoge().

Due to this problem, there are a massive number of memory leaks in GPU test codes. I've fixed them.

## Small update

I removed some trivial warnings.
