### PR TITLE
add stdio.h include for avoiding mac os bugs

### DIFF
--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -1,4 +1,4 @@
-
+#include <stdio.h>
 #include <algorithm>
 #include <iterator>
 #include "circuit_optimizer.hpp"

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -1,4 +1,4 @@
-
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/cppsim/simulator.cpp
+++ b/src/cppsim/simulator.cpp
@@ -1,4 +1,4 @@
-
+#include <stdio.h>
 #include "simulator.hpp"
 #include "state.hpp"
 #include "observable.hpp"


### PR DESCRIPTION
In the previous version, some headers include standard libraries before stdio.h. However, it is known that this invokes errors in some MacOS environment, which is reported in #188 .
I've added include stdio.h for files which cause this error.