### PR TITLE
Fix memleak in observable

### DIFF
--- a/src/cppsim/general_quantum_operator.cpp
+++ b/src/cppsim/general_quantum_operator.cpp
@@ -48,6 +48,7 @@ void GeneralQuantumOperator::add_operator(CPPCTYPE coef, std::string pauli_strin
         this->_is_hermitian = false;
     }
 	this->add_operator(_mpt);
+    delete _mpt;
 }
 
 CPPCTYPE GeneralQuantumOperator::get_expectation_value(const QuantumStateBase* state) const {


### PR DESCRIPTION
There was a memory leak in GeneralQuantumOperator::add_operator.
I've fixed this memory leak.