### PR TITLE
Fix CI on mac; upload built wheel files as CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,11 @@ jobs:
       - name: Run cibuildwheel
         run: python -m cibuildwheel --output-dir wheels
 
+      - name: Upload wheel files as build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: wheels/*.whl
+
       - name: Upload wheel data if the Git tag is set
         run: python -m twine upload wheels/*.whl
         if: ${{ contains(github.ref, '/tags/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         run: pip install -U --only-binary=numpy,scipy numpy scipy
 
       - name: Workaround for OpenMP link error on mac
+        # In GitHub Actions virtual environment macos-10.15/20201115.1,
+        # linking some functions from libgomp fails since the linker cannot find
+        # some library files from gcc-8 installed via Homebrew.
+        # The following command fixes this issue by (brew) re-linking files from gcc-8.
+        # cf. https://stackoverflow.com/a/55500164
         run: brew link --overwrite gcc@8
         if: ${{ contains(matrix.os, 'macos') }}
         
@@ -104,6 +109,11 @@ jobs:
       CIBW_TEST_COMMAND: 'python {project}/python/test/test_qulacs.py'
       CIBW_TEST_REQUIRES: 'numpy scipy'
       CIBW_BEFORE_BUILD: 'pip install cmake'
+      # In GitHub Actions virtual environment macos-10.15/20201115.1,
+      # linking some functions from libgomp fails since the linker cannot find
+      # some library files from gcc-8 installed via Homebrew.
+      # The following command fixes this issue by (brew) re-linking files from gcc-8.
+      # cf. https://stackoverflow.com/a/55500164
       CIBW_BEFORE_BUILD_MACOS: 'brew link --overwrite gcc@8 && pip install cmake'
       CIBW_BUILD: 'cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ jobs:
       - name: Run sdist
         run: python setup.py sdist
 
+      - name: Upload sdist file as build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
+
       - name: Uplead the source if the Git tag is set
         run: python -m twine upload dist/*
         # This condition is refered for:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
           
       - name: Install Python dependencies
         run: pip install -U --only-binary=numpy,scipy numpy scipy
+
+      - name: Workaround for OpenMP link error on mac
+        run: brew link --overwrite gcc@8
+        if: ${{ contains(matrix.os, 'macos') }}
         
       - name: Install qulacs for Windows
         run: ./script/build_msvc_2017.bat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
       CIBW_TEST_COMMAND: 'python {project}/python/test/test_qulacs.py'
       CIBW_TEST_REQUIRES: 'numpy scipy'
       CIBW_BEFORE_BUILD: 'pip install cmake'
+      CIBW_BEFORE_BUILD_MACOS: 'brew link --overwrite gcc@8 && pip install cmake'
       CIBW_BUILD: 'cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY: '1'
       CIBW_ENVIRONMENT: 'QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'


### PR DESCRIPTION
In GitHub Actions virtual environment [macos-10.15/20201115.1](https://github.com/actions/virtual-environments/blob/macOS-10.15/20201115.1/images/macos/macos-10.15-Readme.md), linking some functions from libgomp fails since the linker cannot find some library files from gcc-8 installed via Homebrew.
Failure example: https://github.com/qulacs/qulacs/runs/1462123962?check_suite_focus=true#step:10:165
Added a command that fixes this issue by (brew) re-linking files from gcc-8.
cf. https://stackoverflow.com/a/55500164

Also added a setting to upload built wheel files as CI artifacts so that we can download and test them on local machines before publishing to PyPI.

