### PR TITLE
CI: Publish qulacs-gpu sdist to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Install twine
-        run: python -m pip install twine
-
       - name: Run sdist
         run: python setup.py sdist
 
@@ -93,7 +90,9 @@ jobs:
           path: dist/*
 
       - name: Uplead the source if the Git tag is set
-        run: python -m twine upload dist/*
+        run: |
+          python -m pip install twine
+          python -m twine upload dist/*
         # This condition is refered for:
         #   https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
         if: ${{ contains(github.ref, '/tags/') }}
@@ -114,9 +113,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
           
-      - name: Install twine
-        run: python -m pip install twine
-
       - name: Switch setup.py to GPU enabled version
         run: cp setup_gpu.py setup.py
 
@@ -129,7 +125,9 @@ jobs:
           path: dist/*
 
       - name: Uplead the source if the Git tag is set
-        run: python -m twine upload dist/*
+        run: |
+          python -m pip install twine
+          python -m twine upload dist/*
         # This condition is refered for:
         #   https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
         if: ${{ contains(github.ref, '/tags/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,45 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+
+      - name: Install twine
+        run: python -m pip install twine
+
+      - name: Run sdist
+        run: python setup.py sdist
+
+      - name: Upload sdist file as build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
+
+      - name: Uplead the source if the Git tag is set
+        run: python -m twine upload dist/*
+        # This condition is refered for:
+        #   https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
+        if: ${{ contains(github.ref, '/tags/') }}
+
+  source-dist-gpu:
+    name: Source dist (Qulacs-GPU)
+    needs: gcc8-build
+    strategy:
+      matrix:
+        python-version: [ '3.7.5' ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
           
       - name: Install twine
         run: python -m pip install twine
+
+      - name: Switch setup.py to GPU enabled version
+        run: cp setup_gpu.py setup.py
 
       - name: Run sdist
         run: python setup.py sdist

--- a/setup_gpu.py
+++ b/setup_gpu.py
@@ -91,7 +91,13 @@ class CMakeBuild(build_ext):
             build_args += ['--', '-j2']
 
         if self.opt_flags is not None:
-            cmake_args += ['-DOPT_FLAGS=' + self.opt_flags]
+            opt_flags = self.opt_flags
+        elif os.getenv('QULACS_OPT_FLAGS'):
+            opt_flags = os.getenv('QULACS_OPT_FLAGS')
+        else:
+            opt_flags = None
+        if opt_flags:
+            cmake_args += ['-DOPT_FLAGS=' + opt_flags]
 
         cmake_args += ['-DUSE_GPU:STR=Yes']
         env = os.environ.copy()

--- a/setup_singlethread.py
+++ b/setup_singlethread.py
@@ -92,7 +92,13 @@ class CMakeBuild(build_ext):
 
 
         if self.opt_flags is not None:
-            cmake_args += ['-DOPT_FLAGS=' + self.opt_flags]
+            opt_flags = self.opt_flags
+        elif os.getenv('QULACS_OPT_FLAGS'):
+            opt_flags = os.getenv('QULACS_OPT_FLAGS')
+        else:
+            opt_flags = None
+        if opt_flags:
+            cmake_args += ['-DOPT_FLAGS=' + opt_flags]
 
         cmake_args += ['-DUSE_OMP:STR=No']
         env = os.environ.copy()


### PR DESCRIPTION
-  Sync setup.py for GPU and single thread with the default setup.py
  - They should have been updated in #233
- Add CI setting to upload sdist for GPU enabled version
- Install twine only when publishing to PyPI