### PR TITLE
Fix compiler specification in setup.py to respect environment variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,14 @@ _VERSION = '0.1.9'
 
 project_name = 'Qulacs'
 
+def _is_valid_compiler(cmd):
+    try:
+        out = subprocess.check_output([cmd, '-dumpfullversion', '-dumpversion']).decode()
+        version = LooseVersion(out)
+        return version >= LooseVersion('7.0.0')
+    except:
+        return False
+
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])
@@ -58,17 +66,21 @@ class CMakeBuild(build_ext):
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:
-            try:
-                gcc = os.getenv('C_COMPILER', 'gcc')
-                gcc_out = subprocess.check_output([gcc, '-dumpfullversion', '-dumpversion']).decode()
-                gcc_version = LooseVersion(gcc_out)
-                gxx = os.getenv('CXX_COMPILER', 'g++')
-                gxx_out = subprocess.check_output([gxx, '-dumpfullversion', '-dumpversion']).decode()
-                gxx_version = LooseVersion(gxx_out)
-            except OSError:
-                raise RuntimeError("gcc/g++ >= 7.0.0 must be installed to build the following extensions: " +
-                               ", ".join(e.name for e in self.extensions))
-            if(gcc_version < LooseVersion('7.0.0') or gxx_version < LooseVersion('7.0.0')):
+            env_gcc = os.getenv('C_COMPILER')
+            if env_gcc:
+                gcc_candidates = [env_gcc]
+            else:
+                gcc_candidates = ['gcc', 'gcc-9', 'gcc-8', 'gcc-7']
+            gcc = next(iter(filter(_is_valid_compiler, gcc_candidates)), None)
+
+            env_gxx = os.getenv('CXX_COMPILER')
+            if env_gxx:
+                gxx_candidates = [env_gxx]
+            else:
+                gxx_candidates = ['g++', 'g++-9', 'g++-8', 'g++-7']
+            gxx = next(iter(filter(_is_valid_compiler, gxx_candidates)), None)
+
+            if gcc is None or gxx is None:
                 raise RuntimeError("gcc/g++ >= 7.0.0 must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
 

--- a/setup.py
+++ b/setup.py
@@ -59,26 +59,21 @@ class CMakeBuild(build_ext):
             build_args += ['--', '/m']
         else:
             try:
-                gcc_out = subprocess.check_output([os.getenv('C_COMPILER', 'gcc'), '-dumpfullversion', '-dumpversion']).decode()
+                gcc = os.getenv('C_COMPILER', 'gcc')
+                gcc_out = subprocess.check_output([gcc, '-dumpfullversion', '-dumpversion']).decode()
                 gcc_version = LooseVersion(gcc_out)
-                gxx_out = subprocess.check_output([os.getenv('CXX_COMPILER', 'g++'), '-dumpfullversion', '-dumpversion']).decode()
+                gxx = os.getenv('CXX_COMPILER', 'g++')
+                gxx_out = subprocess.check_output([gxx, '-dumpfullversion', '-dumpversion']).decode()
                 gxx_version = LooseVersion(gxx_out)
             except OSError:
-                raise RuntimeError("gcc/g++ must be installed to build the following extensions: " +
+                raise RuntimeError("gcc/g++ >= 7.0.0 must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
-            if(gcc_version > LooseVersion('9.0.0')):
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc']
-            elif(gcc_version >= LooseVersion('8.0.0')):
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc-8']
-            else:
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc-7']
+            if(gcc_version < LooseVersion('7.0.0') or gxx_version < LooseVersion('7.0.0')):
+                raise RuntimeError("gcc/g++ >= 7.0.0 must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
 
-            if(gxx_version > LooseVersion('9.0.0')):
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++']
-            elif(gxx_version >= LooseVersion('8.0.0')):
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++-8']
-            else:
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++-7']
+            cmake_args += ['-DCMAKE_C_COMPILER=' + gcc]
+            cmake_args += ['-DCMAKE_CXX_COMPILER=' + gxx]
 
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']


### PR DESCRIPTION
Environment variables `C_COMPILER` and `CXX_COMPILER` were used for checking compiler version,
but they were not used to specify actual compilers used for compilation.
This was a problem when you have incompatible 'gcc'/'g++' in PATH and
specify supported compilers by those environment variables.

I encountered this problem on my mac, where Apple clang version 11.0.3, which does not support `-fopenmp` flag, is installed as `/usr/bin/gcc` and gcc-9/g++-9 are installed by Homebrew as `/usr/local/bin/gcc-9` and `/usr/local/bin/g++-9`. I tried `C_COMPILER=gcc-9 CXX_COMPILER=g++-9` but it did not work.