### PR TITLE
Build sdist, bdist_wheel on CI and publish them to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ env:
       CIBW_TEST_REQUIRES='numpy scipy'
       CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY='1'
-      CIBW_ENVIRONMENT='QULACS_OPT_FLAGS="-march=haswell -mtune=haswell -mfpmath=both"'
+      CIBW_ENVIRONMENT='QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
 
 stages:
   - build and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ env:
       CIBW_TEST_REQUIRES='numpy scipy'
       CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY='1'
-      CIBW_ENVIRONMENT='PIP_GLOBAL_OPTION="--opt-flags=\"-march=haswell -mtune=haswell -mfpmath=both\""'
+      CIBW_BEFORE_BUILD='export PIP_GLOBAL_OPTION="--opt-flags=\"-march=haswell -mtune=haswell -mfpmath=both\""'
 
 stages:
   - build and test
@@ -208,7 +208,8 @@ jobs:
       dist: bionic
       services: docker
       env:
-        - CIBW_BEFORE_BUILD='pip install cmake'
+        - CIBW_BEFORE_BUILD='pip install cmake && export PIP_GLOBAL_OPTION="--opt-flags=\"-march=haswell -mtune=haswell -mfpmath=both\""'
+      before_install: *before_install
       install: *wheel_install
       script: *wheel_build
     - name: OSX wheel build

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,16 @@ _script: &script
     fi
 
 _wheel_install: &wheel_install
-  - python -m pip install cibuildwheel==1.4.2
+  - python -m pip install cibuildwheel==1.4.2 twine
 
 _wheel_build: &wheel_build
   - python -m cibuildwheel --output-dir wheels
+
+_wheel_upload: &wheel_upload
+  - if [[ $TRAVIS_TAG ]]; then python -m twine upload wheels/*.whl; fi
+
+_sdist_upload: &sdist_upload
+  - if [[ $TRAVIS_TAG ]]; then python -m twine upload dist/*; fi
 
 language: cpp
 
@@ -98,6 +104,7 @@ env:
       CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY='1'
       CIBW_ENVIRONMENT='QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
+      TWINE_USERNAME=__token__
 
 stages:
   - build and test
@@ -207,6 +214,20 @@ jobs:
       script: *script
       if: false
 
+    - name: Source dist
+      stage: build wheel
+      os: linux
+      dist: bionic
+      env:
+        - PYTHON="${PYTHON3}"
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      before_install: *before_install
+      install:
+        - python -m pip install twine
+      script:
+        - python setup.py sdist
+      after_success: *sdist_upload
     - name: Linux wheel build
       stage: build wheel
       os: linux
@@ -220,6 +241,7 @@ jobs:
       before_install: *before_install
       install: *wheel_install
       script: *wheel_build
+      after_success: *wheel_upload
     - name: OSX wheel build
       stage: build wheel
       os: osx
@@ -228,6 +250,7 @@ jobs:
       before_install: *before_install
       install: *wheel_install
       script: *wheel_build
+      after_success: *wheel_upload
     - name: Windows wheel build
       stage: build wheel
       os: windows
@@ -235,6 +258,7 @@ jobs:
       before_install: *before_install
       install: *wheel_install
       script: *wheel_build
+      after_success: *wheel_upload
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,7 +201,13 @@ jobs:
 
     - name: Linux wheel build
       stage: build wheel
+      os: linux
+      dist: bionic
       services: docker
+      env:
+        - CIBW_BEFORE_BUILD='pip install cmake'
+      install: *wheel_install
+      script: *wheel_build
     - name: OSX wheel build
       stage: build wheel
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,122 +1,4 @@
-language: cpp
-
-env:
-  global:
-    - Fortran_COMPILER='gfortran'
-      BUILD_TYPE='Release'
-      PYTHON3='3.7.5'
-      PYTHON2='2.7.17'
-
-matrix:
-  include:
-    # 1/ OSX GCC8 PYTHON3.7 build
-    - os: osx
-      osx_image: xcode11.2
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-8'
-        - C_COMPILER='gcc-8'
-        - PYTHON="${PYTHON3}"
-        - COVERAGE=OFF
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        homebrew:
-          packages:
-            - gcc@8
-            - swig
-            - openssl
-          update: true
-    # 2/ Linux GCC8 PYTHON3.7 build
-    - os: linux
-      dist: bionic
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-8'
-        - C_COMPILER='gcc-8'
-        - PYTHON="${PYTHON3}"
-        - COVERAGE=ON
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - cmake
-            - g++-8
-            - gcc-8
-            - gfortran-7
-            - lcov
-            - swig
-            - libssl1.0-dev
-    # 3/ Linux GCC7 PYTHON3.7 build
-    - os: linux
-      dist: bionic
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-7'
-        - C_COMPILER='gcc-7'
-        - PYTHON="${PYTHON3}"
-        - COVERAGE=ON
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - cmake
-            - g++-7
-            - gcc-7
-            - gfortran-7
-            - lcov
-            - swig
-            - libssl1.0-dev
-    # 4/ Linux GCC8 PYTHON2.7 build
-    - os: linux
-      dist: bionic
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-8'
-        - C_COMPILER='gcc-8'
-        - PYTHON="${PYTHON2}"
-        - COVERAGE=ON
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - cmake
-            - g++-8
-            - gcc-8
-            - gfortran-7
-            - lcov
-            - swig
-            - libssl-dev
-    # 5/ Windows VS17 PYTHON3.7 build
-    - os: windows
-      env:
-        - COVERAGE=ON
-        - PYTHON="${PYTHON3}"
-        - MSBUILD_BIN='C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin'
-        - CMAKE_BIN='C:\Program Files\CMake'
-        - PYTHON_BIN='C:\Python37'
-        - PATH="$MSBUILD_BIN:$CMAKE_BIN:$PYTHON_BIN:$PYTHON_BIN\Scripts:$PATH"
-
-cache:
-  directories:
-    - $HOME/.local
-    # pip
-    - $HOME/.cache/pip
-    # pyenv
-    - $HOME/.pyenv
-    # Homebrew
-    - $HOME/Library/Caches/Homebrew
-
-before_install:
+_before_install: &before_install
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       travis_retry choco install -y cmake
@@ -147,7 +29,7 @@ before_install:
   - python -m pip install --upgrade pip
   - pip install -U --only-binary=numpy,scipy numpy scipy
 
-install:
+_install: &install
   - set -o pipefail
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
@@ -158,7 +40,7 @@ install:
   # Check if `pip install` will be done successfully or not
   - python setup.py install
 
-script:
+_script: &script
   - set -o pipefail
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
@@ -169,4 +51,137 @@ script:
       make test
       make pythontest
     fi
-    
+
+
+language: cpp
+
+env:
+  global:
+    - Fortran_COMPILER='gfortran'
+      BUILD_TYPE='Release'
+      PYTHON3='3.7.5'
+      PYTHON2='2.7.17'
+
+jobs:
+  include:
+    - name: 1/ OSX GCC8 PYTHON3.7 build
+      os: osx
+      osx_image: xcode11.2
+      compiler: gcc
+      env:
+        - CXX_COMPILER='g++-8'
+        - C_COMPILER='gcc-8'
+        - PYTHON="${PYTHON3}"
+        - COVERAGE=OFF
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      addons:
+        homebrew:
+          packages:
+            - gcc@8
+            - swig
+            - openssl
+          update: true
+      before_install: *before_install
+      install: *install
+      script: *script
+    - name: 2/ Linux GCC8 PYTHON3.7 build
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - CXX_COMPILER='g++-8'
+        - C_COMPILER='gcc-8'
+        - PYTHON="${PYTHON3}"
+        - COVERAGE=ON
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      addons:
+        apt:
+          sources:
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+          packages:
+            - cmake
+            - g++-8
+            - gcc-8
+            - gfortran-7
+            - lcov
+            - swig
+            - libssl1.0-dev
+      before_install: *before_install
+      install: *install
+      script: *script
+    - name: 3/ Linux GCC7 PYTHON3.7 build
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - CXX_COMPILER='g++-7'
+        - C_COMPILER='gcc-7'
+        - PYTHON="${PYTHON3}"
+        - COVERAGE=ON
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      addons:
+        apt:
+          sources:
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+          packages:
+            - cmake
+            - g++-7
+            - gcc-7
+            - gfortran-7
+            - lcov
+            - swig
+            - libssl1.0-dev
+      before_install: *before_install
+      install: *install
+      script: *script
+    - name: 4/ Linux GCC8 PYTHON2.7 build
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - CXX_COMPILER='g++-8'
+        - C_COMPILER='gcc-8'
+        - PYTHON="${PYTHON2}"
+        - COVERAGE=ON
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+      addons:
+        apt:
+          sources:
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+          packages:
+            - cmake
+            - g++-8
+            - gcc-8
+            - gfortran-7
+            - lcov
+            - swig
+            - libssl-dev
+      before_install: *before_install
+      install: *install
+      script: *script
+    - name: 5/ Windows VS17 PYTHON3.7 build
+      os: windows
+      env:
+        - COVERAGE=ON
+        - PYTHON="${PYTHON3}"
+        - MSBUILD_BIN='C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin'
+        - CMAKE_BIN='C:\Program Files\CMake'
+        - PYTHON_BIN='C:\Python37'
+        - PATH="$MSBUILD_BIN:$CMAKE_BIN:$PYTHON_BIN:$PYTHON_BIN\Scripts:$PATH"
+      before_install: *before_install
+      install: *install
+      script: *script
+
+cache:
+  directories:
+    - $HOME/.local
+    # pip
+    - $HOME/.cache/pip
+    # pyenv
+    - $HOME/.pyenv
+    # Homebrew
+    - $HOME/Library/Caches/Homebrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,10 @@ env:
       PYTHON3='3.7.5'
       PYTHON2='2.7.17'
       CIBW_TEST_COMMAND='python {project}/python/test/test_qulacs.py'
-      CIBW_TEST_REQUIRES='numpy'
+      CIBW_TEST_REQUIRES='numpy scipy'
+      CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
+      CIBW_BUILD_VERBOSITY='1'
+      CIBW_ENVIRONMENT='PIP_GLOBAL_OPTION="--opt-flags=\"-march=haswell -mtune=haswell -mfpmath=both\""'
 
 stages:
   - build and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ env:
       CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY='1'
       CIBW_ENVIRONMENT='QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS='delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}'
       TWINE_USERNAME=__token__
 
 stages:
@@ -120,7 +121,6 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
-      if: false
     - name: 2/ Linux GCC8 PYTHON3.7 build
       stage: build and test
       os: linux
@@ -148,7 +148,6 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
-      if: false
     - name: 3/ Linux GCC7 PYTHON3.7 build
       stage: build and test
       os: linux
@@ -176,7 +175,6 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
-      if: false
     - name: 4/ Linux GCC8 PYTHON2.7 build
       stage: build and test
       os: linux
@@ -204,7 +202,6 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
-      if: false
     - name: 5/ Windows VS17 PYTHON3.7 build
       stage: build and test
       os: windows
@@ -212,7 +209,6 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
-      if: false
 
     - name: Source dist
       stage: build wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,30 @@
+_osx_env: &osx_env
+  - CXX_COMPILER='g++-8'
+  - C_COMPILER='gcc-8'
+  - PYTHON="${PYTHON3}"
+  - COVERAGE=OFF
+  - PYENV_ROOT="${HOME}/.pyenv"
+  - PATH="${PYENV_ROOT}/bin:$PATH"
+
+_osx_settings: &osx_settings
+  osx_image: xcode11.2
+  compiler: gcc
+  addons:
+    homebrew:
+      packages:
+        - gcc@8
+        - swig
+        - openssl
+      update: true
+
+_windows_env: &windows_env
+  - COVERAGE=ON
+  - PYTHON="${PYTHON3}"
+  - MSBUILD_BIN='C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin'
+  - CMAKE_BIN='C:\Program Files\CMake'
+  - PYTHON_BIN='C:\Python37'
+  - PATH="$MSBUILD_BIN:$CMAKE_BIN:$PYTHON_BIN:$PYTHON_BIN\Scripts:$PATH"
+
 _before_install: &before_install
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
@@ -52,6 +79,11 @@ _script: &script
       make pythontest
     fi
 
+_wheel_install: &wheel_install
+  - python -m pip install cibuildwheel==1.4.2
+
+_wheel_build: &wheel_build
+  - python -m cibuildwheel --output-dir wheels
 
 language: cpp
 
@@ -61,6 +93,8 @@ env:
       BUILD_TYPE='Release'
       PYTHON3='3.7.5'
       PYTHON2='2.7.17'
+      CIBW_TEST_COMMAND='python {project}/python/test/test_qulacs.py'
+      CIBW_TEST_REQUIRES='numpy'
 
 stages:
   - build and test
@@ -71,22 +105,8 @@ jobs:
     - name: 1/ OSX GCC8 PYTHON3.7 build
       stage: build and test
       os: osx
-      osx_image: xcode11.2
-      compiler: gcc
-      env:
-        - CXX_COMPILER='g++-8'
-        - C_COMPILER='gcc-8'
-        - PYTHON="${PYTHON3}"
-        - COVERAGE=OFF
-        - PYENV_ROOT="${HOME}/.pyenv"
-        - PATH="${PYENV_ROOT}/bin:$PATH"
-      addons:
-        homebrew:
-          packages:
-            - gcc@8
-            - swig
-            - openssl
-          update: true
+      <<: *osx_settings
+      env: *osx_env
       before_install: *before_install
       install: *install
       script: *script
@@ -174,13 +194,7 @@ jobs:
     - name: 5/ Windows VS17 PYTHON3.7 build
       stage: build and test
       os: windows
-      env:
-        - COVERAGE=ON
-        - PYTHON="${PYTHON3}"
-        - MSBUILD_BIN='C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin'
-        - CMAKE_BIN='C:\Program Files\CMake'
-        - PYTHON_BIN='C:\Python37'
-        - PATH="$MSBUILD_BIN:$CMAKE_BIN:$PYTHON_BIN:$PYTHON_BIN\Scripts:$PATH"
+      env: *windows_env
       before_install: *before_install
       install: *install
       script: *script
@@ -190,9 +204,19 @@ jobs:
       services: docker
     - name: OSX wheel build
       stage: build wheel
+      os: osx
+      <<: *osx_settings
+      env: *osx_env
+      before_install: *before_install
+      install: *wheel_install
+      script: *wheel_build
     - name: Windows wheel build
       stage: build wheel
       os: windows
+      env: *windows_env
+      before_install: *before_install
+      install: *wheel_install
+      script: *wheel_build
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ env:
       CIBW_TEST_REQUIRES='numpy scipy'
       CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY='1'
-      QULACS_OPT_FLAGS='-march=haswell -mtune=haswell -mfpmath=both'
+      CIBW_ENVIRONMENT='QULACS_OPT_FLAGS="-march=haswell -mtune=haswell -mfpmath=both"'
 
 stages:
   - build and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ env:
       CIBW_TEST_REQUIRES='numpy scipy'
       CIBW_BUILD='cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY='1'
-      CIBW_BEFORE_BUILD='export PIP_GLOBAL_OPTION="--opt-flags=\"-march=haswell -mtune=haswell -mfpmath=both\""'
+      QULACS_OPT_FLAGS='-march=haswell -mtune=haswell -mfpmath=both'
 
 stages:
   - build and test
@@ -208,7 +208,10 @@ jobs:
       dist: bionic
       services: docker
       env:
-        - CIBW_BEFORE_BUILD='pip install cmake && export PIP_GLOBAL_OPTION="--opt-flags=\"-march=haswell -mtune=haswell -mfpmath=both\""'
+        - PYTHON="${PYTHON3}"
+        - PYENV_ROOT="${HOME}/.pyenv"
+        - PATH="${PYENV_ROOT}/bin:$PATH"
+        - CIBW_BEFORE_BUILD='pip install cmake'
       before_install: *before_install
       install: *wheel_install
       script: *wheel_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,14 @@ env:
       PYTHON3='3.7.5'
       PYTHON2='2.7.17'
 
+stages:
+  - build and test
+  - build wheel
+
 jobs:
   include:
     - name: 1/ OSX GCC8 PYTHON3.7 build
+      stage: build and test
       os: osx
       osx_image: xcode11.2
       compiler: gcc
@@ -86,6 +91,7 @@ jobs:
       install: *install
       script: *script
     - name: 2/ Linux GCC8 PYTHON3.7 build
+      stage: build and test
       os: linux
       dist: bionic
       compiler: gcc
@@ -112,6 +118,7 @@ jobs:
       install: *install
       script: *script
     - name: 3/ Linux GCC7 PYTHON3.7 build
+      stage: build and test
       os: linux
       dist: bionic
       compiler: gcc
@@ -138,6 +145,7 @@ jobs:
       install: *install
       script: *script
     - name: 4/ Linux GCC8 PYTHON2.7 build
+      stage: build and test
       os: linux
       dist: bionic
       compiler: gcc
@@ -164,6 +172,7 @@ jobs:
       install: *install
       script: *script
     - name: 5/ Windows VS17 PYTHON3.7 build
+      stage: build and test
       os: windows
       env:
         - COVERAGE=ON
@@ -175,6 +184,15 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
+
+    - name: Linux wheel build
+      stage: build wheel
+      services: docker
+    - name: OSX wheel build
+      stage: build wheel
+    - name: Windows wheel build
+      stage: build wheel
+      os: windows
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
+      if: false
     - name: 2/ Linux GCC8 PYTHON3.7 build
       stage: build and test
       os: linux
@@ -140,6 +141,7 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
+      if: false
     - name: 3/ Linux GCC7 PYTHON3.7 build
       stage: build and test
       os: linux
@@ -167,6 +169,7 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
+      if: false
     - name: 4/ Linux GCC8 PYTHON2.7 build
       stage: build and test
       os: linux
@@ -194,6 +197,7 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
+      if: false
     - name: 5/ Windows VS17 PYTHON3.7 build
       stage: build and test
       os: windows
@@ -201,6 +205,7 @@ jobs:
       before_install: *before_install
       install: *install
       script: *script
+      if: false
 
     - name: Linux wheel build
       stage: build wheel

--- a/script/fix_wheel_osx.sh
+++ b/script/fix_wheel_osx.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Reference: https://github.com/matthew-brett/delocate/issues/72#issuecomment-623070388
+
+set -ex
+
+wheel_path=$1
+wheel_filename=$(basename $wheel_path)
+dest_dir=$2
+temp_dir=$(mktemp -d)
+
+cd $temp_dir
+unzip $wheel_path
+delocate-path -L qulacs.dylibs .
+zip -r $dest_dir/$wheel_filename *
+cd -
+rm -rf $temp_dir

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,13 @@ class CMakeBuild(build_ext):
             build_args += ['--', '-j2']
 
         if self.opt_flags is not None:
-            cmake_args += ['-DOPT_FLAGS=' + self.opt_flags]
+            opt_flags = self.opt_flags
+        elif os.getenv('QULACS_OPT_FLAGS'):
+            opt_flags = os.getenv('QULACS_OPT_FLAGS')
+        else:
+            opt_flags = None
+        if opt_flags:
+            cmake_args += ['-DOPT_FLAGS=' + opt_flags]
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),


### PR DESCRIPTION
Binary wheels for recent versions are not published on PyPI, which is inconvenient to users since they are forced to prepare a build environment and wait for compile to finish.
I added jobs to build sdist and wheels for mac/Linux/Windows using [cibuildwheel](https://cibuildwheel.readthedocs.io) to Travis CI setting.
Additionally, they are published to PyPI when the build is triggered by a tag.

Summary of additions/changes

- Compiler optimization flags can now be passed via an environment variable `QULACS_OPT_FLAGS` when installing (`python setup.py install` or `pip install` etc.)
- Common parts in `.travis.yml` are extracted and re-used with YAML anchor/reference notation
- Introduced build stages for 1) build/test and 2) build/publish sdist/bdist_wheel
  - The second stage is only executed if the first stage completed without error
- Build sdist
- Build binary wheels
  - Only wheels for CPython on 64bit archtectures are built. Specifically:
      - CPython 2.7, 3.5, 3.6, 3.7, 3.8
      - macOS x86_64, Windows 64bit, manylinux x86_64
      - cf. [cibuildwheel document](https://cibuildwheel.readthedocs.io/en/stable/#what-does-it-do)
  - For mac and Linux
      - Compiled with GCC 8, optimization flags `-mtune=haswell -mfpmath=both`, SIMD enabled
          - Since `-march` is not specified, the compiled binary should be compatible with older CPUs, but the SIMD support requires AVX2 anyway.
  - For Windows
      - Compiled with Visual Studio 2015 (same as build/test stage)
      - AVX2 support is detected from a build machine. At least in [a recent build](https://travis-ci.org/github/qulacs/qulacs/jobs/699979091) it is enabled.
- Publish sdist and wheels to PyPI (only when the build is triggered by a Git tag)
  - An API token of PyPI needs to be set as `TWINE_PASSWORD` in Travis CI setting