### PR TITLE
Change Windows wheel build to `allow_failure`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -247,6 +247,7 @@ jobs:
       install: *wheel_install
       script: *wheel_build
       after_success: *wheel_upload
+  allow_failures:
     - name: Windows wheel build
       stage: build wheel
       os: windows


### PR DESCRIPTION
- Windows wheel build is failing 😇 
    - https://travis-ci.org/github/qulacs/qulacs/jobs/740111232
- The error said:
    - > `urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)>`
- It occurs even though we use the latest version of `certifi`
- For now, would it be better to give `Windows wheel build` up? 🤔 