### PR TITLE
Add `set -o pipefail` to fail CI when failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,7 @@ before_install:
   - pip install -U --only-binary=numpy,scipy numpy scipy
 
 install:
+  - set -o pipefail
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       ./script/build_msvc_2015.bat
@@ -144,6 +145,7 @@ install:
   - python setup.py install
 
 script:
+  - set -o pipefail
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       cmake --build ./visualstudio --target test --config Release


### PR DESCRIPTION
- `.travis.ci` uses `if ....... fi` so CI may success even if tests fail
- So I add `set -o pipefail` when installing and testing
    - It comes from https://github.com/Instagram/IGListKit/pull/283