### PR TITLE
Disable some options when the target arch. is not x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,17 @@ endif()
 
 
 ##### Set default behavior #####
-set(DEFAULT_USE_SIMD Yes)
 set(DEFAULT_USE_OMP Yes)
 set(DEFAULT_USE_GPU No)
 set(DEFAULT_USE_PYTHON Yes)
 set(DEFAULT_USE_TEST Yes)
-set(DEFAULT_OPT_FLAGS "-mtune=native -march=native -mfpmath=both")
+if("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^x86.*")
+	set(DEFAULT_OPT_FLAGS "-mtune=native -march=native -mfpmath=both")
+	set(DEFAULT_USE_SIMD Yes)
+else()
+	set(DEFAULT_OPT_FLAGS "-mtune=native -march=native")
+	set(DEFAULT_USE_SIMD No)
+endif()
 
 if(NOT DEFINED USE_SIMD)
 	set(USE_SIMD ${DEFAULT_USE_SIMD})
@@ -69,7 +74,7 @@ ExternalProject_Add(
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND
-      ${CMAKE_COMMAND} -E copy_directory ${EIGEN_BUILD_DIR}/src/eigen/Eigen ${EIGEN_INCLUDE_DIR}/Eigen 
+      ${CMAKE_COMMAND} -E copy_directory ${EIGEN_BUILD_DIR}/src/eigen/Eigen ${EIGEN_INCLUDE_DIR}/Eigen
       && ${CMAKE_COMMAND} -E copy_directory ${EIGEN_BUILD_DIR}/src/eigen/unsupported ${EIGEN_INCLUDE_DIR}/unsupported
     TEST_COMMAND ""
 )
@@ -240,7 +245,7 @@ elseif(MSVC)
 	endif()
 
 	# static link to multithread runtimes
-	set(variables 
+	set(variables
 		CMAKE_CXX_FLAGS_DEBUG
 		CMAKE_CXX_FLAGS_RELEASE
 		CMAKE_CXX_FLAGS_RELWITHDEBINFO

--- a/src/csim/update_ops_control_multi_target_single.c
+++ b/src/csim/update_ops_control_multi_target_single.c
@@ -9,10 +9,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 

--- a/src/csim/update_ops_control_single_target_single.c
+++ b/src/csim/update_ops_control_single_target_single.c
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 

--- a/src/csim/update_ops_matrix_dense_double.c
+++ b/src/csim/update_ops_matrix_dense_double.c
@@ -10,10 +10,13 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 #ifdef _USE_SIMD
@@ -649,8 +652,8 @@ void double_qubit_dense_matrix_gate_simd_middle(UINT target_qubit_index1, UINT t
 		__m256d vec_bef0, vec_aft0, vec_bef1, vec_aft1;
 		vec_bef0 = _mm256_loadu_pd(ptr_vec + basis00);		// (i1 r1 i0 r0)
 		vec_aft0 = _mm256_loadu_pd(ptr_vec + basis00 + 4);	// (i3 r3 i2 r2)
-		vec_bef1 = _mm256_loadu_pd(ptr_vec + basis10);		
-		vec_aft1 = _mm256_loadu_pd(ptr_vec + basis10 + 4);	
+		vec_bef1 = _mm256_loadu_pd(ptr_vec + basis10);
+		vec_aft1 = _mm256_loadu_pd(ptr_vec + basis10 + 4);
 
 		__m256d vec_u0, vec_u1, vec_u2, vec_u3;
 		__m256d vec_u0f, vec_u1f, vec_u2f, vec_u3f;

--- a/src/csim/update_ops_matrix_dense_multi.c
+++ b/src/csim/update_ops_matrix_dense_multi.c
@@ -9,10 +9,13 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void multi_qubit_dense_matrix_gate_old_single(const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* matrix, CTYPE* state, ITYPE dim);

--- a/src/csim/update_ops_matrix_dense_single.c
+++ b/src/csim/update_ops_matrix_dense_single.c
@@ -9,10 +9,13 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void single_qubit_dense_matrix_gate_old_single(UINT target_qubit_index, const CTYPE matrix[4], CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_matrix_diagonal_multi.c
+++ b/src/csim/update_ops_matrix_diagonal_multi.c
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 
@@ -53,7 +55,7 @@ void multi_qubit_diagonal_matrix_gate(const UINT* target_qubit_index_list, UINT 
 }
 
 
-void multi_qubit_control_multi_qubit_diagonal_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count, 
+void multi_qubit_control_multi_qubit_diagonal_matrix_gate(const UINT* control_qubit_index_list, const UINT* control_value_list, UINT control_qubit_index_count,
 	const UINT* target_qubit_index_list, UINT target_qubit_index_count, const CTYPE* diagonal_element, CTYPE* state, ITYPE dim) {
 
 	// matrix dim, mask, buffer

--- a/src/csim/update_ops_matrix_diagonal_single.c
+++ b/src/csim/update_ops_matrix_diagonal_single.c
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void single_qubit_diagonal_matrix_gate_old_single(UINT target_qubit_index, const CTYPE diagonal_matrix[2], CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_matrix_phase_single.c
+++ b/src/csim/update_ops_matrix_phase_single.c
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void single_qubit_phase_gate_old_single(UINT target_qubit_index, CTYPE phase, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named.c
+++ b/src/csim/update_ops_named.c
@@ -9,10 +9,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void S_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim){

--- a/src/csim/update_ops_named_CNOT.c
+++ b/src/csim/update_ops_named_CNOT.c
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void CNOT_gate_old_single(UINT control_qubit_index, UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_CZ.c
+++ b/src/csim/update_ops_named_CZ.c
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void CZ_gate_old_single(UINT control_qubit_index, UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_H.c
+++ b/src/csim/update_ops_named_H.c
@@ -6,11 +6,13 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #include <iostream>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void H_gate_old_parallel(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_SWAP.c
+++ b/src/csim/update_ops_named_SWAP.c
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void SWAP_gate_old_single(UINT target_qubit_index_0, UINT target_qubit_index_1, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_X.c
+++ b/src/csim/update_ops_named_X.c
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void X_gate_old(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_Y.c
+++ b/src/csim/update_ops_named_Y.c
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void Y_gate_old_single(UINT target_qubit_index, CTYPE *state, ITYPE dim);
@@ -91,7 +93,7 @@ void Y_gate_parallel_unroll(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
 	const CTYPE imag = 1.i;
 	if (target_qubit_index == 0) {
 		ITYPE basis_index;
-#pragma omp parallel for 
+#pragma omp parallel for
 		for (basis_index = 0; basis_index < dim; basis_index += 2) {
 			CTYPE temp0 = state[basis_index];
 			state[basis_index] = -imag * state[basis_index + 1];
@@ -99,7 +101,7 @@ void Y_gate_parallel_unroll(UINT target_qubit_index, CTYPE *state, ITYPE dim) {
 		}
 	}
 	else {
-#pragma omp parallel for 
+#pragma omp parallel for
 		for (state_index = 0; state_index < loop_dim; state_index += 2) {
 			ITYPE basis_index_0 = (state_index&mask_low) + ((state_index&mask_high) << 1);
 			ITYPE basis_index_1 = basis_index_0 + mask;

--- a/src/csim/update_ops_named_Z.c
+++ b/src/csim/update_ops_named_Z.c
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 //void Z_gate_old_single(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_projection.c
+++ b/src/csim/update_ops_named_projection.c
@@ -9,10 +9,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void P0_gate(UINT target_qubit_index, CTYPE *state, ITYPE dim) {

--- a/src/csim/update_ops_named_state.c
+++ b/src/csim/update_ops_named_state.c
@@ -9,10 +9,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void normalize(double squared_norm, CTYPE* state, ITYPE dim){


### PR DESCRIPTION
Some default options passed to the compiler are unavailable in architectures other than x86.
This pull request disables these options when the host system is not x86.

I confirmed that, after this change, the compile process becomes to work well in my chromebook (aarch64 architecture).

# Changes 

- If the architecture only matches `^x86.*`, SIMD and `-mfpmath=both` (this enables SSE) are enabled.
- Some macro IFs are added to prevent unused header files to be loaded when SIMD is disabled.