### PR TITLE
Bugfix for GPU with small targets and many controls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,57 +44,7 @@ matrix:
             - lcov
             - swig
 
-    # 3/ Linux GCC8 PYTHON3.6 build
-    - os: linux
-      dist: trusty
-      compiler: gcc-8
-      env:
-        - C_COMPILER='gcc-8'
-        - CMAKE_C_COMPILER='gcc-8'
-        - CXX_COMPILER='g++-8'
-        - CMAKE_CXX_COMPILER='g++-8'
-        - PYTHON="${PYTHON3}"
-        - COVERAGE=ON
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - cmake3
-            - g++-8
-            - gcc-8
-            - gfortran-8
-            - lcov
-            - swig
-
-    # 4/ Linux GCC9 PYTHON3.6 build
-    - os: linux
-      dist: trusty
-      compiler: gcc-9
-      env:
-        - C_COMPILER='gcc-9'
-        - CMAKE_C_COMPILER='gcc-9'
-        - CXX_COMPILER='g++-9'
-        - CMAKE_CXX_COMPILER='g++-9'
-        - PYTHON="${PYTHON3}"
-        - COVERAGE=ON
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - cmake3
-            - g++-9
-            - gcc-9
-            - gfortran-9
-            - lcov
-            - swig
-
-    # 5/ Linux GCC7 PYTHON2.7 build
+    # 3/ Linux GCC7 PYTHON2.7 build
     - os: linux
       dist: trusty
       compiler: gcc-7
@@ -115,7 +65,7 @@ matrix:
             - lcov
             - swig
 
-    # 6/ Windows VS17 PYTHON3.6 build
+    # 4/ Windows VS17 PYTHON3.6 build
     - os: windows
       env:
         - COVERAGE=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,10 @@ matrix:
       dist: trusty
       compiler: gcc-8
       env:
-        - CXX_COMPILER='g++-8'
         - C_COMPILER='gcc-8'
+        - CMAKE_C_COMPILER='gcc-8'
+        - CXX_COMPILER='g++-8'
+        - CMAKE_CXX_COMPILER='g++-8'
         - PYTHON="${PYTHON3}"
         - COVERAGE=ON
         - PYENV_ROOT="${HOME}/.pyenv"
@@ -72,8 +74,10 @@ matrix:
       dist: trusty
       compiler: gcc-9
       env:
-        - CXX_COMPILER='g++-9'
         - C_COMPILER='gcc-9'
+        - CMAKE_C_COMPILER='gcc-9'
+        - CXX_COMPILER='g++-9'
+        - CMAKE_CXX_COMPILER='g++-9'
         - PYTHON="${PYTHON3}"
         - COVERAGE=ON
         - PYENV_ROOT="${HOME}/.pyenv"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,8 @@ matrix:
         - COVERAGE=OFF
         - PYENV_ROOT="${HOME}/.pyenv"
         - PATH="${PYENV_ROOT}/bin:$PATH"
-    # 2/ OSX GCC7 PYTHON2.7 build
-    - os: osx
-      osx_image: xcode10.1
-      compiler: gcc-7
-      env:
-        - PYTHON="${PYTHON2}"
-        - COVERAGE=OFF
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-    # 3/ Linux GCC7 PYTHON3.6 build
+
+    # 2/ Linux GCC7 PYTHON3.6 build
     - os: linux
       dist: trusty
       compiler: gcc-7
@@ -52,7 +44,53 @@ matrix:
             - lcov
             - swig
 
-    # 4/ Linux GCC7 PYTHON2.7 build
+    # 3/ Linux GCC8 PYTHON3.6 build
+    - os: linux
+      dist: trusty
+      compiler: gcc-8
+      env:
+        - CXX_COMPILER='g++-8'
+        - C_COMPILER='gcc-8'
+        - PYTHON="${PYTHON3}"
+        - COVERAGE=ON
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - cmake3
+            - g++-8
+            - gcc-8
+            - gfortran-8
+            - lcov
+            - swig
+
+    # 4/ Linux GCC9 PYTHON3.6 build
+    - os: linux
+      dist: trusty
+      compiler: gcc-9
+      env:
+        - CXX_COMPILER='g++-9'
+        - C_COMPILER='gcc-9'
+        - PYTHON="${PYTHON3}"
+        - COVERAGE=ON
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - cmake3
+            - g++-9
+            - gcc-9
+            - gfortran-9
+            - lcov
+            - swig
+
+    # 5/ Linux GCC7 PYTHON2.7 build
     - os: linux
       dist: trusty
       compiler: gcc-7
@@ -73,7 +111,7 @@ matrix:
             - lcov
             - swig
 
-    # 5/ Windows VS17 PYTHON3.6 build
+    # 6/ Windows VS17 PYTHON3.6 build
     - os: windows
       env:
         - COVERAGE=ON
@@ -81,16 +119,6 @@ matrix:
         - MSBUILD_BIN='C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin'
         - CMAKE_BIN='C:\Program Files\CMake'
         - PYTHON_BIN='C:\Python36'
-        - PATH="$MSBUILD_BIN:$CMAKE_BIN:$PYTHON_BIN:$PYTHON_BIN\Scripts:$PATH"
-
-    # 6/ Windows VS17 PYTHON2.7 build
-    - os: windows
-      env:
-        - COVERAGE=ON
-        - PYTHON="${PYTHON2}"
-        - MSBUILD_BIN='C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin'
-        - CMAKE_BIN='C:\Program Files\CMake'
-        - PYTHON_BIN='C:\tools\python'
         - PATH="$MSBUILD_BIN:$CMAKE_BIN:$PYTHON_BIN:$PYTHON_BIN\Scripts:$PATH"
 
 cache:

--- a/src/cppsim/gate_matrix.cpp
+++ b/src/cppsim/gate_matrix.cpp
@@ -141,7 +141,7 @@ void QuantumGateMatrix::update_quantum_state(QuantumStateBase* state) {
 #ifdef _USE_GPU
 				if (state->get_device_name() == "gpu") {
 					//
-					std::cerr << "Redirected to multi_control multi_target in GPU" << std::endl;
+					//std::cerr << "Redirected to multi_control multi_target in GPU" << std::endl;
 					multi_qubit_control_multi_qubit_dense_matrix_gate_host(
 						control_index.data(), control_value.data(), (UINT)(control_index.size()),
 						target_index.data(), (UINT)(target_index.size()),

--- a/src/cppsim/type.hpp
+++ b/src/cppsim/type.hpp
@@ -19,7 +19,7 @@ typedef Eigen::Matrix<CPPCTYPE, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
 typedef Eigen::SparseMatrix<CPPCTYPE> SparseComplexMatrix;
 
 #ifdef __GNUC__
-#if __GNUC__ >= 9
+#if __GNUC__ >= 8
 using namespace std::complex_literals;
 #endif
 #endif

--- a/src/gpusim/update_ops_multi.cu
+++ b/src/gpusim/update_ops_multi.cu
@@ -986,7 +986,7 @@ __host__ void single_qubit_control_multi_qubit_dense_matrix_gate_host(UINT contr
         if(target_qubit_index_count<=5){
 		    checkCudaErrors(cudaMemcpyToSymbolAsync(matrix_const_gpu, matrix, sizeof(GTYPE)*matrix_dim*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 		    checkCudaErrors(cudaMemcpyToSymbolAsync(matrix_mask_list_gpu, matrix_mask_list, sizeof(ITYPE)*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
-		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
+		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*(target_qubit_index_count + 1), 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 
             single_qubit_control_multi_qubit_dense_matrix_gate_const_gpu<<< grid, block, 0, *cuda_stream >>> (control_qubit_index, control_value, target_qubit_index_count, state_gpu, dim);
         }else{
@@ -994,7 +994,7 @@ __host__ void single_qubit_control_multi_qubit_dense_matrix_gate_host(UINT contr
 		    checkCudaErrors(cudaMemcpyAsync(d_matrix, matrix, matrix_dim *matrix_dim * sizeof(GTYPE), cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 		    checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_matrix_mask_list), matrix_dim *matrix_dim * sizeof(GTYPE) ), __FILE__, __LINE__);
 		    checkCudaErrors(cudaMemcpyAsync(d_matrix_mask_list, matrix_mask_list, sizeof(ITYPE)*matrix_dim, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
-		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
+		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*(target_qubit_index_count + 1), 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 		    
             single_qubit_control_multi_qubit_dense_matrix_gate_const_gpu<<< grid, block, 0, *cuda_stream >>> (control_qubit_index, control_value, target_qubit_index_count, d_matrix, state_gpu, dim);
         }
@@ -1135,7 +1135,7 @@ __host__ void multi_qubit_control_multi_qubit_dense_matrix_gate_host(const UINT*
         if(target_qubit_index_count<=5){
 		    checkCudaErrors(cudaMemcpyToSymbolAsync(matrix_const_gpu, matrix, sizeof(GTYPE)*matrix_dim*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 		    checkCudaErrors(cudaMemcpyToSymbolAsync(matrix_mask_list_gpu, matrix_mask_list, sizeof(ITYPE)*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
-		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
+		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*(target_qubit_index_count+control_qubit_index_count), 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 
             multi_qubit_control_multi_qubit_dense_matrix_gate_const_gpu<<< grid, block, 0, *cuda_stream >>> (control_mask, target_qubit_index_count, control_qubit_index_count, state_gpu, dim);
         }else{
@@ -1143,7 +1143,7 @@ __host__ void multi_qubit_control_multi_qubit_dense_matrix_gate_host(const UINT*
 		    checkCudaErrors(cudaMemcpyAsync(d_matrix, matrix, matrix_dim *matrix_dim * sizeof(GTYPE), cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 		    checkCudaErrors(cudaMalloc(reinterpret_cast<void **>(&d_matrix_mask_list), matrix_dim *matrix_dim * sizeof(GTYPE) ), __FILE__, __LINE__);
 		    checkCudaErrors(cudaMemcpyAsync(d_matrix_mask_list, matrix_mask_list, sizeof(ITYPE)*matrix_dim, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
-		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*matrix_dim, 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
+		    checkCudaErrors(cudaMemcpyToSymbolAsync(sorted_insert_index_list_gpu, sorted_insert_index_list, sizeof(UINT)*(target_qubit_index_count + control_qubit_index_count), 0, cudaMemcpyHostToDevice, *cuda_stream), __FILE__, __LINE__);
 		    
             multi_qubit_control_multi_qubit_dense_matrix_gate_const_gpu<<< grid, block, 0, *cuda_stream >>> (control_mask, target_qubit_index_count, control_qubit_index_count, d_matrix, state_gpu, dim);
         }

--- a/test/gpusim/test_compat_cpu.cpp
+++ b/test/gpusim/test_compat_cpu.cpp
@@ -73,3 +73,158 @@ TEST(CompatTest, ApplyRandomOrderUnitary) {
 		}
 	}
 }
+
+
+TEST(CompatTest, SingleControlQubitApplyRandomOrderUnitary) {
+	UINT n = 15;
+	UINT max_gate_count = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	UINT max_repeat = 3;
+	Random random;
+	random.set_seed(0);
+
+	int ngpus = get_num_device();
+	for (int idx = 0; idx < ngpus; ++idx) {
+		set_device(idx);
+		auto stream_ptr = allocate_cuda_stream_host(1, idx);
+
+		// define states
+		QuantumStateCpu state_cpu(n);
+		QuantumStateGpu state_gpu(n, idx);
+		std::vector<UINT> indices(n);
+		for (UINT i = 0; i < n; ++i) indices[i] = i;
+		std::mt19937 engine(0);
+
+		for (UINT m = 1; m <= max_gate_count; ++m) {
+			if (m <= 5) { gate_count = 10; max_repeat = 3; }
+			else { gate_count = 1; max_repeat = 1; }
+			for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+				state_gpu.set_Haar_random_state();
+				state_cpu.load(&state_gpu);
+
+				for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+					std::shuffle(indices.begin(), indices.end(), engine);
+					std::vector<UINT> targets(indices.begin(), indices.begin() + m);
+					//for (UINT i : targets) std::cout << i << " "; std::cout << std::endl;
+					QuantumGateMatrix* gate = NULL;
+
+					gate = gate::RandomUnitary(targets);
+					gate->add_control_qubit(indices[m], 1);
+					gate->update_quantum_state(&state_cpu);
+					gate->update_quantum_state(&state_gpu);
+					delete gate;
+				}
+
+				assert_cpu_eq_gpu(state_cpu, state_gpu, dim, eps);
+			}
+		}
+	}
+}
+
+TEST(CompatTest, DoubleControlQubitApplyRandomOrderUnitary) {
+	UINT n = 15;
+	UINT max_gate_count = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	UINT max_repeat = 3;
+	Random random;
+	random.set_seed(0);
+
+	int ngpus = get_num_device();
+	for (int idx = 0; idx < ngpus; ++idx) {
+		set_device(idx);
+		auto stream_ptr = allocate_cuda_stream_host(1, idx);
+
+		// define states
+		QuantumStateCpu state_cpu(n);
+		QuantumStateGpu state_gpu(n, idx);
+		std::vector<UINT> indices(n);
+		for (UINT i = 0; i < n; ++i) indices[i] = i;
+		std::mt19937 engine(0);
+
+		for (UINT m = 1; m <= max_gate_count; ++m) {
+			if (m <= 5) { gate_count = 10; max_repeat = 3; }
+			else { gate_count = 1; max_repeat = 1; }
+			for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+				state_gpu.set_Haar_random_state();
+				state_cpu.load(&state_gpu);
+
+				for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+					std::shuffle(indices.begin(), indices.end(), engine);
+					std::vector<UINT> targets(indices.begin(), indices.begin() + m);
+					//for (UINT i : targets) std::cout << i << " "; std::cout << std::endl;
+					QuantumGateMatrix* gate = NULL;
+
+					gate = gate::RandomUnitary(targets);
+					gate->add_control_qubit(indices[m], 1);
+					gate->add_control_qubit(indices[m+1], 1);
+					gate->update_quantum_state(&state_cpu);
+					gate->update_quantum_state(&state_gpu);
+					delete gate;
+				}
+
+				assert_cpu_eq_gpu(state_cpu, state_gpu, dim, eps);
+			}
+		}
+	}
+}
+
+
+TEST(CompatTest, MultiControlQubitApplyRandomOrderUnitary) {
+	UINT n = 15;
+	UINT max_gate_count = 5;
+	UINT max_control = 5;
+	ITYPE dim = 1ULL << n;
+	const double eps = 1e-14;
+
+	UINT gate_count = 10;
+	UINT max_repeat = 3;
+	Random random;
+	random.set_seed(0);
+
+	int ngpus = get_num_device();
+	for (int idx = 0; idx < ngpus; ++idx) {
+		set_device(idx);
+		auto stream_ptr = allocate_cuda_stream_host(1, idx);
+
+		// define states
+		QuantumStateCpu state_cpu(n);
+		QuantumStateGpu state_gpu(n, idx);
+		std::vector<UINT> indices(n);
+		for (UINT i = 0; i < n; ++i) indices[i] = i;
+		std::mt19937 engine(0);
+
+		for (UINT c = 0; c <= max_control; ++c) {
+			for (UINT m = 1; m <= max_gate_count; ++m) {
+				if (m <= 5) { gate_count = 10; max_repeat = 3; }
+				else { gate_count = 1; max_repeat = 1; }
+				for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
+					state_gpu.set_Haar_random_state();
+					state_cpu.load(&state_gpu);
+
+					for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
+						std::shuffle(indices.begin(), indices.end(), engine);
+						std::vector<UINT> targets(indices.begin(), indices.begin() + m);
+						//for (UINT i : targets) std::cout << i << " "; std::cout << std::endl;
+						QuantumGateMatrix* gate = NULL;
+
+						gate = gate::RandomUnitary(targets);
+						for (int i = m; i <= m + c; ++i) {
+							gate->add_control_qubit(indices[i], 1);
+						}
+						gate->update_quantum_state(&state_cpu);
+						gate->update_quantum_state(&state_gpu);
+						delete gate;
+					}
+
+					assert_cpu_eq_gpu(state_cpu, state_gpu, dim, eps);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I've fixed bugs in multi-control-multi-target gate and multi-control-single-target gate of GPU.

Before this update, dense matrix gate satisfying
"target_qubit_index_count + control_qubit_index_count > 2^target_qubit_index_count"
were not processed correctly since size of index list sent to GPU was wrong.
This happens many controls with small dense matrix gate.

Additionally, I've removed warning message for single qubit gate with multi control. 
