### PR TITLE
Add state control functions

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -236,6 +236,9 @@ PYBIND11_MODULE(qulacs, m) {
 #endif
     mstate.def("inner_product", py::overload_cast<const QuantumState*, const QuantumState*>(&state::inner_product), "Get inner product", py::arg("state_bra"), py::arg("state_ket"));
     //mstate.def("inner_product", &state::inner_product);
+	mstate.def("tensor_product", &state::tensor_product, pybind11::return_value_policy::take_ownership, "Get tensor product of states", py::arg("state_left"), py::arg("state_right"));
+	mstate.def("permutate_qubit", &state::permutate_qubit, pybind11::return_value_policy::take_ownership, "Permutate qubits from state", py::arg("state"), py::arg("order"));
+	mstate.def("drop_qubit", &state::drop_qubit, pybind11::return_value_policy::take_ownership, "Drop qubits from state", py::arg("state"), py::arg("target"), py::arg("projection"));
 
     py::class_<QuantumGateBase>(m, "QuantumGateBase")
         .def("update_quantum_state", &QuantumGateBase::update_quantum_state, "Update quantum state", py::arg("state"))

--- a/src/cppsim/state.cpp
+++ b/src/cppsim/state.cpp
@@ -21,4 +21,26 @@ namespace state {
 		
 		return state_inner_product(state1->data_c(), state2->data_c(), state1->dim);
     }
+	QuantumState* tensor_product(const QuantumState* state_left, const QuantumState* state_right) {
+		UINT qubit_count = state_left->qubit_count + state_right->qubit_count;
+		QuantumState* qs = new QuantumState(qubit_count);
+		state_tensor_product(state_left->data_c(), state_left->dim, state_right->data_c(), state_right->dim, qs->data_c());
+		return qs;
+	}
+	QuantumState* permutate_qubit(const QuantumState* state, std::vector<UINT> qubit_order) {
+		UINT qubit_count = state->qubit_count;
+		QuantumState* qs = new QuantumState(qubit_count);
+		state_permutate_qubit(qubit_order.data(), state->data_c(), qs->data_c(), state->qubit_count, state->dim);
+		return qs;
+	}
+	QuantumState* drop_qubit(const QuantumState* state, std::vector<UINT> target, std::vector<UINT> projection) {
+		if (state->qubit_count <= target.size() || target.size() != projection.size()) {
+			std::cerr << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): invalid qubit count" << std::endl;
+			return NULL;
+		}
+		UINT qubit_count = state->qubit_count - (UINT)target.size();
+		QuantumState* qs = new QuantumState(qubit_count);
+		state_drop_qubits(target.data(), projection.data(), (UINT)target.size(), state->data_c(), qs->data_c(), state->dim);
+		return qs;
+	}
 }

--- a/src/cppsim/state.cpp
+++ b/src/cppsim/state.cpp
@@ -28,6 +28,10 @@ namespace state {
 		return qs;
 	}
 	QuantumState* permutate_qubit(const QuantumState* state, std::vector<UINT> qubit_order) {
+		if (state->qubit_count != (UINT)qubit_order.size()) {
+			std::cerr << "Error: permutate_qubit(const QuantumState*, std::vector<UINT>): invalid qubit count" << std::endl;
+			return NULL;
+		}
 		UINT qubit_count = state->qubit_count;
 		QuantumState* qs = new QuantumState(qubit_count);
 		state_permutate_qubit(qubit_order.data(), state->data_c(), qs->data_c(), state->qubit_count, state->dim);

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -581,5 +581,7 @@ namespace state {
      * @return 内積の値
      */
     CPPCTYPE DllExport inner_product(const QuantumState* state_bra, const QuantumState* state_ket);
-
+	DllExport QuantumState* tensor_product(const QuantumState* state_left, const QuantumState* state_right);
+	DllExport QuantumState* permutate_qubit(const QuantumState* state, std::vector<UINT> qubit_order);
+	DllExport QuantumState* drop_qubit(const QuantumState* state, std::vector<UINT> target, std::vector<UINT> projection);
 }

--- a/src/csim/stat_ops.c
+++ b/src/csim/stat_ops.c
@@ -51,3 +51,45 @@ CTYPE state_inner_product(const CTYPE *state_bra, const CTYPE *state_ket, ITYPE 
 }
 
 
+void state_tensor_product(const CTYPE* state_left, ITYPE dim_left, const CTYPE* state_right, ITYPE dim_right, CTYPE* state_dst) {
+	ITYPE index_left, index_right;
+	for (index_left = 0; index_left < dim_left; ++index_left) {
+		CTYPE val_left = state_left[index_left];
+		for (index_right = 0; index_right < dim_right; ++index_right) {
+			state_dst[index_left*dim_right + index_right] = val_left * state_right[index_right];
+		}
+	}
+}
+void state_permutate_qubit(const UINT* qubit_order, const CTYPE* state_src, CTYPE* state_dst, UINT qubit_count, ITYPE dim) {
+	ITYPE index;
+	for (index = 0; index < dim; ++index) {
+		ITYPE src_index = 0;
+		for (UINT qubit_index = 0; qubit_index < qubit_count; ++qubit_index) {
+			if ((index >> qubit_index) % 2) {
+				src_index += 1ULL << qubit_order[qubit_index];
+			}
+		}
+		state_dst[index] = state_src[src_index];
+	}
+}
+
+void state_drop_qubits(const UINT* target, const UINT* projection, UINT target_count, const CTYPE* state_src, CTYPE* state_dst, ITYPE dim) {
+	ITYPE dst_dim = dim >> target_count;
+	UINT* sorted_target = create_sorted_ui_list(target, target_count);
+	ITYPE projection_mask=0;
+	for (UINT target_index = 0; target_index < target_count; ++target_index) {
+		projection_mask ^= (projection[target_index] << target[target_index]);
+	}
+
+	ITYPE index;
+	for (index = 0; index < dst_dim; ++index) {
+		ITYPE src_index = index;
+		for (UINT target_index = 0; target_index < target_count; ++target_index) {
+			UINT insert_index = sorted_target[target_index];
+			src_index = insert_zero_to_basis_index(src_index, 1ULL << insert_index, insert_index);
+		}
+		src_index ^= projection_mask;
+		state_dst[index] = state_src[src_index];
+	}
+	free(sorted_target);
+}

--- a/src/csim/stat_ops.h
+++ b/src/csim/stat_ops.h
@@ -6,6 +6,10 @@ DllExport double state_norm_squared(const CTYPE *state, ITYPE dim) ;
 DllExport double measurement_distribution_entropy(const CTYPE *state, ITYPE dim);
 DllExport CTYPE state_inner_product(const CTYPE *state_bra, const CTYPE *state_ket, ITYPE dim);
 
+DllExport void state_tensor_product(const CTYPE* state_left, ITYPE dim_left, const CTYPE* state_right, ITYPE dim_right, CTYPE* state_dst);
+DllExport void state_permutate_qubit(const UINT* qubit_order, const CTYPE* state_src, CTYPE* state_dst, UINT qubit_count, ITYPE dim);
+DllExport void state_drop_qubits(const UINT* target, const UINT* projection, UINT target_count, const CTYPE* state_src, CTYPE* state_dst, ITYPE dim);
+
 DllExport double M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double marginal_prob(const UINT* sorted_target_qubit_index_list, const UINT* measured_value_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim);

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -125,3 +125,57 @@ TEST(StateTest, MultiplyCoef) {
 		ASSERT_NEAR(state.data_cpp()[i].imag(), state_vector[i].imag(), eps);
 	}
 }
+
+TEST(StateTest, TensorProduct) {
+	const double eps = 1e-10;
+	const UINT n = 5;
+
+	QuantumState state1(n), state2(n);
+	state1.set_Haar_random_state();
+	state2.set_Haar_random_state();
+
+	QuantumState* state3 = state::tensor_product(&state1, &state2);
+	for (ITYPE i = 0; i < state1.dim; ++i) {
+		for (ITYPE j = 0; j < state2.dim; ++j) {
+			ASSERT_NEAR(state3->data_cpp()[i*state2.dim + j].real(), (state1.data_cpp()[i]*state2.data_cpp()[j]).real(), eps);
+			ASSERT_NEAR(state3->data_cpp()[i*state2.dim + j].imag(), (state1.data_cpp()[i]*state2.data_cpp()[j]).imag(), eps);
+		}
+	}
+	delete state3;
+}
+
+TEST(StateTest, DropQubit) {
+	const double eps = 1e-10;
+	const UINT n = 4;
+
+	QuantumState state(n);
+	state.set_Haar_random_state();
+	QuantumState* state2 = state::drop_qubit(&state, { 2, 0 }, { 0, 1 });
+
+	ASSERT_EQ(state2->dim, 4);
+	int corr[] = { 1,3,9,11 };
+	for (ITYPE i = 0; i < state2->dim; ++i) {
+		ASSERT_NEAR(state2->data_cpp()[i].real(), state.data_cpp()[corr[i]].real(), eps);
+		ASSERT_NEAR(state2->data_cpp()[i].imag(), state.data_cpp()[corr[i]].imag(), eps);
+	}
+	delete state2;
+}
+
+
+
+TEST(StateTest, PermutateQubit) {
+	const double eps = 1e-10;
+	const UINT n = 3;
+
+	QuantumState state(n);
+	state.set_Haar_random_state();
+	QuantumState* state2 = state::permutate_qubit(&state, { 1, 0, 2 });
+
+	int corr[] = {0, 2, 1, 3, 4, 6, 5, 7 };
+	for (ITYPE i = 0; i < state2->dim; ++i) {
+		ASSERT_NEAR(state2->data_cpp()[i].real(), state.data_cpp()[corr[i]].real(), eps);
+		ASSERT_NEAR(state2->data_cpp()[i].imag(), state.data_cpp()[corr[i]].imag(), eps);
+	}
+	delete state2;
+}
+


### PR DESCRIPTION
I've added three functions to control quantum state objects.

1. tensor_product

We can generate a tensor product of two quantum states.

Usage
```python
from qulacs.state import tensor_product
from qulacs import QuantumState

qs1 = QuantumState(3)
qs2 = QuantumState(5)
qs3 = tensor_product(qs1, qs2)
# qs3 is 8-qubit state
# np.kron(qs1.get_vector(), qs2.get_vector()) = tensor_product(qs1, qs2).get_vector()
```

2. permutate_qubit

We can permutate the order of qubits in a quantum state.

Usage
```python
from qulacs.state import permutate_qubit
from qulacs import QuantumState

qs1 = QuantumState(3)
qs2 = permutate_qubit(qs1, [1,0,2])
# qs1's [0,1,2,3,4,5,6,7]-th elements are ordered as [0,2,1,3,4,6,5,7]
```

3. drop_qubit

We can drop a set of qubits from a quantum state with projecting to a given subspace.

Usage
```python
from qulacs.state import drop_qubit
from qulacs import QuantumState

qs1 = QuantumState(3)
drop_index = [2,1]
projection = [0,1]
qs2 = drop_qubit(qs1, drop_index, projection)
# 2nd and 1st qubits are removed, and projected to a subspace of |01*> (rightmost is 0-th qubit).
# Thus, qs2[0] = qs1[2], qs2[1] = qs1[3]
```

