### PR TITLE
Fix pauli operator get expection value

### DIFF
--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -95,7 +95,7 @@ CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) con
     if (state->qubit_count < this->get_qubit_count()) {
         std::cerr << "Error: PauliOperator::get_expectation_value(QuantumStateBase*) : The number of qubit in PauliOperator is greater than QuantumState. PauliOperator: " 
                << this -> get_qubit_count() << " QuantumState: " << state -> qubit_count << std::endl;
-        return std::nan("");
+        return CPPCTYPE(std::nan(""), std::nan(""));
     }
 	if(state->is_state_vector()){
 #ifdef _USE_GPU

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -35,8 +35,16 @@ PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef){
     std::string pauli_str;
     UINT index, pauli_type=0;
     while(!ss.eof()){
+        pauli_str.clear();
+        index = UINT_MAX - 1;
         ss >> pauli_str >> index;
-        if (pauli_str.length() == 0) break;
+        if (index == UINT_MAX - 1) {
+            if (pauli_str.empty() == false) {
+                std::cerr << "Warning: PauliOperator::PauliOperator(std::string, CPPCTYPE) : detected pauli_str without indexs. Maybe mistyped?" << std::endl;
+                std::cerr << "Original Pauli string: " << strings << std::endl;
+            }
+            break;
+        }
         if(pauli_str=="I" || pauli_str=="i") pauli_type = 0;
         else if(pauli_str=="X" || pauli_str=="x") pauli_type = 1;
         else if(pauli_str=="Y" || pauli_str=="y") pauli_type = 2;

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -105,15 +105,6 @@ CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) con
 				state->device_number
 			);
 		}
-		else {
-			return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
-				this->get_index_list().data(),
-				this->get_pauli_id_list().data(),
-				(UINT)this->get_index_list().size(),
-				state->data_c(),
-				state->dim
-			);
-		}
 #else
 		return _coef * expectation_value_multi_qubit_Pauli_operator_partial_list(
 			this->get_index_list().data(),

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -92,6 +92,11 @@ void PauliOperator::add_single_Pauli(UINT qubit_index, UINT pauli_type){
 }
 
 CPPCTYPE PauliOperator::get_expectation_value(const QuantumStateBase* state) const {
+    if (state->qubit_count < this->get_qubit_count()) {
+        std::cerr << "Error: PauliOperator::get_expectation_value(QuantumStateBase*) : The number of qubit in PauliOperator is greater than QuantumState. PauliOperator: " 
+               << this -> get_qubit_count() << " QuantumState: " << state -> qubit_count << std::endl;
+        return std::nan("");
+    }
 	if(state->is_state_vector()){
 #ifdef _USE_GPU
 		if (state->get_device_name() == "gpu") {

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -82,6 +82,11 @@ public:
         return res;
     }
 
+    UINT get_qubit_count() const{
+        std::vector<UINT> index_list = get_index_list();
+        if (index_list.size() == 0) return 0;
+        return *std::max_element(index_list.begin(), index_list.end()) + 1;
+    }
     /**
      * \~japanese-en
      * 自身が保持するパウリ演算子を返す。

--- a/test/cppsim/test_pauli_operator.cpp
+++ b/test/cppsim/test_pauli_operator.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+#include "../util/util.h"
+
+#include <cppsim/state.hpp>
+#include <cppsim/gate_factory.hpp>
+#include <cppsim/gate_merge.hpp>
+#include <cppsim/circuit.hpp>
+#include <cppsim/pauli_operator.hpp>
+
+TEST(PauliOperatorTest,BasicTest) {
+	//This test is based on issue #259. Thanks tsuvihatu!
+	int n = 10;
+	double coef = 2.0;
+	std::string Pauli_string = "X 0 Y 1 Z 2 I 3 X 4 Y 6 Z 5 I 8 X 7 Y 9";
+	PauliOperator pauli = PauliOperator(Pauli_string, coef);
+	QuantumState state = QuantumState(n);
+	state.set_Haar_random_state();
+	CPPCTYPE value = pauli.get_expectation_value(&state);
+	ASSERT_NE(value, CPPCTYPE(0,0));
+}
+
+TEST(PauliOperatorTest, PauliQubitOverflow) {
+	//This test is based on issue #259. Thanks tsuvihatu!
+	int n = 2;
+	double coef = 2.0;
+	std::string Pauli_string = "X 0 X 1 X 3";
+	PauliOperator pauli = PauliOperator(Pauli_string, coef);
+	QuantumState state = QuantumState(n);
+	state.set_Haar_random_state();
+	CPPCTYPE value = pauli.get_expectation_value(&state);
+	ASSERT_NE(value, value); // (value != value is true) if and only if value is NaN.
+}

--- a/test/cppsim/test_pauli_operator.cpp
+++ b/test/cppsim/test_pauli_operator.cpp
@@ -8,7 +8,6 @@
 #include <cppsim/pauli_operator.hpp>
 
 TEST(PauliOperatorTest,BasicTest) {
-	//This test is based on issue #259. Thanks tsuvihatu!
 	int n = 10;
 	double coef = 2.0;
 	std::string Pauli_string = "X 0 Y 1 Z 2 I 3 X 4 Y 6 Z 5 I 8 X 7 Y 9";
@@ -29,4 +28,32 @@ TEST(PauliOperatorTest, PauliQubitOverflow) {
 	state.set_Haar_random_state();
 	CPPCTYPE value = pauli.get_expectation_value(&state);
 	ASSERT_NE(value, value); // (value != value is true) if and only if value is NaN.
+}
+
+TEST(PauliOperatorTest, BrokenPauliString) {
+	int n = 5;
+	double coef = 2.0;
+	std::string Pauli_string = "X 0 X Z 1 Y 2";
+	PauliOperator pauli = PauliOperator(Pauli_string, coef);
+	int PauliSize = pauli.get_index_list().size();
+	ASSERT_EQ(PauliSize,2);
+}
+
+TEST(PauliOperatorTest, SpacedPauliString) {
+	//This test is based on issue #257.  Thanks r-imai-quantum!
+	int n = 5;
+	double coef = 2.0;
+	std::string Pauli_string = "X 0 Y 1 ";
+	PauliOperator pauli = PauliOperator(Pauli_string, coef);
+	int PauliSize = pauli.get_index_list().size();
+	ASSERT_EQ(PauliSize, 2);
+}
+
+TEST(PauliOperatorTest, PartedPauliString) {
+	int n = 5;
+	double coef = 2.0;
+	std::string Pauli_string = "X 0 Y ";
+	PauliOperator pauli = PauliOperator(Pauli_string, coef);
+	int PauliSize = pauli.get_index_list().size();
+	ASSERT_EQ(PauliSize, 1);
 }


### PR DESCRIPTION
This PR fixes issue #257 and #259.

# issue #257
This issue says that wrong Pauli Strings is processed without errors.
This happens because initialization process in parsing Pauli Strings is broken.
To prevent this, I've added appropriate initialization process.

# issue #259 
This issue says that PauliOperator::get_expection_value() will broke when number of qubits in PauliOperator is larger than in QuantumState.
To prevent this, I've added PauliOperator::get_qubit_count() function and do some checks before applying PauliOperator using added function.
 
# Other minor changes

Added Tests for PauliOperator.
Refactored PauliOperator::get_expection_value() GPU code.