### PR TITLE
Fix: ignore trailing whitespaces in Pauli string.

### DIFF
--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -31,7 +31,7 @@ extern "C"{
 
 PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef){
     _coef = coef;
-    std::stringstream ss(strings);
+    std::stringstream ss(rtrim(strings));
     std::string pauli_str;
     UINT index, pauli_type=0;
     while(!ss.eof()){

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -105,3 +105,9 @@ bool check_is_unique_index_list(std::vector<UINT> index_list) {
 	}
 	return flag;
 }
+
+std::string& rtrim(std::string& str) {
+	auto it = std::find_if(str.rbegin(), str.rend(), [](unsigned char c){return !std::isspace(c);});
+	str.erase(it.base(), str.end());
+	return str;
+}

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <cstdio>
+#include <cctype>
 #include <chrono>
+#include <cstdio>
 #include <random>
 #include <string>
 #include <tuple>
@@ -195,3 +196,11 @@ DllExport std::tuple<double, double, std::string> parse_openfermion_line(std::st
  * @return 重複がある場合にtrue、ない場合にfalse
  */
 bool check_is_unique_index_list(std::vector<UINT> index_list);
+
+/**
+ * \~japanese-en 与えられた文字列の末尾の空白文字を削除します。
+ *
+ * @param[in] str 文字列
+ * @return 末尾の空白文字を削除された文字列
+ */
+std::string& rtrim(std::string& str);


### PR DESCRIPTION
This PR fixes issue #257.

### Added

- `rtrim` function to `utility`.

### Changes

- Trim trailing whitespaces in given Pauli string in the beginning of process to construct PauliOperator.
 Then, PauliOperator will be created properly.

### How it works

```
Python 3.7.8 (default, Aug 17 2020, 14:49:28)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from qulacs import PauliOperator
>>> p = PauliOperator("X 0 Y 1    ", 1.0) # with writespaces
>>> assert len(p.get_index_list()) == 2
```