### PR TITLE
Remove `sudo: false` to use Linux infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: cpp
 
-sudo: false
-
 env:
   global:
     - Fortran_COMPILER='gfortran'


### PR DESCRIPTION
- Travis CI requires to remove `sudo: false` option to move into Linux infrastructure. See also:
    - [Upcoming Required Linux Infrastructure Migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
- The official document says that Container-based infrastructure has been fully deprecated
    - https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure
- So I dropped `sudo: false`