### PR TITLE
Bugfix about GPU index constant

### DIFF
--- a/src/gpusim/update_ops_cuda.h
+++ b/src/gpusim/update_ops_cuda.h
@@ -55,7 +55,7 @@ DllExport void multi_qubit_Pauli_gate_partial_list_host(const UINT* target_qubit
 DllExport void multi_qubit_Pauli_gate_whole_list_host(const UINT* Pauli_operator_type_list, UINT qubit_count, void* state, ITYPE dim);
 DllExport void multi_qubit_Pauli_rotation_gate_partial_list_host(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, double angle, void* state, ITYPE dim);
 DllExport void multi_qubit_Pauli_rotation_gate_whole_list_host(const UINT* Pauli_operator_type_list, UINT qubit_count, double angle, void* state, ITYPE dim);
-DllExport void multi_qubit_dense_matrix_gate_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim);
+DllExport void multi_qubit_dense_matrix_gate_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim);
 DllExport void single_qubit_control_multi_qubit_dense_matrix_gate_host(UINT control_qubit_index, UINT control_value, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim);
 DllExport void multi_qubit_control_multi_qubit_dense_matrix_gate_host(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim);
 
@@ -102,7 +102,7 @@ DllExport void multi_qubit_Pauli_rotation_gate_XZ_mask_host(ITYPE bit_flip_mask,
 DllExport void multi_qubit_Pauli_rotation_gate_Z_mask_host(ITYPE phase_flip_mask, double angle, void* state, ITYPE dim, void* stream);
 DllExport void multi_qubit_Pauli_rotation_gate_partial_list_host(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, double angle, void* state, ITYPE dim, void* stream);
 DllExport void multi_qubit_Pauli_rotation_gate_whole_list_host(const UINT* Pauli_operator_type_list, UINT qubit_count, double angle, void* state, ITYPE dim, void* stream);
-DllExport void multi_qubit_dense_matrix_gate_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream);
+DllExport void multi_qubit_dense_matrix_gate_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream);
 DllExport void single_qubit_control_multi_qubit_dense_matrix_gate_host(UINT control_qubit_index, UINT control_value, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream);
 DllExport void multi_qubit_control_multi_qubit_dense_matrix_gate_host(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream);
 

--- a/src/gpusim/update_ops_multi.cu
+++ b/src/gpusim/update_ops_multi.cu
@@ -62,7 +62,7 @@ __global__ void penta_qubit_dense_matrix_gate_gpu(GTYPE *state_gpu, ITYPE dim){
 	}
 }
 
-__host__ void penta_qubit_dense_matrix_gate_host(unsigned int target_qubit_index[5], const CPPCTYPE matrix[1024], void* state, ITYPE dim) {
+__host__ void penta_qubit_dense_matrix_gate_host(const unsigned int target_qubit_index[5], const CPPCTYPE matrix[1024], void* state, ITYPE dim) {
     GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
 	cudaError cudaStatus;
 	checkCudaErrors(cudaMemcpyToSymbol(matrix_const_gpu, matrix, sizeof(GTYPE)*1024), __FILE__, __LINE__);
@@ -74,8 +74,11 @@ __host__ void penta_qubit_dense_matrix_gate_host(unsigned int target_qubit_index
 	unsigned int grid = loop_dim / block.x;
 
 	checkCudaErrors(cudaMemcpyToSymbol(target_index_list_gpu, target_qubit_index, sizeof(UINT) * 5), __FILE__, __LINE__);
-	std::sort(target_qubit_index, target_qubit_index + 5);
-	checkCudaErrors(cudaMemcpyToSymbol(sorted_insert_index_list_gpu, target_qubit_index, sizeof(UINT)*5), __FILE__, __LINE__);
+
+	unsigned int sort_list[5];
+	memcpy(sort_list, target_qubit_index, sizeof(unsigned int) * 5);
+	std::sort(sort_list, sort_list + 5);
+	checkCudaErrors(cudaMemcpyToSymbol(sorted_insert_index_list_gpu, sort_list, sizeof(UINT)*5), __FILE__, __LINE__);
  
     penta_qubit_dense_matrix_gate_gpu<<< grid, block>>>(state_gpu, dim);
     
@@ -153,7 +156,7 @@ __global__ void quad_qubit_dense_matrix_gate_gpu(unsigned int target0_qubit_inde
 	}
 }
 
-__host__ void quad_qubit_dense_matrix_gate_host(unsigned int target_qubit_index[4], const CPPCTYPE matrix[256], void* state, ITYPE dim, void* stream) {
+__host__ void quad_qubit_dense_matrix_gate_host(const unsigned int target_qubit_index[4], const CPPCTYPE matrix[256], void* state, ITYPE dim, void* stream) {
     cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
     GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
 	cudaError cudaStatus;
@@ -167,11 +170,14 @@ __host__ void quad_qubit_dense_matrix_gate_host(unsigned int target_qubit_index[
 	target1_qubit_index=target_qubit_index[1];
 	target2_qubit_index=target_qubit_index[2];
 	target3_qubit_index=target_qubit_index[3];
-	std::sort(target_qubit_index, target_qubit_index + 4);
+
+	unsigned int sort_list[4];
+	memcpy(sort_list, target_qubit_index, sizeof(unsigned int) * 4);
+	std::sort(sort_list, sort_list + 4);
 
 	quad_qubit_dense_matrix_gate_gpu << <grid, block, 0, *cuda_stream >> >(
 		target0_qubit_index, target1_qubit_index, target2_qubit_index, target3_qubit_index, 
-		target_qubit_index[0], target_qubit_index[1], target_qubit_index[2], target_qubit_index[3], 
+		sort_list[0], sort_list[1], sort_list[2], sort_list[3],
 		state_gpu, dim
 	);
 	    
@@ -196,7 +202,7 @@ __host__ void quad_qubit_dense_matrix_gate_host(unsigned int target_qubit_index[
     */
 }
 
-__host__ void quad_qubit_dense_matrix_gate_host(unsigned int target_qubit_index[4], const CPPCTYPE matrix[256], void* state, ITYPE dim) {
+__host__ void quad_qubit_dense_matrix_gate_host(const unsigned int target_qubit_index[4], const CPPCTYPE matrix[256], void* state, ITYPE dim) {
 	cudaStream_t cuda_stream = (cudaStream_t)0;
 	quad_qubit_dense_matrix_gate_host(target_qubit_index, matrix, state, dim, &cuda_stream);
 }
@@ -732,7 +738,7 @@ __global__ void multi_qubit_dense_matrix_gate_gpu(UINT target_qubit_index_count,
     }
 }
 
-__host__ void multi_qubit_dense_matrix_gate_small_qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream) {
+__host__ void multi_qubit_dense_matrix_gate_small_qubit_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream) {
 	cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
 	GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
 	cudaError cudaStatus;
@@ -781,12 +787,12 @@ __host__ void multi_qubit_dense_matrix_gate_small_qubit_host(UINT* target_qubit_
 	state = reinterpret_cast<void*>(state_gpu);
 }
 
-__host__ void multi_qubit_dense_matrix_gate_small_qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim) {
+__host__ void multi_qubit_dense_matrix_gate_small_qubit_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim) {
 	cudaStream_t cuda_stream = (cudaStream_t)0;
 	multi_qubit_dense_matrix_gate_small_qubit_host(target_qubit_index_list, target_qubit_index_count, matrix, state, dim, cuda_stream);
 }
 
-__host__ void multi_qubit_dense_matrix_gate_11qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream){
+__host__ void multi_qubit_dense_matrix_gate_11qubit_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream){
     cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
     GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
 	//cudaError cudaStatus;
@@ -821,12 +827,12 @@ __host__ void multi_qubit_dense_matrix_gate_11qubit_host(UINT* target_qubit_inde
     state = reinterpret_cast<void*>(state_gpu);
 }
 
-__host__ void multi_qubit_dense_matrix_gate_11qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim) {
+__host__ void multi_qubit_dense_matrix_gate_11qubit_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim) {
 	cudaStream_t cuda_stream = (cudaStream_t)0;
 	multi_qubit_dense_matrix_gate_11qubit_host(target_qubit_index_list, target_qubit_index_count, matrix, state, dim, &cuda_stream);
 }
 
-__host__ void multi_qubit_dense_matrix_gate_more_than_11qubit_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream){
+__host__ void multi_qubit_dense_matrix_gate_more_than_11qubit_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream){
 	cudaStream_t* cuda_stream = reinterpret_cast<cudaStream_t*>(stream);
 	GTYPE* state_gpu = reinterpret_cast<GTYPE*>(state);
 	//cudaError cudaStatus;
@@ -867,7 +873,7 @@ __host__ void multi_qubit_dense_matrix_gate_more_than_11qubit_host(UINT* target_
     state = reinterpret_cast<void*>(state_gpu);
 }
 
-__host__ void multi_qubit_dense_matrix_gate_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream) {
+__host__ void multi_qubit_dense_matrix_gate_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim, void* stream) {
 	if (target_qubit_index_count == 1) {
 		single_qubit_dense_matrix_gate_host(target_qubit_index_list[0], matrix, state, dim, &stream);
 	}
@@ -893,7 +899,7 @@ __host__ void multi_qubit_dense_matrix_gate_host(UINT* target_qubit_index_list, 
 	}
 }
 
-__host__ void multi_qubit_dense_matrix_gate_host(UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim) {
+__host__ void multi_qubit_dense_matrix_gate_host(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CPPCTYPE* matrix, void* state, ITYPE dim) {
 	cudaStream_t cuda_stream = (cudaStream_t)0;
 	if (target_qubit_index_count == 1) {
 		single_qubit_dense_matrix_gate_host(target_qubit_index_list[0], matrix, state, dim, &cuda_stream);


### PR DESCRIPTION
- Update

In PR #171 , I've updated gpu codes so that they correctly process unordered target indices.
However, in that time, I've sorted given list of indices and modify original array. This might modify contents of raw vectors inside matrix gate classes. 
I've attach all the pointers should be const-typed, and avoid unintended modification of a raw array.