### PR TITLE
bugfix for measurement-log copy of GPU quantum state

### DIFF
--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -142,6 +142,7 @@ public:
 	virtual QuantumStateBase* copy() const override {
 		QuantumStateGpu* new_state = new QuantumStateGpu(this->_qubit_count, device_number);
 		copy_quantum_state_from_device_to_device(new_state->data(), _state_vector, _dim, _cuda_stream, device_number);
+		for (UINT i = 0; i<_classical_register.size(); ++i) new_state->set_classical_value(i, _classical_register[i]);
 		return new_state;
 	}
 	/**


### PR DESCRIPTION
QuantumStateBase::copy and its overrides must copy not only the state vector but also previous measurement results. It works for CPU state, However, in the case of GPU state, only state vector was copied and measurement results are not copied. I've fixed this point.
