### PR TITLE
Add a notice of AVX2 to install by pip command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install qulacs
 
 Notice: this command install the Qulacs binary which requires AVX2 features.
 If your computer doesn't support AVX2, the Python program using Qulacs installed by this command will almost certainly fail due to segmentation fault or something else.
-You should check your CPU and if it doesn't support AVX2 then you have to install Qulacs from the source code.
+You should check your CPU and if it doesn't support AVX2 (i.e. older than Haswell) then you have to install Qulacs from the source code.
 
 ```
 pip install git+https://github.com/qulacs/qulacs.git

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Qulacs is licensed under the [MIT license](https://github.com/qulacs/qulacs/blob
 pip install qulacs
 ```
 
+Notice: this command install the Qulacs binary which requires AVX2 features.
+If your computer doesn't support AVX2, the Python program using Qulacs installed by this command will almost certainly fail due to segmentation fault or something else.
+You should check your CPU and if it doesn't support AVX2 then you have to install Qulacs from the source code.
+
+```
+pip install git+https://github.com/qulacs/qulacs.git
+```
+
 If you have NVIDIA GPU with CUDA installed try:
 ```
 pip install qulacs-gpu


### PR DESCRIPTION
- Before merge #233, we always install Qulacs from the source code when run `pip install`
- However after that, the compiled Qulacs binary has been published to PyPI and download it
- Qulacs binary in PyPI requires AVX2 but if the computer where the program using Qulacs will run doesn't support AVX2 then the program will almost certainly fail due to segmentation fault or something else 😇 
- So I add this notice for the user who want to install Qulacs by `pip`
