### PR TITLE
Add support for override of compiler optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(DEFAULT_USE_OMP Yes)
 set(DEFAULT_USE_GPU No)
 set(DEFAULT_USE_PYTHON Yes)
 set(DEFAULT_USE_TEST Yes)
+set(DEFAULT_OPT_FLAGS "-mtune=native -march=native -mfpmath=both")
 
 if(NOT DEFINED USE_SIMD)
 	set(USE_SIMD ${DEFAULT_USE_SIMD})
@@ -32,12 +33,16 @@ endif()
 if(NOT DEFINED USE_TEST)
 	set(USE_TEST ${DEFAULT_USE_TEST})
 endif()
+if(NOT DEFINED OPT_FLAGS)
+	set(OPT_FLAGS ${DEFAULT_OPT_FLAGS})
+endif()
 
 message(STATUS "USE_SIMD = ${USE_SIMD}")
 message(STATUS "USE_OMP = ${USE_OMP}")
 message(STATUS "USE_GPU = ${USE_GPU}")
 message(STATUS "USE_TEST = ${USE_TEST}")
 message(STATUS "USE_PYTHON = ${USE_PYTHON}")
+message(STATUS "OPT_FLAGS = ${OPT_FLAGS}")
 
 
 ##### configure include files #####
@@ -197,8 +202,8 @@ if(MSYS OR MINGW OR UNIX OR APPLE)
 		add_compile_options("-D _USE_SIMD")
 	endif()
 
-	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -mtune=native -march=native -mfpmath=both")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mtune=native -march=native -mfpmath=both")
+	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${OPT_FLAGS}")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${OPT_FLAGS}")
 
 	if(8.0.0 VERSION_LESS ${CMAKE_CXX_COMPILER_VERSION})
 		set(PYBIND11_CPP_STANDARD -std=gnu++14)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,18 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
+    user_options = build_ext.user_options + [
+        ('opt-flags=', 'o', 'optimization flags for compiler')
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.opt_flags = None
+
+    def finalize_options(self):
+        super().finalize_options()
+        pass
+
     def run(self):
         try:
             out = subprocess.check_output(['cmake', '--version'])
@@ -71,6 +83,9 @@ class CMakeBuild(build_ext):
 
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
+
+        if self.opt_flags is not None:
+            cmake_args += ['-DOPT_FLAGS=' + self.opt_flags]
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,11 @@ class CMakeBuild(build_ext):
     ]
 
     def initialize_options(self):
-        super().initialize_options()
+        build_ext.initialize_options(self)
         self.opt_flags = None
 
     def finalize_options(self):
-        super().finalize_options()
-        pass
+        build_ext.finalize_options(self)
 
     def run(self):
         try:

--- a/setup_gpu.py
+++ b/setup_gpu.py
@@ -19,6 +19,18 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
+    user_options = build_ext.user_options + [
+        ('opt-flags=', 'o', 'optimization flags for compiler')
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.opt_flags = None
+
+    def finalize_options(self):
+        super().finalize_options()
+        pass
+
     def run(self):
         try:
             out = subprocess.check_output(['cmake', '--version'])
@@ -65,6 +77,9 @@ class CMakeBuild(build_ext):
                 cmake_args += ['-DCMAKE_CXX_COMPILER=g++-7']
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
+
+        if self.opt_flags is not None:
+            cmake_args += ['-DOPT_FLAGS=' + self.opt_flags]
 
         cmake_args += ['-DUSE_GPU:STR=Yes']
         env = os.environ.copy()

--- a/setup_gpu.py
+++ b/setup_gpu.py
@@ -24,12 +24,11 @@ class CMakeBuild(build_ext):
     ]
 
     def initialize_options(self):
-        super().initialize_options()
+        build_ext.initialize_options(self)
         self.opt_flags = None
 
     def finalize_options(self):
-        super().finalize_options()
-        pass
+        build_ext.finalize_options(self)
 
     def run(self):
         try:

--- a/setup_singlethread.py
+++ b/setup_singlethread.py
@@ -19,6 +19,18 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
+    user_options = build_ext.user_options + [
+        ('opt-flags=', 'o', 'optimization flags for compiler')
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.opt_flags = None
+
+    def finalize_options(self):
+        super().finalize_options()
+        pass
+
     def run(self):
         try:
             out = subprocess.check_output(['cmake', '--version'])
@@ -65,6 +77,9 @@ class CMakeBuild(build_ext):
                 cmake_args += ['-DCMAKE_CXX_COMPILER=g++-7']
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
+
+        if self.opt_flags is not None:
+            cmake_args += ['-DOPT_FLAGS=' + self.opt_flags]
 
         cmake_args += ['-DUSE_OMP:STR=No']
         env = os.environ.copy()

--- a/setup_singlethread.py
+++ b/setup_singlethread.py
@@ -24,12 +24,11 @@ class CMakeBuild(build_ext):
     ]
 
     def initialize_options(self):
-        super().initialize_options()
+        build_ext.initialize_options(self)
         self.opt_flags = None
 
     def finalize_options(self):
-        super().finalize_options()
-        pass
+        build_ext.finalize_options(self)
 
     def run(self):
         try:


### PR DESCRIPTION
Default compiler optimization flags can be overridden by OPT_FLAGS cmake variable.
It is also possible to override the flags via setup.py.
E.g.
```
python setup.py build_ext --opt-flags='-march=haswell -mtune=haswell -mfpmath=both'
```