### PR TITLE
Fix C++ library compile issues and guides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(EIGEN_INSTALL_DIR ${CMAKE_SOURCE_DIR}/include)
 set(EIGEN_INCLUDE_DIR ${EIGEN_INSTALL_DIR})
 ExternalProject_Add(
     eigen
-    URL https://gitlab.com/libeigen/eigen/-/archive/3.3.5/eigen-3.3.5.tar.gz
+    URL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
     PREFIX ${EIGEN_BUILD_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/doc/1_HowToInstall.md
+++ b/doc/1_HowToInstall.md
@@ -85,12 +85,12 @@ Example of build command:
 
 #### GCC
 ```sh
-g++ -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -lcppsim_static -lcsim_static -fopenmp
+g++ -O2 -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -lcppsim_static -lcsim_static -fopenmp
 ```
 
 #### MSVC
 ```sh
-cl -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp ./<qulacs_path>/cppsim_static.lib ./<qulacs_path>/csim_static.lib /openmp
+cl -O2 -I ./<qulacs_path>/include <your_code>.cpp ./<qulacs_path>/cppsim_static.lib ./<qulacs_path>/csim_static.lib /openmp
 ```
 
 ### C++ Libraries with GPU

--- a/doc/1_HowToInstall.md
+++ b/doc/1_HowToInstall.md
@@ -41,7 +41,7 @@ Uninstall
 pip uninstall qulacs
 ```
 
-## Gettig started
+## Getting started
 
 See the following document for more detail.  
 [C++ Tutorial](http://qulacs.org/md_2__tutorial__c_p_p.html)  
@@ -82,9 +82,61 @@ int main(){
 ```
 
 Example of build command:
+
+#### GCC
 ```sh
-g++ -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -lcsim_static -lcppsim_static
+g++ -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp -lcppsim_static -lcsim_static -fopenmp
 ```
+
+#### MSVC
+```sh
+cl -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cpp ./<qulacs_path>/cppsim_static.lib ./<qulacs_path>/csim_static.lib /openmp
+```
+
+### C++ Libraries with GPU
+
+qulacs uses cuBLAS library, so you need to include it.
+if you want to use QuantumStateGpu, define `_USE_GPU` to load QuantumStateGpu definitions.
+
+Example of C++ code:
+```cpp
+#include <iostream>
+#include <cppsim/state_gpu.hpp>
+#include <cppsim/circuit.hpp>
+#include <cppsim/observable.hpp>
+
+int main(){
+    QuantumStateGpu state(3);
+    state.set_Haar_random_state();
+
+    QuantumCircuit circuit(3);
+    circuit.add_X_gate(0);
+    auto merged_gate = gate::merge(gate::CNOT(0,1),gate::Y(1));
+    circuit.add_gate(merged_gate);
+    circuit.add_RX_gate(1,0.5);
+    circuit.update_quantum_state(&state);
+
+    Observable observable(3);
+    observable.add_operator(2.0, "X 2 Y 1 Z 0");
+    observable.add_operator(-3.0, "Z 2");
+    auto value = observable.get_expectation_value(&state);
+    std::cout << value << std::endl;
+    return 0;
+}
+```
+
+Example of build command:
+
+#### GCC
+```sh
+nvcc -O2 -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cu -lcppsim_static -lcsim_static -lgpusim_static -D _USE_GPU -lcublas  -Xcompiler -fopenmp 
+```
+
+#### MSVC
+```sh
+nvcc -O2 -I ./<qulacs_path>/include -L ./<qulacs_path>/lib <your_code>.cu ./<qulacs_path>/cppsim_static.lib ./<qulacs_path>/csim_static.lib ./<qulacs_path>/gpusim_static.lib -D _USE_GPU -lcublas  -Xcompiler /openmp 
+```
+
 
 ### Python Libraries
 You can use features by simply importing `qulacs`.


### PR DESCRIPTION
This PR fix the following two issues:
1. C++ library compile issues
In Eigen 3.3.5 with CUDA, a lot of Eigen users report that compile errors happen in Eigen/Half.h file.
This qulacs C++ library is being affected by this issue.
So, I tried updating version to Eigen 3.3.5 -> 3.3.7, which Eigen maintainers say that the issue has been removed.
I manually checked that this solution passes tests.

2. Usage guide of C++ with CUDA
When we use nvcc, we need to add many compile options compared to non-GPU qulacs.
Therefore, I think it is essential to add usage guide on documents.