### PR TITLE
Add feature of several density matrix controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         run: brew link --overwrite gcc@8
         if: ${{ contains(matrix.os, 'macos') }}
         
+      - name: Verify gcc-8 / g++-8 is installed
+        run: sudo apt-get install gcc-8 g++-8
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+
       - name: Install qulacs for Windows
         run: ./script/build_msvc_2017.bat
         if: ${{ contains(matrix.os, 'windows') }}

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -236,9 +236,16 @@ PYBIND11_MODULE(qulacs, m) {
 #endif
     mstate.def("inner_product", py::overload_cast<const QuantumState*, const QuantumState*>(&state::inner_product), "Get inner product", py::arg("state_bra"), py::arg("state_ket"));
     //mstate.def("inner_product", &state::inner_product);
-	mstate.def("tensor_product", &state::tensor_product, pybind11::return_value_policy::take_ownership, "Get tensor product of states", py::arg("state_left"), py::arg("state_right"));
-	mstate.def("permutate_qubit", &state::permutate_qubit, pybind11::return_value_policy::take_ownership, "Permutate qubits from state", py::arg("state"), py::arg("order"));
-	mstate.def("drop_qubit", &state::drop_qubit, pybind11::return_value_policy::take_ownership, "Drop qubits from state", py::arg("state"), py::arg("target"), py::arg("projection"));
+    //mstate.def("tensor_product", &state::tensor_product, pybind11::return_value_policy::take_ownership, "Get tensor product of states", py::arg("state_left"), py::arg("state_right"));
+    //mstate.def("permutate_qubit", &state::permutate_qubit, pybind11::return_value_policy::take_ownership, "Permutate qubits from state", py::arg("state"), py::arg("order"));
+    mstate.def("tensor_product", py::overload_cast<const QuantumState*, const QuantumState*>(&state::tensor_product), pybind11::return_value_policy::take_ownership, "Get tensor product of states", py::arg("state_left"), py::arg("state_right"));
+    mstate.def("tensor_product", py::overload_cast<const DensityMatrix*, const DensityMatrix*>(&state::tensor_product), pybind11::return_value_policy::take_ownership, "Get tensor product of states", py::arg("state_left"), py::arg("state_right"));
+    mstate.def("permutate_qubit", py::overload_cast<const QuantumState*, std::vector<UINT>>(&state::permutate_qubit), pybind11::return_value_policy::take_ownership, "Permutate qubits from state", py::arg("state"), py::arg("order"));
+    mstate.def("permutate_qubit", py::overload_cast<const DensityMatrix*, std::vector<UINT>>(&state::permutate_qubit), pybind11::return_value_policy::take_ownership, "Permutate qubits from state", py::arg("state"), py::arg("order"));
+
+    mstate.def("drop_qubit", &state::drop_qubit, pybind11::return_value_policy::take_ownership, "Drop qubits from state", py::arg("state"), py::arg("target"), py::arg("projection"));
+    mstate.def("partial_trace", py::overload_cast<const QuantumState*, std::vector<UINT>>(&state::partial_trace), pybind11::return_value_policy::take_ownership, "Take partial trace", py::arg("state"), py::arg("target_traceout"));
+    mstate.def("partial_trace", py::overload_cast<const DensityMatrix*, std::vector<UINT>>(&state::partial_trace), pybind11::return_value_policy::take_ownership, "Take partial trace", py::arg("state"), py::arg("target_traceout"));
 
     py::class_<QuantumGateBase>(m, "QuantumGateBase")
         .def("update_quantum_state", &QuantumGateBase::update_quantum_state, "Update quantum state", py::arg("state"))

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -394,7 +394,7 @@ class TestDensityMatrixHandling(unittest.TestCase):
         sv.set_Haar_random_state(seed=0)
         dm.load(sv)
         svv = np.atleast_2d(sv.get_vector()).T
-        mat = svv@svv.T.conj()
+        mat = np.dot(svv, svv.T.conj())
         self.assertTrue(np.allclose(dm.get_matrix(), mat), msg="check pure matrix to density matrix")
         
 
@@ -500,7 +500,7 @@ class TestDensityMatrixHandling(unittest.TestCase):
         sv = qulacs.StateVector(num_qubit)
         sv.set_Haar_random_state(seed=0)
         svv = np.atleast_2d(sv.get_vector()).T
-        mat = svv@svv.T.conj()
+        mat = np.dot(svv, svv.T.conj())
 
         target = np.arange(num_qubit)
         np.random.shuffle(target)

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -380,6 +380,142 @@ class TestPointerHandling(unittest.TestCase):
         pqc.remove_gate(3)  # [1, 0, 3, *, 2]
         check(pqc, [1, 0, 4, 2])
 
+class TestDensityMatrixHandling(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_density_matrix(self):
+        num_qubit = 5
+        sv = qulacs.StateVector(num_qubit)
+        dm = qulacs.DensityMatrix(num_qubit)
+        sv.set_Haar_random_state(seed=0)
+        dm.load(sv)
+        svv = np.atleast_2d(sv.get_vector()).T
+        mat = svv@svv.T.conj()
+        self.assertTrue(np.allclose(dm.get_matrix(), mat), msg="check pure matrix to density matrix")
+        
+
+    def test_tensor_product_sv(self):
+        num_qubit = 4
+        sv1 = qulacs.StateVector(num_qubit)
+        sv2 = qulacs.StateVector(num_qubit)
+        sv1.set_Haar_random_state(seed=0)
+        sv2.set_Haar_random_state(seed=1)
+        sv3 = qulacs.state.tensor_product(sv1, sv2)
+        sv3_test = np.kron(sv1.get_vector(), sv2.get_vector())
+        self.assertTrue(np.allclose(sv3_test, sv3.get_vector()), msg="check pure state tensor product")
+        del sv1
+        del sv2
+        del sv3
+
+    def test_tensor_product_dm(self):
+        num_qubit = 4
+        dm1 = qulacs.DensityMatrix(num_qubit)
+        dm2 = qulacs.DensityMatrix(num_qubit)
+        dm1.set_Haar_random_state(seed=0)
+        dm2.set_Haar_random_state(seed=1)
+        dm3 = qulacs.state.tensor_product(dm1, dm2)
+        dm3_test = np.kron(dm1.get_matrix(), dm2.get_matrix())
+        self.assertTrue(np.allclose(dm3_test, dm3.get_matrix()), msg="check density matrix tensor product")
+        del dm1
+        del dm2
+        del dm3
+
+    def test_permutate_qubit_sv(self):
+        num_qubit = 8
+        sv = qulacs.StateVector(num_qubit)
+        sv.set_Haar_random_state(seed=0)
+        order = np.arange(num_qubit)
+        np.random.shuffle(order)
+
+        arr = []
+        for ind in range(2**num_qubit):
+            s = format(ind, "0{}b".format(num_qubit))
+            s = np.array(list(s[::-1]))
+            v = np.array(["*"]*num_qubit)
+            for ind in range(len(s)):
+                v[order[ind]] = s[ind]
+            s = ("".join(v))[::-1]
+            arr.append(int(s, 2))
+
+        sv_perm = qulacs.state.permutate_qubit(sv, order)
+        self.assertTrue(np.allclose(sv.get_vector()[arr], sv_perm.get_vector()), msg="check pure state permutation")
+        del sv_perm
+        del sv
+
+    def test_permutate_qubit_dm(self):
+        num_qubit = 3
+        dm = qulacs.DensityMatrix(num_qubit)
+        dm.set_Haar_random_state(seed=0)
+        order = np.arange(num_qubit)
+        np.random.shuffle(order)
+
+        arr = []
+        for ind in range(2**num_qubit):
+            s = format(ind, "0{}b".format(num_qubit))
+            s = np.array(list(s[::-1]))
+            v = np.array(["*"]*num_qubit)
+            for ind in range(len(s)):
+                v[order[ind]] = s[ind]
+            s = ("".join(v))[::-1]
+            arr.append(int(s, 2))
+
+        dm_perm = qulacs.state.permutate_qubit(dm, order)
+        dm_perm_test = dm.get_matrix()
+        dm_perm_test = dm_perm_test[arr, :]
+        dm_perm_test = dm_perm_test[:, arr]
+        self.assertTrue(np.allclose(dm_perm_test, dm_perm.get_matrix()), msg="check density matrix permutation")
+        del dm_perm
+        del dm
+
+    def test_partial_trace_dm(self):
+        num_qubit = 5
+        num_traceout = 2
+        dm = qulacs.DensityMatrix(num_qubit)
+        dm.set_Haar_random_state(seed=0)
+        mat = dm.get_matrix()
+
+        target = np.arange(num_qubit)
+        np.random.shuffle(target)
+        target = target[:num_traceout]
+        target_cor = [num_qubit-1-i for i in target]
+        target_cor.sort()
+
+        dmt = mat.reshape([2,2]*num_qubit)
+        for cnt,val in enumerate(target_cor):
+            ofs = num_qubit - cnt
+            dmt = np.trace(dmt, axis1=val-cnt, axis2=ofs+val-cnt)
+        dmt = dmt.reshape([2**(num_qubit-num_traceout),2**(num_qubit-num_traceout)])
+        
+        pdm = qulacs.state.partial_trace(dm, target)
+        self.assertTrue(np.allclose(pdm.get_matrix(), dmt), msg="check density matrix partial trace")
+        del dm,pdm
+
+    def test_partial_trace_sv(self):
+        num_qubit = 6
+        num_traceout = 4
+        sv = qulacs.StateVector(num_qubit)
+        sv.set_Haar_random_state(seed=0)
+        svv = np.atleast_2d(sv.get_vector()).T
+        mat = svv@svv.T.conj()
+
+        target = np.arange(num_qubit)
+        np.random.shuffle(target)
+        target = target[:num_traceout]
+        target_cor = [num_qubit-1-i for i in target]
+        target_cor.sort()
+
+        dmt = mat.reshape([2,2]*num_qubit)
+        for cnt,val in enumerate(target_cor):
+            ofs = num_qubit - cnt
+            dmt = np.trace(dmt, axis1=val-cnt, axis2=ofs+val-cnt)
+        dmt = dmt.reshape([2**(num_qubit-num_traceout),2**(num_qubit-num_traceout)])
+        
+        pdm = qulacs.state.partial_trace(sv, target)
+        self.assertTrue(np.allclose(pdm.get_matrix(), dmt), msg="check pure state partial trace")
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cppsim/state_dm.cpp
+++ b/src/cppsim/state_dm.cpp
@@ -1,0 +1,52 @@
+
+
+
+#include "state_dm.hpp"
+
+#ifndef _MSC_VER
+extern "C" {
+#include <csim/stat_ops_dm.h>
+}
+#else
+#include <csim/stat_ops_dm.h>
+#endif
+#include <iostream>
+
+namespace state {
+    DensityMatrixCpu* tensor_product(const DensityMatrixCpu* state_left, const DensityMatrixCpu* state_right) {
+        UINT qubit_count = state_left->qubit_count + state_right->qubit_count;
+        DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
+        dm_state_tensor_product(state_left->data_c(), state_left->dim, state_right->data_c(), state_right->dim, qs->data_c());
+        return qs;
+    }
+    DensityMatrixCpu* permutate_qubit(const DensityMatrixCpu* state, std::vector<UINT> qubit_order) {
+        if (state->qubit_count != (UINT)qubit_order.size()) {
+            std::cerr << "Error: permutate_qubit(const QuantumState*, std::vector<UINT>): invalid qubit count" << std::endl;
+            return NULL;
+        }
+        UINT qubit_count = state->qubit_count;
+        DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
+        dm_state_permutate_qubit(qubit_order.data(), state->data_c(), qs->data_c(), state->qubit_count, state->dim);
+        return qs;
+    }
+    DensityMatrixCpu* partial_trace(const QuantumStateCpu* state, std::vector<UINT> target) {
+        if (state->qubit_count <= target.size()) {
+            std::cerr << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): invalid qubit count" << std::endl;
+            return NULL;
+        }
+        DensityMatrix temp(state->qubit_count);
+        temp.load(state);
+        DensityMatrix* qs = partial_trace(&temp, target);
+        return qs;
+    }
+    DensityMatrixCpu* partial_trace(const DensityMatrixCpu* state, std::vector<UINT> target) {
+        if (state->qubit_count <= target.size()) {
+            std::cerr << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): invalid qubit count" << std::endl;
+            return NULL;
+        }
+        UINT qubit_count = state->qubit_count - (UINT)target.size();
+        DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
+        dm_state_partial_trace(target.data(), (UINT)target.size(), state->data_c(), qs->data_c(), state->dim);
+        return qs;
+    }
+}

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -336,3 +336,9 @@ public:
 
 typedef DensityMatrixCpu DensityMatrix; /**< QuantumState is an alias of QuantumStateCPU */
 
+namespace state{
+    DllExport DensityMatrixCpu* tensor_product(const DensityMatrixCpu* state_left, const DensityMatrixCpu* state_right);
+    DllExport DensityMatrixCpu* permutate_qubit(const DensityMatrixCpu* state, std::vector<UINT> qubit_order);
+    DllExport DensityMatrixCpu* partial_trace(const QuantumStateCpu* state, std::vector<UINT> target);
+    DllExport DensityMatrixCpu* partial_trace(const DensityMatrixCpu* state, std::vector<UINT> target);
+}

--- a/src/csim/stat_ops_dm.h
+++ b/src/csim/stat_ops_dm.h
@@ -7,6 +7,10 @@ DllExport double dm_measurement_distribution_entropy(const CTYPE *state, ITYPE d
 DllExport void dm_state_add(const CTYPE *state_added, CTYPE *state, ITYPE dim);
 DllExport void dm_state_multiply(CTYPE coef, CTYPE *state, ITYPE dim);
 
+DllExport void dm_state_tensor_product(const CTYPE* state_left, ITYPE dim_left, const CTYPE* state_right, ITYPE dim_right, CTYPE* state_dst);
+DllExport void dm_state_permutate_qubit(const UINT* qubit_order, const CTYPE* state_src, CTYPE* state_dst, UINT qubit_count, ITYPE dim);
+DllExport void dm_state_partial_trace(const UINT* target, UINT target_count, const CTYPE* state_src, CTYPE* state_dst, ITYPE dim);
+
 DllExport double dm_M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double dm_M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double dm_marginal_prob(const UINT* sorted_target_qubit_index_list, const UINT* measured_value_list, UINT target_qubit_index_count, const CTYPE* state, ITYPE dim);

--- a/test/cppsim/test_hamiltonian.cpp
+++ b/test/cppsim/test_hamiltonian.cpp
@@ -148,8 +148,8 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile){
     res = observable->get_expectation_value(&state);
     test_res = func(filename, &state);
 
-    ASSERT_EQ(test_res, res);
-
+    ASSERT_NEAR(test_res.real(), res.real(), eps);
+    ASSERT_NEAR(test_res.imag(), res.imag(), eps);
 
     state.set_Haar_random_state();
 
@@ -221,8 +221,8 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionText){
     res = observable->get_expectation_value(&state);
     test_res = func(text, &state);
 
-    ASSERT_EQ(test_res, res);
-
+    ASSERT_NEAR(test_res.real(), res.real(), eps);
+    ASSERT_NEAR(test_res.imag(), res.imag(), eps);
 
     state.set_Haar_random_state();
 

--- a/test/cppsim/test_state_dm.cpp
+++ b/test/cppsim/test_state_dm.cpp
@@ -142,3 +142,55 @@ TEST(DensityMatrixTest, MultiplyCoef) {
 		}
 	}
 }
+
+
+
+TEST(DensityMatrixTest, TensorProduct) {
+    const double eps = 1e-10;
+    const UINT n = 4;
+
+    DensityMatrix state1(n), state2(n);
+    state1.set_Haar_random_state();
+    state2.set_Haar_random_state();
+
+    DensityMatrix* state3 = state::tensor_product(&state1, &state2);
+    // numerical test is performed in python
+    delete state3;
+}
+
+TEST(DensityMatrixTest, PermutateQubit) {
+    const double eps = 1e-10;
+    const UINT n = 3;
+
+    DensityMatrix state(n);
+    state.set_Haar_random_state();
+    DensityMatrix* state2 = state::permutate_qubit(&state, { 1, 0, 2 });
+    // numerical test is performed in python
+    delete state2;
+}
+
+
+
+TEST(DensityMatrixTest, PartialTraceSVtoDM) {
+    const double eps = 1e-10;
+    const UINT n = 5;
+
+    DensityMatrix state(n);
+    state.set_Haar_random_state();
+    DensityMatrix* state2 = state::partial_trace(&state, {2, 0});
+    // numerical test is performed in python
+    delete state2;
+}
+
+
+TEST(DensityMatrixTest, PartialTraceDMtoDM) {
+    const double eps = 1e-10;
+    const UINT n = 5;
+
+    QuantumState state(n);
+    state.set_Haar_random_state();
+    DensityMatrix* state2 = state::partial_trace(&state, { 2, 0 });
+    // numerical test is performed in python
+    delete state2;
+}
+


### PR DESCRIPTION
I've added `tensor_product`, `permutate_qubit` and `partial_trace` for density matrix controls, and added tests for them.
I also fixed tests for openfermion text to allow an epsilon error.