### PR TITLE
Add GitHub Action setting file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,129 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  gcc8-build:
+    name: GCC8 build
+    strategy:
+      matrix:
+        python-version: [ '3.7.5', '2.7.17' ]
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-2016' ]
+    runs-on: ${{ matrix.os }}
+    env:
+      CXX_COMPILER: 'g++-8'
+      C_COMPILER: 'gcc-8'
+      PYTHON: ${{ matrix.python-version }}
+      COVERAGE: 'ON'
+    steps:
+      - uses: actions/checkout@v2
+       
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+  
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          
+      - name: Install Python dependencies
+        run: pip install -U --only-binary=numpy,scipy numpy scipy
+        
+      - name: Install qulacs for Windows
+        run: ./script/build_msvc_2017.bat
+        if: ${{ contains(matrix.os, 'windows') }}
+
+      - name: Install qulacs for macOS or Ubuntu
+        run: ./script/build_gcc.sh
+        if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu') }}
+
+      - name: Install qulacs Python module
+        run: python setup.py install
+
+      - name: Test in Windows
+        run: |
+          cmake --build ./visualstudio --target test --config Release
+          cmake --build ./visualstudio --target pythontest --config Release      
+        if: ${{ contains(matrix.os, 'windows') }}
+        
+      - name: Test in macOS or Ubuntu
+        run: |
+          cd ./build
+          make test
+          make pythontest
+        if: ${{ contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu') }}
+
+  source-dist:
+    name: Source dist
+    needs: gcc8-build
+    strategy:
+      matrix:
+        python-version: [ '3.7.5' ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          
+      - name: Install twine
+        run: python -m pip install twine
+
+      - name: Run sdist
+        run: python setup.py sdist
+
+      - name: Uplead the source if the Git tag is set
+        run: python -m twine upload dist/*
+        # This condition is refered for:
+        #   https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
+        if: ${{ contains(github.ref, '/tags/') }}
+
+  wheel-build:
+    name: Python wheel build
+    needs: gcc8-build
+    strategy:
+      matrix:
+        python-version: [ '3.7.5' ]
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-2016' ]
+    runs-on: ${{ matrix.os }}
+    env:
+      CXX_COMPILER: 'g++-8'
+      C_COMPILER: 'gcc-8'
+      PYTHON: ${{ matrix.python-version }}
+      COVERAGE: 'ON'
+      CIBW_TEST_COMMAND: 'python {project}/python/test/test_qulacs.py'
+      CIBW_TEST_REQUIRES: 'numpy scipy'
+      CIBW_BEFORE_BUILD: 'pip install cmake'
+      CIBW_BUILD: 'cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
+      CIBW_BUILD_VERBOSITY: '1'
+      CIBW_ENVIRONMENT: 'QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: 'delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}'
+      TWINE_USERNAME: '__token__'
+    steps:
+      - uses: actions/checkout@v2
+       
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+  
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          
+      - name: Install Python dependencies
+        run: python -m pip install cibuildwheel==1.4.2 twine
+
+      - name: Run cibuildwheel
+        run: python -m cibuildwheel --output-dir wheels
+
+      - name: Upload wheel data if the Git tag is set
+        run: python -m twine upload wheels/*.whl
+        if: ${{ contains(github.ref, '/tags/') }}
+

--- a/script/build_msvc_2017.bat
+++ b/script/build_msvc_2017.bat
@@ -1,6 +1,6 @@
 mkdir visualstudio
 cd visualstudio
-cmake -G "Visual Studio 15 2017 Win64" ..
+cmake -G "Visual Studio 15 2017" -A "x64" ..
 cd ..
 cmake --build ./visualstudio --target ALL_BUILD --config Release
 cmake --build ./visualstudio --target python --config Release


### PR DESCRIPTION
- Travis CI( [travis-ci.**com**](https://travis-ci.com) ) has been required an application to use their resource unlimitedly even though we are OSS works
    - https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
    - > We will be offering an allotment of OSS minutes that will be reviewed and allocated on a case by case basis. Should you want to apply for these credits please open a request with Travis CI support stating that you’d like to be considered for the OSS allotment
- We use [travis-ci.**org**](https://travis-ci.org) so it's not irrelevant for now.....
    - But [travis-ci.org](https://travis-ci.org) is now _deprecated_ 😢 
    - Since [travis-ci.org](https://travis-ci.org) is using GitHub V1 API, it causes many problems such like the build status would not be updated
        - For example: https://github.com/gfngfn/SATySFi/issues/224
    - In the common sense, we have to move [travis-ci.com](https://travis-ci.com) even if we keep using Travis CI
- Then I make GitHub Action setting, which could be the next our CI service
    - Example result: https://github.com/y-yu/qulacs/actions/runs/362695201
        - It's done in 40 minutes
           <img src="https://user-images.githubusercontent.com/612043/99139116-63ab4880-2679-11eb-9793-ee1b90355894.png" width="50%" />
        - It seems to be tow times faster than the current Travis CI
           <img src="https://user-images.githubusercontent.com/612043/99139158-bedd3b00-2679-11eb-86d0-e376abab236a.png" width="60%" />
