### PR TITLE
remove experimental qasm load function

### DIFF
--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -63,36 +63,6 @@ QuantumCircuit::QuantumCircuit(UINT qubit_count_):
     this->_qubit_count = qubit_count_;
 }
 
-
-QuantumCircuit::QuantumCircuit(std::string qasm_path, std::string qasm_loader_script_path):
-qubit_count(_qubit_count), gate_list(_gate_list) {
-	// generate quantum circuit from qasm
-	// now we delegate compile of qasm string to quantumopencompiler in qiskit-sdk.
-	std::string exec_string = std::string("python ")+qasm_loader_script_path+" "+qasm_path;
-    const unsigned int MAX_BUF = 1024;
-    char line[MAX_BUF];
-    char* endPoint;
-    FILE* fp;
-
-    
-    fp = popen(exec_string.c_str(),"r");
-    if(fp==NULL){
-        fprintf(stderr,"Error : cannot launch python loader or cannot load QASM: %s\n", qasm_path.c_str());
-        exit(0);
-    }
-    fgets(line,MAX_BUF,fp);
-    this->_qubit_count = atoi(line);
-    while(1){
-        (void)fgets(line,MAX_BUF,fp);
-        if(feof(fp)) break;
-
-        endPoint = strchr(line,'\n');
-        if(endPoint != NULL) *endPoint = '\0';
-        this->add_gate(gate::create_quantum_gate_from_string(line));
-    }
-    pclose(fp);
-}
-
 QuantumCircuit* QuantumCircuit::copy() const{
     QuantumCircuit* new_circuit = new QuantumCircuit(this->_qubit_count);
     for(const auto& gate : this->_gate_list){

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -45,17 +45,6 @@ public:
     QuantumCircuit(UINT qubit_count);
 
     /**
-     * \~japanese-en 量子回路をQASMから生成する
-     * 
-     * QASMのファイルをパスを指定し、QASMに記載されている量子回路を作成する。
-     * QASMのパースのためにqiskitが指定されている必要がある。
-     * @param[in] qasm_path QASMファイルのパス
-     * @param[in] qasm_loader_script_path QASMを読むためのpythonのパス
-     * @return 生成されたインスタンス。生成でエラーが生じた場合はNULLを返す。
-     */
-    QuantumCircuit(std::string qasm_path, std::string qasm_loader_script_path = "qasmloader.py");
-
-    /**
      * \~japanese-en 量子回路のディープコピーを生成する
      * 
      * @return 量子回路のディープコピー

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -5,10 +5,6 @@
 #include "parametric_gate_factory.hpp"
 
 ParametricQuantumCircuit::ParametricQuantumCircuit(UINT qubit_count_) : QuantumCircuit(qubit_count_) {};
-ParametricQuantumCircuit::ParametricQuantumCircuit(std::string qasm_path, std::string qasm_loader_script_path) : QuantumCircuit(qasm_path, qasm_loader_script_path) {
-    // TODO: enables load of parametric gate
-};
-
 
 ParametricQuantumCircuit* ParametricQuantumCircuit::copy() const {
 	ParametricQuantumCircuit* new_circuit = new ParametricQuantumCircuit(this->qubit_count);

--- a/src/vqcsim/parametric_circuit.hpp
+++ b/src/vqcsim/parametric_circuit.hpp
@@ -10,7 +10,6 @@ private:
     std::vector<UINT> _parametric_gate_position;
 public:
     ParametricQuantumCircuit(UINT qubit_count);
-    ParametricQuantumCircuit(std::string qasm_path, std::string qasm_loader_script_path = "qasmloader.py");
 
 	ParametricQuantumCircuit* copy() const;
 	


### PR DESCRIPTION
Originally, there was a function which enables us to load  QASM by delegating compilation tasks to qiksit. However, this requires installation of qiskit, so this function was removed.
Though loading script files are removed, delegating function in cppsim was left not removed. This PR removes confusing residual functions.