### PR TITLE
Restore default thread number after disabling parallelization

### DIFF
--- a/src/csim/update_ops_matrix_dense_double.c
+++ b/src/csim/update_ops_matrix_dense_double.c
@@ -25,6 +25,7 @@ void double_qubit_dense_matrix_gate_simd_low(UINT target_qubit_index1, UINT targ
 void double_qubit_dense_matrix_gate_c(UINT target_qubit_index1, UINT target_qubit_index2, const CTYPE matrix[16], CTYPE *state, ITYPE dim) {
 #ifdef _OPENMP
 	UINT threshold = 12;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #endif
 
@@ -35,7 +36,7 @@ void double_qubit_dense_matrix_gate_c(UINT target_qubit_index1, UINT target_qubi
 #endif
 
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 }
 

--- a/src/csim/update_ops_matrix_diagonal_multi.c
+++ b/src/csim/update_ops_matrix_diagonal_multi.c
@@ -28,6 +28,7 @@ void multi_qubit_diagonal_matrix_gate(const UINT* target_qubit_index_list, UINT 
 	ITYPE state_index;
 #ifdef _OPENMP
 	UINT threshold = 14;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #pragma omp parallel for
 #endif
@@ -45,7 +46,7 @@ void multi_qubit_diagonal_matrix_gate(const UINT* target_qubit_index_list, UINT 
 		}
 	}
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 	free((UINT*)sorted_insert_index_list);
 	free((ITYPE*)matrix_mask_list);
@@ -72,6 +73,7 @@ void multi_qubit_control_multi_qubit_diagonal_matrix_gate(const UINT* control_qu
 
 #ifdef _OPENMP
 	UINT threshold = 14;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #pragma omp parallel for
 #endif
@@ -93,7 +95,7 @@ void multi_qubit_control_multi_qubit_diagonal_matrix_gate(const UINT* control_qu
 		}
 	}
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 	free(sorted_insert_index_list);
 	free(matrix_mask_list);

--- a/src/csim/update_ops_pauli_multi.c
+++ b/src/csim/update_ops_pauli_multi.c
@@ -34,6 +34,7 @@ void multi_qubit_Pauli_gate_XZ_mask(ITYPE bit_flip_mask, ITYPE phase_flip_mask, 
 
 #ifdef _OPENMP
 	UINT threshold = 14;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #pragma omp parallel for
 #endif
@@ -58,7 +59,7 @@ void multi_qubit_Pauli_gate_XZ_mask(ITYPE bit_flip_mask, ITYPE phase_flip_mask, 
 		state[basis_1] = cval_0 * PHASE_M90ROT[(global_phase_90rot_count + sign_1 * 2) % 4];
 	}
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 }
 void multi_qubit_Pauli_rotation_gate_XZ_mask(ITYPE bit_flip_mask, ITYPE phase_flip_mask, UINT global_phase_90rot_count, UINT pivot_qubit_index, double angle, CTYPE* state, ITYPE dim) {
@@ -75,6 +76,7 @@ void multi_qubit_Pauli_rotation_gate_XZ_mask(ITYPE bit_flip_mask, ITYPE phase_fl
 	const double sinval = sin(angle / 2);
 #ifdef _OPENMP
 	UINT threshold = 14;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #pragma omp parallel for
 #endif
@@ -99,7 +101,7 @@ void multi_qubit_Pauli_rotation_gate_XZ_mask(ITYPE bit_flip_mask, ITYPE phase_fl
 		state[basis_1] = cosval * cval_1 + 1.i * sinval * cval_0 * PHASE_M90ROT[(global_phase_90rot_count + bit_parity_1 * 2) % 4];
 	}
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 }
 
@@ -111,6 +113,7 @@ void multi_qubit_Pauli_gate_Z_mask(ITYPE phase_flip_mask, CTYPE* state, ITYPE di
 
 #ifdef _OPENMP
 	UINT threshold = 14;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #pragma omp parallel for
 #endif
@@ -124,7 +127,7 @@ void multi_qubit_Pauli_gate_Z_mask(ITYPE phase_flip_mask, CTYPE* state, ITYPE di
 		}
 	}
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 }
 
@@ -141,6 +144,7 @@ void multi_qubit_Pauli_rotation_gate_Z_mask(ITYPE phase_flip_mask, double angle,
 
 #ifdef _OPENMP
 	UINT threshold = 14;
+	UINT default_thread_count = omp_get_max_threads();
 	if (dim < (((ITYPE)1) << threshold)) omp_set_num_threads(1);
 #pragma omp parallel for
 #endif
@@ -154,7 +158,7 @@ void multi_qubit_Pauli_rotation_gate_Z_mask(ITYPE phase_flip_mask, double angle,
 		state[state_index] *= cosval + (CTYPE)sign * 1.i * sinval;
 	}
 #ifdef _OPENMP
-	omp_set_num_threads(omp_get_max_threads());
+	omp_set_num_threads(default_thread_count);
 #endif
 }
 


### PR DESCRIPTION
Qulacs automatically disable parallelization when the number of qubits is small.
In the previous release, once parallelization is disabled in several functions, OMP_NUM_THREADS is overwritten to 1 and never restored to the original values. This does not affect the numerical results, but slow down the successive computation.
I've fixed this bug in this PR.

```
# Before PR
# num_qubit time_per_gate
25 0.07381165879113334
25 0.09755897521972656 Pauli
5 1.5777012765499026e-06
5 2.0947527406195033e-06 Pauli
25 0.19424397295171564
25 0.43433232307434083 Pauli

# After PR
# num_qubit time_per_gate
25 0.0742875646661829
25 0.10022400674365815 Pauli
5 1.5065100076042516e-06
5 1.933501226313842e-06 Pauli
25 0.08536406358083089
25 0.09836796351841517 Pauli
```