### PR TITLE
add CP map

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -418,7 +418,8 @@ PYBIND11_MODULE(qulacs, m) {
     mgate.def("to_matrix_gate", &gate::to_matrix_gate, pybind11::return_value_policy::take_ownership, "Convert named gate to matrix gate", py::arg("gate"));
     mgate.def("Probabilistic", &gate::Probabilistic, pybind11::return_value_policy::take_ownership, "Create probabilistic gate", py::arg("prob_list"), py::arg("gate_list"));
     mgate.def("CPTP", &gate::CPTP, pybind11::return_value_policy::take_ownership, "Create completely-positive trace preserving map", py::arg("kraus_list"));
-    mgate.def("Instrument", &gate::Instrument, pybind11::return_value_policy::take_ownership, "Create instruments", py::arg("kraus_list"), py::arg("register"));
+	mgate.def("CP", &gate::CP, pybind11::return_value_policy::take_ownership, "Create completely-positive map", py::arg("kraus_list"), py::arg("state_normalize"), py::arg("probability_normalize"), py::arg("assign_zero_if_not_matched"));
+	mgate.def("Instrument", &gate::Instrument, pybind11::return_value_policy::take_ownership, "Create instruments", py::arg("kraus_list"), py::arg("register"));
     mgate.def("Adaptive", &gate::Adaptive, pybind11::return_value_policy::take_ownership, "Create adaptive gate", py::arg("gate"), py::arg("condition"));
 
 	py::class_<QuantumGate_SingleParameter, QuantumGateBase>(m, "QuantumGate_SingleParameter")

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -270,7 +270,7 @@ public:
 					buffer->load(state);
 				}
 			}
-			if (!(r < sum)) {
+			if (!(r * probability_sum < sum)) {
 				if (_assign_zero_if_not_matched) {
 					state->multiply_coef(CPPCTYPE(0.));
 				}

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -202,6 +202,127 @@ public:
     }
 };
 
+
+
+/**
+ * \~japanese-en Kraus表現のCP-map
+ */
+class QuantumGate_CP : public QuantumGateBase {
+protected:
+	Random random;
+	std::vector<QuantumGateBase*> _gate_list;
+	const bool _state_normalize;
+	const bool _probability_normalize;
+	const bool _assign_zero_if_not_matched;
+
+public:
+	QuantumGate_CP(std::vector<QuantumGateBase*> gate_list, bool state_normalize, bool probability_normalize, bool assign_zero_if_not_matched)
+		:_state_normalize(state_normalize), _probability_normalize(probability_normalize), _assign_zero_if_not_matched(assign_zero_if_not_matched){
+		for (auto gate : gate_list) {
+			_gate_list.push_back(gate->copy());
+		}
+	};
+	virtual ~QuantumGate_CP() {
+		for (unsigned int i = 0; i < _gate_list.size(); ++i) {
+			delete _gate_list[i];
+		}
+	}
+
+	/**
+	 * \~japanese-en 量子状態を更新する
+	 *
+	 * @param state 更新する量子状態
+	 */
+	virtual void update_quantum_state(QuantumStateBase* state) override {
+		if (state->is_state_vector()) {
+			double r = random.uniform();
+
+			double sum = 0.;
+			double org_norm = state->get_squared_norm();
+
+			auto buffer = state->copy();
+			double norm;
+
+			// if probability normalize = true
+			//  compute sum of distribution and normalize it
+			double probability_sum = 1.;
+			if (_probability_normalize) {
+				probability_sum = 0.;
+				for (auto gate : _gate_list) {
+					gate->update_quantum_state(buffer);
+					norm = buffer->get_squared_norm() / org_norm;
+					probability_sum += norm;
+				}
+			}
+
+			for (auto gate : _gate_list) {
+				gate->update_quantum_state(buffer);
+				norm = buffer->get_squared_norm() / org_norm;
+				sum += norm;
+				if (r * probability_sum < sum) {
+					state->load(buffer);
+					if (_state_normalize) {
+						state->normalize(norm);
+					}
+					break;
+				}
+				else {
+					buffer->load(state);
+				}
+			}
+			if (!(r < sum)) {
+				if (_assign_zero_if_not_matched) {
+					state->multiply_coef(CPPCTYPE(0.));
+				}
+			}
+			delete buffer;
+		}
+		else {
+			auto org_state = state->copy();
+			auto temp_state = state->copy();
+			for (UINT gate_index = 0; gate_index < _gate_list.size(); ++gate_index) {
+				if (gate_index == 0) {
+					_gate_list[gate_index]->update_quantum_state(state);
+				}
+				else if (gate_index + 1 < _gate_list.size()) {
+					temp_state->load(org_state);
+					_gate_list[gate_index]->update_quantum_state(temp_state);
+					state->add_state(temp_state);
+				}
+				else {
+					_gate_list[gate_index]->update_quantum_state(org_state);
+					state->add_state(org_state);
+				}
+			}
+			delete org_state;
+			delete temp_state;
+		}
+	};
+
+	/**
+	 * \~japanese-en 自身のディープコピーを生成する
+	 *
+	 * @return 自身のディープコピー
+	 */
+	virtual QuantumGateBase* copy() const override {
+		std::vector<QuantumGateBase*> new_gate_list;
+		for (auto item : _gate_list) {
+			new_gate_list.push_back(item->copy());
+		}
+		return new QuantumGate_CP(new_gate_list, _state_normalize, _probability_normalize, _assign_zero_if_not_matched);
+	};
+	/**
+	 * \~japanese-en 自身のゲート行列をセットする
+	 *
+	 * @param matrix 行列をセットする変数の参照
+	 */
+	virtual void set_matrix(ComplexMatrix& matrix) const override {
+		std::cerr << "* Warning : Gate-matrix of CPTP-map cannot be obtained. Identity matrix is returned." << std::endl;
+		matrix = Eigen::MatrixXcd::Ones(1, 1);
+	}
+};
+
+
 /**
  * \~japanese-en Instrument
  */

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -251,6 +251,7 @@ public:
 				for (auto gate : _gate_list) {
 					gate->update_quantum_state(buffer);
 					norm = buffer->get_squared_norm() / org_norm;
+					buffer->load(state);
 					probability_sum += norm;
 				}
 			}

--- a/src/cppsim/gate_merge.cpp
+++ b/src/cppsim/gate_merge.cpp
@@ -348,6 +348,10 @@ namespace gate {
         return new QuantumGate_CPTP(gate_list);
     }
 
+	QuantumGateBase* CP(std::vector<QuantumGateBase*> gate_list, bool state_normalize, bool probability_normalize, bool assign_zero_if_not_matched) {
+		return new QuantumGate_CP(gate_list, state_normalize, probability_normalize, assign_zero_if_not_matched);
+	}
+
     QuantumGateBase* Instrument(std::vector<QuantumGateBase*> gate_list, UINT classical_register_address) {
         return new QuantumGate_Instrument(gate_list, classical_register_address);
     }

--- a/src/cppsim/gate_merge.hpp
+++ b/src/cppsim/gate_merge.hpp
@@ -74,6 +74,18 @@ namespace gate {
      */
     DllExport QuantumGateBase* CPTP(std::vector<QuantumGateBase*> gate_list);
 
+	/**
+	 * \~japanese-en CP-mapを作成する
+	 *
+	 * \f$p_i = {\rm Tr}[K_i \rho K_i^{\dagger}]\f$を計算し、\f$\{p_i\}\f$の確率分布でクラウス演算子を採用する。
+	 * @param gate_list クラウス演算を行うゲートのリスト
+	 * @param state_normlize trueだったら状態を規格化する
+	 * @param probability_normalize trueだったら確率分布を規格化する
+	 * @param assign_zero_if_not_matched どのKraus演算子にもマッチしなかったら0を代入する
+	 * @return CP-map
+	 */
+	DllExport QuantumGateBase* CP(std::vector<QuantumGateBase*> gate_list, bool state_normalize, bool probability_normalize, bool assign_zero_if_not_matched);
+
     /**
      * \~japanese-en Instrumentを作成する
      *


### PR DESCRIPTION
I've added CP-map for the advanced use of an irreversible map.

```python
from qulacs.gate import CP, P0, H
from qulacs import QuantumState
p0 = P0(0)
# If true, state is normalized if Kraus operator is applied.
# If not, state is left unnormalized.
state_normalize = True 
# If true, probability distribution is normalized to unity.
# If not, no Kraus operator may be matched when the map is trace decreasing.
probability_normalize = False
# If true, return zero-filled vector when no Kraus operator is matched.
# If not, return the original input state when no Kraus operator is matched.
# This parameter is meaningless if you set probability_normalize = true.
assign_zero_if_not_matched = True

gate = CP([p0], state_normalize, probability_normalize, assign_zero_if_not_matched)

qs = QuantumState(1)
H(0).update_quantum_state(qs)
gate.update_quantum_state(qs)
```