### PR TITLE
Choose random seed for sampling from state

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -130,7 +130,8 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_classical_value", &QuantumState::get_classical_value)
         .def("set_classical_value", &QuantumState::set_classical_value)
         .def("to_string",&QuantumState::to_string)
-        .def("sampling",&QuantumState::sampling)
+        .def("sampling", (std::vector<ITYPE> (QuantumState::*)(UINT))&QuantumState::sampling)
+		.def("sampling", (std::vector<ITYPE>(QuantumState::*)(UINT, UINT))&QuantumState::sampling)
 
         .def("get_vector", [](const QuantumState& state) {
         Eigen::VectorXcd vec = Eigen::Map<Eigen::VectorXcd>(state.data_cpp(), state.dim);
@@ -164,7 +165,8 @@ PYBIND11_MODULE(qulacs, m) {
 		.def("get_classical_value", &DensityMatrix::get_classical_value)
 		.def("set_classical_value", &DensityMatrix::set_classical_value)
 		.def("to_string", &DensityMatrix::to_string)
-		.def("sampling", &DensityMatrix::sampling)
+		.def("sampling", (std::vector<ITYPE>(DensityMatrix::*)(UINT))&DensityMatrix::sampling)
+		.def("sampling", (std::vector<ITYPE>(DensityMatrix::*)(UINT, UINT))&DensityMatrix::sampling)
 
 		.def("get_matrix", [](const DensityMatrix& state) {
 			Eigen::MatrixXcd mat(state.dim, state.dim);
@@ -206,8 +208,9 @@ PYBIND11_MODULE(qulacs, m) {
         .def("get_classical_value", &QuantumStateGpu::get_classical_value)
         .def("set_classical_value", &QuantumStateGpu::set_classical_value)
         .def("to_string", &QuantumStateGpu::to_string)
-        .def("sampling", &QuantumStateGpu::sampling)
-        .def("get_vector", [](const QuantumStateGpu& state) {
+		.def("sampling", (std::vector<ITYPE>(QuantumStateGpu::*)(UINT))&QuantumStateGpu::sampling)
+		.def("sampling", (std::vector<ITYPE>(QuantumStateGpu::*)(UINT, UINT))&QuantumStateGpu::sampling)
+		.def("get_vector", [](const QuantumStateGpu& state) {
             Eigen::VectorXcd vec = Eigen::Map<Eigen::VectorXcd>(state.duplicate_data_cpp(), state.dim);
             return vec;
         }, pybind11::return_value_policy::take_ownership)

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -245,10 +245,12 @@ public:
      * \~japanese-en 量子状態を測定した際の計算基底のサンプリングを行う
      *
      * @param[in] sampling_count サンプリングを行う回数
+	 * @param[in] random_seed サンプリングで乱数を振るシード値
      * @return サンプルされた値のリスト
      */
     virtual std::vector<ITYPE> sampling(UINT sampling_count) = 0;
-    
+	virtual std::vector<ITYPE> sampling(UINT sampling_count, UINT random_seed) = 0;
+
 
     /**
      * \~japanese-en 量子回路のデバッグ情報の文字列を生成する
@@ -561,6 +563,10 @@ public:
         }
         return result;
     }
+	virtual std::vector<ITYPE> sampling(UINT sampling_count, UINT random_seed) override {
+		random.set_seed(random_seed);
+		return this->sampling(sampling_count);
+	}
 
 };
 

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -313,6 +313,10 @@ public:
         return result;
     }
 
+	virtual std::vector<ITYPE> sampling(UINT sampling_count, UINT random_seed) override {
+		random.set_seed(random_seed);
+		return this->sampling(sampling_count);
+	}
 	virtual std::string to_string() const {
 		std::stringstream os;
 		ComplexMatrix eigen_state(this->dim, this->dim);

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -264,6 +264,11 @@ public:
 		return result;
 	}
 
+	virtual std::vector<ITYPE> sampling(UINT sampling_count, UINT random_seed) override {
+		random.set_seed(random_seed);
+		return this->sampling(sampling_count);
+	}
+
 	virtual std::string to_string() const {
 		std::stringstream os;
 		ComplexVector eigen_state(this->dim);


### PR DESCRIPTION
I've overloaded <code>sampling</code> function of all the subclasses of <code>QuantumStateBase</code> so that we can choose seed value.

Example: 
```
from qulacs import QuantumState
n=1
state = QuantumState(n)
state.set_Haar_random_state()
count = 100
state.sampling(count)
state.sampling(count) # different results for each call
seed = 42
state.sampling(count ,seed)
state.sampling(count ,seed) # same result as far as seed is the same
``` 
(behavior is the same for <code>QuantumStateGpu</code> and <code>DensityMatrix</code>)

