### PR TITLE
Bugfix of bitstring sampling for density matrix

### DIFF
--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -300,7 +300,7 @@ public:
         auto ptr = this->data_cpp();
         stacked_prob.push_back(0.);
         for (UINT i = 0; i < this->dim; ++i) {
-            sum += norm(ptr[i*dim+i]);
+            sum += abs(ptr[i*dim+i]);
             stacked_prob.push_back(sum);
         }
 

--- a/test/cppsim/test_noise_dm.cpp
+++ b/test/cppsim/test_noise_dm.cpp
@@ -305,6 +305,25 @@ TEST(DensityMatrixGeneralGateTest, TwoQubitDepolarizingTest) {
 }
 
 
+TEST(DensityMatrixGeneralGateTest, NoiseSampling) {
+	const UINT n = 1;
+	const ITYPE dim = 1ULL << n;
+	double eps = 1e-15;
+	double prob = 0.2;
+
+	Random random;
+	DensityMatrix state(n);
+
+	// update density matrix
+	DensityMatrix dm(n);
+	dm.set_Haar_random_state();
+	std::vector<ITYPE> samples = dm.sampling(1000);
+	for (UINT i = 0; i < samples.size(); ++i) {
+		ASSERT_TRUE(samples[i] == 0 || samples[i] == 1);
+	}
+}
+
+
 /*
 // not implemented yet
 TEST(DensityMatrixGateTest, ReversibleBooleanGate) {


### PR DESCRIPTION
# summary

In the previous versions, sampling distribution of density matrix was wrong due to mistakenly used norm and abs. This bug was fixed, and simple test case was added.

