### PR TITLE
Segfault in get parameter

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -425,6 +425,7 @@ PYBIND11_MODULE(qulacs, m) {
 	py::class_<QuantumGate_SingleParameter, QuantumGateBase>(m, "QuantumGate_SingleParameter")
 		.def("get_parameter_value", &QuantumGate_SingleParameter::get_parameter_value, "Get parameter value")
 		.def("set_parameter_value", &QuantumGate_SingleParameter::set_parameter_value, "Set parameter value", py::arg("value"))
+		.def("copy", &QuantumGate_SingleParameter::copy, pybind11::return_value_policy::take_ownership, "Create copied instance")
 		;
 	mgate.def("ParametricRX", &gate::ParametricRX, pybind11::return_value_policy::take_ownership, "Create parametric Pauli-X rotation gate", py::arg("index"), py::arg("angle"));
     mgate.def("ParametricRY", &gate::ParametricRY, pybind11::return_value_policy::take_ownership, "Create parametric Pauli-Y rotation gate", py::arg("index"), py::arg("angle"));

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -300,6 +300,48 @@ class TestPointerHandling(unittest.TestCase):
         del gate
         del state
 
+    def test_copied_parametric_gate(self):
+
+        from qulacs import ParametricQuantumCircuit, QuantumState
+        from qulacs.gate import ParametricRX
+
+        def f():
+            circuit = ParametricQuantumCircuit(1)
+            gate = ParametricRX(0, 0.1)
+            circuit.add_parametric_gate(gate)
+            circuit.add_parametric_gate(gate)
+            circuit.add_gate(gate)
+            gate.set_parameter_value(0.2)
+            circuit.add_parametric_gate(gate)
+            circuit.add_parametric_RX_gate(0, 0.3)
+            gate2 = gate.copy()
+            gate2.set_parameter_value(0.4)
+            gate.set_parameter_value(1.0)
+            del gate
+            circuit.add_parametric_gate(gate2)
+            circuit.remove_gate(1)
+            del gate2
+            return circuit
+
+        c = f()
+        for gc in range(c.get_parameter_count()):
+            val = c.get_parameter(gc)
+            c.set_parameter(gc, val + 1.0)
+            self.assertAlmostEqual(val, gc * 0.1 + 0.1, msg="check vector size")
+
+        d = c.copy()
+        del c
+        for gc in range(d.get_parameter_count()):
+            val = d.get_parameter(gc)
+            d.set_parameter(gc, val + 10)
+            val = d.get_parameter(gc)
+            self.assertAlmostEqual(val, 11.1 + gc * 0.1, msg="check vector size")
+
+        qs = QuantumState(1)
+        d.update_quantum_state(qs)
+        del d
+        del qs
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -39,10 +39,10 @@ void ParametricQuantumCircuit::add_parametric_gate_copy(QuantumGate_SingleParame
 	_parametric_gate_list.push_back(copied_gate);
 };
 void ParametricQuantumCircuit::add_parametric_gate_copy(QuantumGate_SingleParameter* gate, UINT index) {
+	for (auto& val : _parametric_gate_position) if (val >= index)val++;
 	_parametric_gate_position.push_back(index);
 	QuantumGate_SingleParameter* copied_gate = gate->copy();
 	QuantumCircuit::add_gate(copied_gate, index);
-	for (auto& val : _parametric_gate_position) if (val >= index)val++;
 	_parametric_gate_list.push_back(copied_gate);
 }
 UINT ParametricQuantumCircuit::get_parameter_count() const {

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -34,13 +34,16 @@ void ParametricQuantumCircuit::add_parametric_gate(QuantumGate_SingleParameter* 
 }
 void ParametricQuantumCircuit::add_parametric_gate_copy(QuantumGate_SingleParameter* gate) {
 	_parametric_gate_position.push_back((UINT)gate_list.size());
-	this->add_gate_copy(gate);
-	_parametric_gate_list.push_back(gate);
+	QuantumGate_SingleParameter* copied_gate = gate->copy();
+	QuantumCircuit::add_gate(copied_gate);
+	_parametric_gate_list.push_back(copied_gate);
 };
 void ParametricQuantumCircuit::add_parametric_gate_copy(QuantumGate_SingleParameter* gate, UINT index) {
 	_parametric_gate_position.push_back(index);
-	this->add_gate_copy(gate, index);
-	_parametric_gate_list.push_back(gate);
+	QuantumGate_SingleParameter* copied_gate = gate->copy();
+	QuantumCircuit::add_gate(copied_gate, index);
+	for (auto& val : _parametric_gate_position) if (val >= index)val++;
+	_parametric_gate_list.push_back(copied_gate);
 }
 UINT ParametricQuantumCircuit::get_parameter_count() const {
     return (UINT)_parametric_gate_list.size(); 

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -36,6 +36,7 @@ public:
     }
     virtual void set_parameter_value(double value) { _angle = value; }
     virtual double get_parameter_value() const { return _angle; }
+	virtual QuantumGate_SingleParameter* copy() const override = 0;
 };
 
 class QuantumGate_SingleParameterOneQubitRotation : public QuantumGate_SingleParameter {
@@ -85,7 +86,7 @@ public:
 		matrix = ComplexMatrix::Zero(2, 2);
 		matrix << cos(_angle/2), sin(_angle/2) * 1.i, sin(_angle/2) * 1.i, cos(_angle/2);
 	}
-	virtual QuantumGateBase* copy() const override {
+	virtual QuantumGate_SingleParameter* copy() const override {
 		return new ClsParametricRXGate(*this);
 	};
 };
@@ -105,7 +106,7 @@ public:
 		matrix = ComplexMatrix::Zero(2, 2);
 		matrix << cos(_angle/2), sin(_angle/2), -sin(_angle/2), cos(_angle/2);
 	}
-	virtual QuantumGateBase* copy() const override {
+	virtual QuantumGate_SingleParameter* copy() const override {
 		return new ClsParametricRYGate(*this);
 	};
 };
@@ -125,7 +126,7 @@ public:
 		matrix = ComplexMatrix::Zero(2, 2);
 		matrix << cos(_angle/2) + 1.i*sin(_angle/2), 0, 0, cos(_angle/2) - 1.i * sin(_angle/2);
 	}
-	virtual QuantumGateBase* copy() const override {
+	virtual QuantumGate_SingleParameter* copy() const override {
 		return new ClsParametricRZGate(*this);
 	};
 };
@@ -180,7 +181,7 @@ public:
 				_angle, state->data_c(), state->dim);
 		}
     };
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_SingleParameter* copy() const override {
         return new ClsParametricPauliRotationGate(_angle, _pauli->copy());
     };
     virtual void set_matrix(ComplexMatrix& matrix) const override {


### PR DESCRIPTION
In the previous version, get_parameter invokes segmentation fault.

In qulacs, if add_gate is called from python, copied gate instance is added to a quantum circuit to avoid double free from python and C++.
However, parametric_gate_list, which is an internal member variable to keep where a parametric variable is, is pointing a pointer before copy. Thus, it yields double free in several cases. I've fixed this problem.

This bug is reported by @kosukemtr .