### PR TITLE
Use latest cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           architecture: x64
           
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==1.4.2 twine
+        run: python -m pip install cibuildwheel twine
 
       - name: Run cibuildwheel
         run: python -m cibuildwheel --output-dir wheels


### PR DESCRIPTION
The old version (1.4.2) of cibuildwheel does not build wheel files for Python 3.9.
Let's use the latest cibuildwheel so that wheel files for new Python versions are automatically built.