### PR TITLE
Move OpenMP parallel directives of get_expectaiton_value

### DIFF
--- a/src/cppsim/general_quantum_operator.cpp
+++ b/src/cppsim/general_quantum_operator.cpp
@@ -55,11 +55,19 @@ CPPCTYPE GeneralQuantumOperator::get_expectation_value(const QuantumStateBase* s
 		std::cerr << "Error: GeneralQuantumOperator::get_expectation_value(const QuantumStateBase*): invalid qubit count" << std::endl;
 		return 0.;
 	}
-    CPPCTYPE sum = 0;
-    for (auto pauli : this->_operator_list) {
-        sum += pauli->get_expectation_value(state);
+    double sum_real = 0.;
+    double sum_imag = 0.;
+    CPPCTYPE tmp(0., 0.);
+    size_t n_terms = this->_operator_list.size();
+    #ifdef _OPENMP
+    #pragma omp parallel for reduction(+:sum_real, sum_imag) private(tmp)
+    #endif
+    for (int i=0; i<n_terms; ++i) {
+        tmp = _operator_list[i]->get_expectation_value_single_thread(state);
+        sum_real += tmp.real();
+        sum_imag += tmp.imag();
     }
-    return sum;
+    return CPPCTYPE(sum_real, sum_imag);
 }
 
 CPPCTYPE GeneralQuantumOperator::get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const {

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -135,6 +135,51 @@ CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) con
 	}
 }
 
+
+CPPCTYPE PauliOperator::get_expectation_value_single_thread(const QuantumStateBase* state) const {
+    if(state->is_state_vector()){
+#ifdef _USE_GPU
+        if (state->get_device_name() == "gpu") {
+			return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list_host(
+                    this->get_index_list().data(),
+                    this->get_pauli_id_list().data(),
+                    (UINT)this->get_index_list().size(),
+                    state->data(),
+                    state->dim,
+                    state->get_cuda_stream(),
+                    state->device_number
+                    );
+		}
+		else {
+			return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
+                    this->get_index_list().data(),
+                    this->get_pauli_id_list().data(),
+                    (UINT)this->get_index_list().size(),
+                    state->data_c(),
+                    state->dim
+                    );
+		}
+#else
+        return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list_single_thread(
+                this->get_index_list().data(),
+                this->get_pauli_id_list().data(),
+                (UINT)this->get_index_list().size(),
+                state->data_c(),
+                state->dim
+                );
+#endif
+    }
+    else {
+        return _coef * dm_expectation_value_multi_qubit_Pauli_operator_partial_list(
+			this->get_index_list().data(),
+			this->get_pauli_id_list().data(),
+			(UINT)this->get_index_list().size(),
+			state->data_c(),
+			state->dim
+		);
+    }
+}
+
 CPPCTYPE PauliOperator::get_transition_amplitude(const QuantumStateBase* state_bra, const QuantumStateBase* state_ket) const {
 	if ((!state_bra->is_state_vector()) || (!state_ket->is_state_vector())) {
 		std::cerr << "get_transition_amplitude for density matrix is not implemented" << std::endl;

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -205,6 +205,16 @@ public:
      */
     virtual PauliOperator* copy() const;
 
+    /**
+     * \~japanese-en
+     * added by myself
+     * 量子状態に対応するパウリ演算子の期待値を計算する
+     * get_expectation_value の 1 スレッドバージョン
+     *
+     * @param[in] state 期待値をとるときの量子状態
+     * @return stateに対応する期待値
+     */
+    virtual CPPCTYPE get_expectation_value_single_thread(const QuantumStateBase* state) const;
 };
 
 

--- a/src/csim/stat_ops.h
+++ b/src/csim/stat_ops.h
@@ -16,3 +16,7 @@ DllExport double expectation_value_multi_qubit_Pauli_operator_partial_list(const
 
 DllExport CTYPE transition_amplitude_multi_qubit_Pauli_operator_whole_list(const UINT* Pauli_operator_type_list, UINT qubit_count, const CTYPE* state_bra, const CTYPE* state_ket, ITYPE dim);
 DllExport CTYPE transition_amplitude_multi_qubit_Pauli_operator_partial_list(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, const CTYPE* state_bra, const CTYPE* state_ket, ITYPE dim);
+
+DllExport double expectation_value_multi_qubit_Pauli_operator_XZ_mask_single_thread(ITYPE bit_flip_mask, ITYPE phase_flip_mask, UINT global_phase_90rot_count,UINT pivot_qubit_index, const CTYPE* state, ITYPE dim);
+DllExport double expectation_value_multi_qubit_Pauli_operator_Z_mask_single_thread(ITYPE phase_flip_mask, const CTYPE* state, ITYPE dim);
+DllExport double expectation_value_multi_qubit_Pauli_operator_partial_list_single_thread(const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim);


### PR DESCRIPTION
Moved openmp directive from `PauliOperator.get_expectation_value` to `GeneralQuantumOperator.get_expectation_value` for faster computation of expectation values.

This is done by defining new function `PauliOperator::get_expectation_value_single_thread` and single thread version of pauli expectation value functions in `csim/stat_ops_expectation_value`. `PauliOperator::get_expectation_value` is left as is to maintain the speed for single pauli expectation value.
