### PR TITLE
Fix C++ Example Compile Commands in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ int main(){
 
 Build command for g++:
 ```sh
-g++ -O2 -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -fopenmp -lcppsim_static.so
+g++ -O2 -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -fopenmp -lcsim_static -lcppsim_static
 ```
 
 If you want to run it on GPU, include <code>cppsim/state_gpu.hpp</code> and replace <code>QuantumState</code> with <code>QuantumStateGpu</code>.

--- a/doc/1_HowToInstall.md
+++ b/doc/1_HowToInstall.md
@@ -83,7 +83,7 @@ int main(){
 
 Example of build command:
 ```sh
-g++ -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -lcppsim.so
+g++ -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -lcsim_static -lcppsim_static
 ```
 
 ### Python Libraries


### PR DESCRIPTION
This PR fix C++ example compile commands in document to work correctly.

I think C++ example compile commands written in document and readme is outdated, and does not work.
So I fixed example commands to work as expected.
