### PR TITLE
Add formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+IndentWidth: 4
+---
+Language: Cpp
+TabWidth: 4
+ColumnLimit: 0
+SortIncludes: false
+UseTab: Always

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+
+charset = utf-8
+
+[*.cpp]
+
+# If you change these settings,
+# you have to change `.clang-format` similarly.
+indent_style = tab
+indent_size = 4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,22 @@
+name: Format
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  format:
+    name: Check format
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+       
+      - name: Run clang-format style check
+        uses: jidicula/clang-format-action@v4.6.2
+        with:
+          clang-format-version: '13'
+          check-path: 'src'
+          fallback-style: 'Mozilla'


### PR DESCRIPTION
- qulacs has many C++ code which are NOT formatted like indentation or spacing....
    - Both tabs and spaces are used in the same file
- So I try to use C++ code formatter [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
- I add the clang-format setting file `.clang-format`
- Then I reformat using the command: `git ls-files "*.cpp" | xargs clang-format -style=file -i`
- I add check for violation of the format at `.travis.yml` 
- Firstly I think it's enough to reformat indentation but its diff size is more than 10000..... 😇 
    - It mixed some other reformatting(like spacing after commas)
    - You can see the differential ignored whitespace by https://github.com/qulacs/qulacs/pull/201/files?w=1
- And add [.editorconfig](https://editorconfig.org/) to unite the coding rule

## Discussion

- Would we need any formatter?
- Tab _vs_ space?
    - Especially I don't care if either tabs or spaces but It could be a problem to include both in the same file or the same project
    - **UPDATE**: Some developers are using Visual Studio and it uses tabs for indentation. So I think it would be better to decide using tabs
        - As my research, Visual Studio uses spaces for indentation by default.... 🤔 