### PR TITLE
Bugfix for parametric gate

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -391,17 +391,17 @@ PYBIND11_MODULE(qulacs, m) {
 		return ptr;
 	}, pybind11::return_value_policy::take_ownership, "Create state reflection gate", py::arg("state"));
 
-    mgate.def("BitFlipNoise", &gate::BitFlipNoise, "Create bit-flip noise", py::arg("index"), py::arg("prob"));
-    mgate.def("DephasingNoise", &gate::DephasingNoise, "Create dephasing noise", py::arg("index"), py::arg("prob"));
-    mgate.def("IndependentXZNoise", &gate::IndependentXZNoise, "Create independent XZ noise", py::arg("index"), py::arg("prob"));
-    mgate.def("DepolarizingNoise", &gate::DepolarizingNoise, "Create depolarizing noise", py::arg("index"),py::arg("prob"));
+    mgate.def("BitFlipNoise", &gate::BitFlipNoise, pybind11::return_value_policy::take_ownership, "Create bit-flip noise", py::arg("index"), py::arg("prob"));
+    mgate.def("DephasingNoise", &gate::DephasingNoise, pybind11::return_value_policy::take_ownership, "Create dephasing noise", py::arg("index"), py::arg("prob"));
+    mgate.def("IndependentXZNoise", &gate::IndependentXZNoise, pybind11::return_value_policy::take_ownership, "Create independent XZ noise", py::arg("index"), py::arg("prob"));
+    mgate.def("DepolarizingNoise", &gate::DepolarizingNoise, pybind11::return_value_policy::take_ownership, "Create depolarizing noise", py::arg("index"),py::arg("prob"));
 	mgate.def("TwoQubitDepolarizingNoise", [](UINT target_index1, UINT target_index2, double probability) {
 		auto ptr = gate::TwoQubitDepolarizingNoise(target_index1, target_index2, probability);
 		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to TwoQubitDepolarizingNoise.");
 		return ptr;
 	}, pybind11::return_value_policy::take_ownership, "Create two-qubit depolarizing noise", py::arg("index1"), py::arg("index2"), py::arg("prob"));
-	mgate.def("AmplitudeDampingNoise", &gate::AmplitudeDampingNoise, "Create amplitude damping noise", py::arg("index"), py::arg("prob"));
-    mgate.def("Measurement", &gate::Measurement, "Create measurement gate", py::arg("index"), py::arg("register"));
+	mgate.def("AmplitudeDampingNoise", &gate::AmplitudeDampingNoise, pybind11::return_value_policy::take_ownership, "Create amplitude damping noise", py::arg("index"), py::arg("prob"));
+    mgate.def("Measurement", &gate::Measurement, pybind11::return_value_policy::take_ownership, "Create measurement gate", py::arg("index"), py::arg("register"));
 
     QuantumGateMatrix*(*ptr3)(const QuantumGateBase*, const QuantumGateBase*) = &gate::merge;
     mgate.def("merge", ptr3, pybind11::return_value_policy::take_ownership, "Merge two quantum gate", py::arg("gate1"), py::arg("gate2"));
@@ -425,9 +425,9 @@ PYBIND11_MODULE(qulacs, m) {
 		.def("get_parameter_value", &QuantumGate_SingleParameter::get_parameter_value, "Get parameter value")
 		.def("set_parameter_value", &QuantumGate_SingleParameter::set_parameter_value, "Set parameter value", py::arg("value"))
 		;
-	mgate.def("ParametricRX", &gate::ParametricRX, "Create parametric Pauli-X rotation gate", py::arg("index"), py::arg("angle"));
-    mgate.def("ParametricRY", &gate::ParametricRY, "Create parametric Pauli-Y rotation gate", py::arg("index"), py::arg("angle"));
-    mgate.def("ParametricRZ", &gate::ParametricRZ, "Create parametric Pauli-Z rotation gate", py::arg("index"), py::arg("angle"));
+	mgate.def("ParametricRX", &gate::ParametricRX, pybind11::return_value_policy::take_ownership, "Create parametric Pauli-X rotation gate", py::arg("index"), py::arg("angle"));
+    mgate.def("ParametricRY", &gate::ParametricRY, pybind11::return_value_policy::take_ownership, "Create parametric Pauli-Y rotation gate", py::arg("index"), py::arg("angle"));
+    mgate.def("ParametricRZ", &gate::ParametricRZ, pybind11::return_value_policy::take_ownership, "Create parametric Pauli-Z rotation gate", py::arg("index"), py::arg("angle"));
     mgate.def("ParametricPauliRotation", [](std::vector<unsigned int> target_qubit_index_list, std::vector<unsigned int> pauli_ids, double angle) {
 		auto ptr = gate::ParametricPauliRotation(target_qubit_index_list, pauli_ids, angle);
 		if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to ParametricPauliRotation.");
@@ -438,8 +438,8 @@ PYBIND11_MODULE(qulacs, m) {
         .def(py::init<unsigned int>(), "Constructor", py::arg("qubit_count"))
         .def("copy", &QuantumCircuit::copy, pybind11::return_value_policy::take_ownership, "Create copied instance")
         // In order to avoid double release, we force using add_gate_copy in python
-        .def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*))&QuantumCircuit::add_gate, "Add gate and take ownership", py::arg("gate"))
-        .def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate, "Add gate and take ownership", py::arg("gate"), py::arg("position"))
+        //.def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*))&QuantumCircuit::add_gate, "Add gate and take ownership", py::arg("gate"))
+        //.def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate, "Add gate and take ownership", py::arg("gate"), py::arg("position"))
         .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*))&QuantumCircuit::add_gate_copy, "Add gate with copy", py::arg("gate"))
         .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate_copy, "Add gate with copy", py::arg("gate"), py::arg("position"))
         .def("remove_gate", &QuantumCircuit::remove_gate, "Remove gate", py::arg("position"))
@@ -500,9 +500,9 @@ PYBIND11_MODULE(qulacs, m) {
 
     py::class_<ParametricQuantumCircuit, QuantumCircuit>(m, "ParametricQuantumCircuit")
         .def(py::init<unsigned int>(), "Constructor", py::arg("qubit_count"))
-        .def("copy", &ParametricQuantumCircuit::copy, pybind11::return_value_policy::take_ownership, "Create copied instance")
-        .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate))  &ParametricQuantumCircuit::add_parametric_gate, "Add parametric gate", py::arg("gate"))
-        .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate, UINT))  &ParametricQuantumCircuit::add_parametric_gate, "Add parametric gate", py::arg("gate"), py::arg("position"))
+        .def("copy", &ParametricQuantumCircuit::copy, pybind11::return_value_policy::take_ownership, "Create copied instance")		
+		.def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate))  &ParametricQuantumCircuit::add_parametric_gate_copy, "Add parametric gate", py::arg("gate"))
+        .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate, UINT))  &ParametricQuantumCircuit::add_parametric_gate_copy, "Add parametric gate", py::arg("gate"), py::arg("position"))
         .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate))  &ParametricQuantumCircuit::add_gate_copy, "Add gate", py::arg("gate"))
         .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate, unsigned int))  &ParametricQuantumCircuit::add_gate_copy, "Add gate", py::arg("gate"), py::arg("position"))
         .def("get_parameter_count", &ParametricQuantumCircuit::get_parameter_count, "Get parameter count")

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1,13 +1,13 @@
 
 # set library dir
+import qulacs
+import unittest
+import numpy as np
 import sys
-for ind in range(1,len(sys.argv)):
+for ind in range(1, len(sys.argv)):
     sys.path.append(sys.argv[ind])
 sys.argv = sys.argv[:1]
 
-import numpy as np
-import unittest
-import qulacs
 
 class TestQuantumState(unittest.TestCase):
     def setUp(self):
@@ -20,22 +20,23 @@ class TestQuantumState(unittest.TestCase):
 
     def test_state_dim(self):
         vector = self.state.get_vector()
-        self.assertEqual(len(vector),self.dim, msg = "check vector size")
+        self.assertEqual(len(vector), self.dim, msg="check vector size")
 
     def test_zero_state(self):
         self.state.set_zero_state()
         vector = self.state.get_vector()
         vector_ans = np.zeros(self.dim)
-        vector_ans[0]=1.
-        self.assertTrue(((vector-vector_ans)<1e-10).all(), msg = "check set_zero_state")
+        vector_ans[0] = 1.
+        self.assertTrue(((vector - vector_ans) < 1e-10).all(), msg="check set_zero_state")
 
     def test_comp_basis(self):
         pos = 0b0101
         self.state.set_computational_basis(pos)
         vector = self.state.get_vector()
         vector_ans = np.zeros(self.dim)
-        vector_ans[pos]=1.
-        self.assertTrue(((vector-vector_ans)<1e-10).all(), msg = "check set_computational_basis")
+        vector_ans[pos] = 1.
+        self.assertTrue(((vector - vector_ans) < 1e-10).all(), msg="check set_computational_basis")
+
 
 class TestQuantumCircuit(unittest.TestCase):
     def setUp(self):
@@ -50,14 +51,15 @@ class TestQuantumCircuit(unittest.TestCase):
 
     def test_make_bell_state(self):
         self.circuit.add_H_gate(0)
-        self.circuit.add_CNOT_gate(0,1)
+        self.circuit.add_CNOT_gate(0, 1)
         self.state.set_zero_state()
         self.circuit.update_quantum_state(self.state)
         vector = self.state.get_vector()
         vector_ans = np.zeros(self.dim)
         vector_ans[0] = np.sqrt(0.5)
         vector_ans[3] = np.sqrt(0.5)
-        self.assertTrue(((vector-vector_ans)<1e-10).all(), msg = "check make bell state")
+        self.assertTrue(((vector - vector_ans) < 1e-10).all(), msg="check make bell state")
+
 
 class TestPointerHandling(unittest.TestCase):
     def setUp(self):
@@ -65,7 +67,7 @@ class TestPointerHandling(unittest.TestCase):
 
     def tearDown(self):
         pass
-    
+
     def test_pointer_del(self):
         from qulacs import QuantumCircuit
         from qulacs.gate import X
@@ -77,6 +79,7 @@ class TestPointerHandling(unittest.TestCase):
 
     def test_internal_return_value_of_get_gate_is_valid(self):
         from qulacs import QuantumCircuit, QuantumState
+
         def func():
             def copy_circuit(c):
                 ret = QuantumCircuit(2)
@@ -98,17 +101,131 @@ class TestPointerHandling(unittest.TestCase):
 
         func2()
 
+    def test_circuit_add_gate(self):
+        from qulacs import QuantumCircuit, QuantumState
+        from qulacs.gate import Identity, X, Y, Z, H, S, Sdag, T, Tdag, sqrtX, sqrtXdag, sqrtY, sqrtYdag
+        from qulacs.gate import P0, P1, U1, U2, U3, RX, RY, RZ, CNOT, CZ, SWAP, TOFFOLI, FREDKIN, Pauli, PauliRotation
+        from qulacs.gate import DenseMatrix, SparseMatrix, DiagonalMatrix, RandomUnitary, ReversibleBoolean, StateReflection
+        from qulacs.gate import BitFlipNoise, DephasingNoise, IndependentXZNoise, DepolarizingNoise, TwoQubitDepolarizingNoise, AmplitudeDampingNoise, Measurement
+        from qulacs.gate import merge, add, to_matrix_gate, Probabilistic, CPTP, Instrument, Adaptive
+        from scipy.sparse import lil_matrix
+        qc = QuantumCircuit(3)
+        qs = QuantumState(3)
+        ref = QuantumState(3)
+        sparse_mat = lil_matrix((4, 4))
+        sparse_mat[0, 0] = 1
+        sparse_mat[1, 1] = 1
+
+        def func(v, d):
+            return (v + 1) % d
+
+        def adap(v):
+            return True
+
+        gates = [
+            Identity(0), X(0), Y(0), Z(0), H(0), S(0), Sdag(0), T(0), Tdag(0), sqrtX(0), sqrtXdag(0), sqrtY(0), sqrtYdag(0),
+            Probabilistic([0.5, 0.5], [X(0), Y(0)]), CPTP([P0(0), P1(0)]), Instrument([P0(0), P1(0)], 1), Adaptive(X(0), adap),
+            CNOT(0, 1), CZ(0, 1), SWAP(0, 1), TOFFOLI(0, 1, 2), FREDKIN(0, 1, 2), Pauli([0, 1], [1, 2]), PauliRotation([0, 1], [1, 2], 0.1),
+            DenseMatrix(0, np.eye(2)), DenseMatrix([0, 1], np.eye(4)), SparseMatrix([0, 1], sparse_mat),
+            DiagonalMatrix([0, 1], np.ones(4)), RandomUnitary([0, 1]), ReversibleBoolean([0, 1], func), StateReflection(ref),
+            BitFlipNoise(0, 0.1), DephasingNoise(0, 0.1), IndependentXZNoise(0, 0.1), DepolarizingNoise(0, 0.1), TwoQubitDepolarizingNoise(0, 1, 0.1),
+            AmplitudeDampingNoise(0, 0.1), Measurement(0, 1), merge(X(0), Y(1)), add(X(0), Y(1)), to_matrix_gate(X(0)),
+            P0(0), P1(0), U1(0, 0.), U2(0, 0., 0.), U3(0, 0., 0., 0.), RX(0, 0.), RY(0, 0.), RZ(0, 0.),
+        ]
+        gates.append(merge(gates[0], gates[1]))
+        gates.append(add(gates[0], gates[1]))
+
+        ref = None
+        for gate in gates:
+            qc.add_gate(gate)
+
+        for gate in gates:
+            qc.add_gate(gate)
+
+        qc.update_quantum_state(qs)
+        qc = None
+        qs = None
+        for gate in gates:
+            gate = None
+
+        gates = None
+        parametric_gates = None
+
+    def test_circuit_add_parametric_gate(self):
+        from qulacs import ParametricQuantumCircuit, QuantumState
+        from qulacs.gate import Identity, X, Y, Z, H, S, Sdag, T, Tdag, sqrtX, sqrtXdag, sqrtY, sqrtYdag
+        from qulacs.gate import P0, P1, U1, U2, U3, RX, RY, RZ, CNOT, CZ, SWAP, TOFFOLI, FREDKIN, Pauli, PauliRotation
+        from qulacs.gate import DenseMatrix, SparseMatrix, DiagonalMatrix, RandomUnitary, ReversibleBoolean, StateReflection
+        from qulacs.gate import BitFlipNoise, DephasingNoise, IndependentXZNoise, DepolarizingNoise, TwoQubitDepolarizingNoise, AmplitudeDampingNoise, Measurement
+        from qulacs.gate import merge, add, to_matrix_gate, Probabilistic, CPTP, Instrument, Adaptive
+        from qulacs.gate import ParametricRX, ParametricRY, ParametricRZ, ParametricPauliRotation
+        from scipy.sparse import lil_matrix
+        qc = ParametricQuantumCircuit(3)
+        qs = QuantumState(3)
+        ref = QuantumState(3)
+        sparse_mat = lil_matrix((4, 4))
+        sparse_mat[0, 0] = 1
+        sparse_mat[1, 1] = 1
+
+        def func(v, d):
+            return (v + 1) % d
+
+        def adap(v):
+            return True
+
+        gates = [
+            Identity(0), X(0), Y(0), Z(0), H(0), S(0), Sdag(0), T(0), Tdag(0), sqrtX(0), sqrtXdag(0), sqrtY(0), sqrtYdag(0),
+            Probabilistic([0.5, 0.5], [X(0), Y(0)]), CPTP([P0(0), P1(0)]), Instrument([P0(0), P1(0)], 1), Adaptive(X(0), adap),
+            CNOT(0, 1), CZ(0, 1), SWAP(0, 1), TOFFOLI(0, 1, 2), FREDKIN(0, 1, 2), Pauli([0, 1], [1, 2]), PauliRotation([0, 1], [1, 2], 0.1),
+            DenseMatrix(0, np.eye(2)), DenseMatrix([0, 1], np.eye(4)), SparseMatrix([0, 1], sparse_mat),
+            DiagonalMatrix([0, 1], np.ones(4)), RandomUnitary([0, 1]), ReversibleBoolean([0, 1], func), StateReflection(ref),
+            BitFlipNoise(0, 0.1), DephasingNoise(0, 0.1), IndependentXZNoise(0, 0.1), DepolarizingNoise(0, 0.1), TwoQubitDepolarizingNoise(0, 1, 0.1),
+            AmplitudeDampingNoise(0, 0.1), Measurement(0, 1), merge(X(0), Y(1)), add(X(0), Y(1)), to_matrix_gate(X(0)),
+            P0(0), P1(0), U1(0, 0.), U2(0, 0., 0.), U3(0, 0., 0., 0.), RX(0, 0.), RY(0, 0.), RZ(0, 0.),
+        ]
+
+        gates.append(merge(gates[0], gates[1]))
+        gates.append(add(gates[0], gates[1]))
+
+        parametric_gates = [
+            ParametricRX(0, 0.1), ParametricRY(0, 0.1), ParametricRZ(0, 0.1), ParametricPauliRotation([0, 1], [1, 1], 0.1)
+        ]
+
+        ref = None
+        for gate in gates:
+            qc.add_gate(gate)
+
+        for gate in gates:
+            qc.add_gate(gate)
+
+        for pgate in parametric_gates:
+            qc.add_parametric_gate(pgate)
+
+        for pgate in parametric_gates:
+            qc.add_parametric_gate(pgate)
+
+        qc.update_quantum_state(qs)
+        qc = None
+        qs = None
+        for gate in gates:
+            gate = None
+        for pgate in parametric_gates:
+            gate = None
+
+        gates = None
+        parametric_gates = None
+
     def test_add_same_gate_multiple_time(self):
         from qulacs import QuantumCircuit, QuantumState
         from qulacs.gate import X, DepolarizingNoise, DephasingNoise, Probabilistic, RX
         state = QuantumState(1)
         circuit = QuantumCircuit(1)
-        noise = DepolarizingNoise(0,0)
+        noise = DepolarizingNoise(0, 0)
         circuit.add_gate(noise)
         circuit.add_gate(noise.copy())
-        circuit.add_gate(DephasingNoise(0,0))
-        circuit.add_gate(Probabilistic([0.1],[RX(0,0)]))
-        gate = RX(0,0)
+        circuit.add_gate(DephasingNoise(0, 0))
+        circuit.add_gate(Probabilistic([0.1], [RX(0, 0)]))
+        gate = RX(0, 0)
         circuit.add_gate(gate)
         circuit.add_gate(gate)
         circuit.add_gate(gate)
@@ -125,7 +242,7 @@ class TestPointerHandling(unittest.TestCase):
         circuit.to_string()
         del circuit
         del state
-    
+
     def test_observable(self):
         from qulacs import Observable
         obs = Observable(1)
@@ -151,12 +268,13 @@ class TestPointerHandling(unittest.TestCase):
         del gate
         s = circuit.to_string()
         del circuit
-        
+
     def test_state_reflection(self):
         from qulacs import QuantumState
         from qulacs.gate import StateReflection
         n = 5
         s1 = QuantumState(n)
+
         def gen_gate():
             s2 = QuantumState(n)
             gate = StateReflection(s2)
@@ -168,20 +286,20 @@ class TestPointerHandling(unittest.TestCase):
         del s1
 
     def test_sparse_matrix(self):
-        
+
         from qulacs import QuantumState
         from qulacs.gate import SparseMatrix
         from scipy.sparse import lil_matrix
         n = 5
         state = QuantumState(n)
-        matrix = lil_matrix( (4,4) , dtype = np.complex128)
-        matrix[0,0] = 1 + 1.j
-        matrix[1,1] = 1. + 1.j
-        gate = SparseMatrix([0,1], matrix)
+        matrix = lil_matrix((4, 4), dtype=np.complex128)
+        matrix[0, 0] = 1 + 1.j
+        matrix[1, 1] = 1. + 1.j
+        gate = SparseMatrix([0, 1], matrix)
         gate.update_quantum_state(state)
         del gate
         del state
-        
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -32,6 +32,16 @@ void ParametricQuantumCircuit::add_parametric_gate(QuantumGate_SingleParameter* 
     this->add_gate(gate, index);
     _parametric_gate_list.push_back(gate);
 }
+void ParametricQuantumCircuit::add_parametric_gate_copy(QuantumGate_SingleParameter* gate) {
+	_parametric_gate_position.push_back((UINT)gate_list.size());
+	this->add_gate_copy(gate);
+	_parametric_gate_list.push_back(gate);
+};
+void ParametricQuantumCircuit::add_parametric_gate_copy(QuantumGate_SingleParameter* gate, UINT index) {
+	_parametric_gate_position.push_back(index);
+	this->add_gate_copy(gate, index);
+	_parametric_gate_list.push_back(gate);
+}
 UINT ParametricQuantumCircuit::get_parameter_count() const {
     return (UINT)_parametric_gate_list.size(); 
 }

--- a/src/vqcsim/parametric_circuit.hpp
+++ b/src/vqcsim/parametric_circuit.hpp
@@ -15,7 +15,9 @@ public:
 	
 	virtual void add_parametric_gate(QuantumGate_SingleParameter* gate);
     virtual void add_parametric_gate(QuantumGate_SingleParameter* gate, UINT index);
-    virtual UINT get_parameter_count() const;
+    virtual void add_parametric_gate_copy(QuantumGate_SingleParameter* gate);
+    virtual void add_parametric_gate_copy(QuantumGate_SingleParameter* gate, UINT index);
+	virtual UINT get_parameter_count() const;
     virtual double get_parameter(UINT index) const;
     virtual void set_parameter(UINT index, double value);
 


### PR DESCRIPTION
In the previous release, `add_parametric_gate` function of `ParametricQuantumCircuit` class picks given gate without copying. This results in double-free and causes segmentation fault with the below codes for example.

```python
import qulacs
from qulacs.gate import ParametricRX
pqc = qulacs.ParametricQuantumCircuit(2)
prx = ParametricRX(0,0.1)
pqc.add_parametric_gate(prx)
del prx  # prx gate is released by python
del pqc  # prx gate in pqc is released by C++, and result in segfault.
```

This happens only when you add parametric rotation gates with `add_parametric_gate`, and does not happen with `add_parametric_RX_gate`, for example.
This PR fixes this issue, and I've added several tests on it. This issue is proposed by @akpc .