### PR TITLE
Fix compiler specification in setup_gpu.py and setup_singlethread.py

### DIFF
--- a/setup_gpu.py
+++ b/setup_gpu.py
@@ -12,6 +12,14 @@ _VERSION = '0.1.9'
 
 project_name = 'Qulacs-GPU'
 
+def _is_valid_compiler(cmd):
+    try:
+        out = subprocess.check_output([cmd, '-dumpfullversion', '-dumpversion']).decode()
+        version = LooseVersion(out)
+        return version >= LooseVersion('7.0.0')
+    except:
+        return False
+
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])
@@ -58,22 +66,27 @@ class CMakeBuild(build_ext):
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:
-            try:
-                gcc_out = subprocess.check_output(['gcc', '-dumpfullversion', '-dumpversion']).decode()
-                gcc_version = LooseVersion(gcc_out)
-                gxx_out = subprocess.check_output(['g++', '-dumpfullversion', '-dumpversion']).decode()
-                gxx_version = LooseVersion(gxx_out)
-            except OSError:
-                raise RuntimeError("gcc/g++ must be installed to build the following extensions: " +
+            env_gcc = os.getenv('C_COMPILER')
+            if env_gcc:
+                gcc_candidates = [env_gcc]
+            else:
+                gcc_candidates = ['gcc', 'gcc-9', 'gcc-8', 'gcc-7']
+            gcc = next(iter(filter(_is_valid_compiler, gcc_candidates)), None)
+
+            env_gxx = os.getenv('CXX_COMPILER')
+            if env_gxx:
+                gxx_candidates = [env_gxx]
+            else:
+                gxx_candidates = ['g++', 'g++-9', 'g++-8', 'g++-7']
+            gxx = next(iter(filter(_is_valid_compiler, gxx_candidates)), None)
+
+            if gcc is None or gxx is None:
+                raise RuntimeError("gcc/g++ >= 7.0.0 must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
-            if(gcc_version >= LooseVersion('7.0.0')):
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc']
-            else:
-                cmake_args += ['-DCMAKE_C_COMPILER=gcc-7']
-            if(gxx_version >= LooseVersion('7.0.0')):
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++']
-            else:
-                cmake_args += ['-DCMAKE_CXX_COMPILER=g++-7']
+
+            cmake_args += ['-DCMAKE_C_COMPILER=' + gcc]
+            cmake_args += ['-DCMAKE_CXX_COMPILER=' + gxx]
+
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
 


### PR DESCRIPTION
The change applied to setup.py in #216 is also applied to setup_gpu.py and setup_singlethread.py.
Now diffs between the setup scripts are simple as follows:

```
$ diff setup.py setup_gpu.py
13c13
< project_name = 'Qulacs'
---
> project_name = 'Qulacs-GPU'
95a96
>         cmake_args += ['-DUSE_GPU:STR=Yes']
```

```
$ diff setup.py setup_singlethread.py
92a93
> 
95a97
>         cmake_args += ['-DUSE_OMP:STR=No']
```