### PR TITLE
Add light partial trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         run: sudo apt-get install gcc-8 g++-8
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
-      - name: Verify gcc-8 / g++-8 is installed macos
-        run: brew install gcc@8 g++@8
+      - name: Verify gcc-8 is installed macos
+        run: brew install gcc@8
         if: ${{ contains(matrix.os, 'macos') }}
 
       - name: Workaround for OpenMP link error on mac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       # some library files from gcc-8 installed via Homebrew.
       # The following command fixes this issue by (brew) re-linking files from gcc-8.
       # cf. https://stackoverflow.com/a/55500164
-      CIBW_BEFORE_BUILD_MACOS: 'brew link --overwrite gcc@8 && pip install cmake'
+      CIBW_BEFORE_BUILD_MACOS: 'brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake'
       CIBW_BUILD: 'cp*-macosx_x86_64 cp*-manylinux_x86_64 cp*-win_amd64'
       CIBW_BUILD_VERBOSITY: '1'
       CIBW_ENVIRONMENT: 'QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Install Python dependencies
         run: pip install -U --only-binary=numpy,scipy numpy scipy
 
+      - name: Verify gcc-8 / g++-8 is installed
+        run: sudo apt-get install gcc-8 g++-8
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+
       - name: Workaround for OpenMP link error on mac
         # In GitHub Actions virtual environment macos-10.15/20201115.1,
         # linking some functions from libgomp fails since the linker cannot find
@@ -41,10 +45,6 @@ jobs:
         run: brew link --overwrite gcc@8
         if: ${{ contains(matrix.os, 'macos') }}
         
-      - name: Verify gcc-8 / g++-8 is installed
-        run: sudo apt-get install gcc-8 g++-8
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-
       - name: Install qulacs for Windows
         run: ./script/build_msvc_2017.bat
         if: ${{ contains(matrix.os, 'windows') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
        
+      - name: Verify gcc-8 / g++-8 is installed ubuntu
+        run: sudo apt-get install gcc-8 g++-8
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+
+      - name: Verify gcc-8 / g++-8 is installed macos
+        run: brew install gcc@8 g++@8
+        if: ${{ contains(matrix.os, 'macos') }}
+
+      - name: Workaround for OpenMP link error on mac
+        # In GitHub Actions virtual environment macos-10.15/20201115.1,
+        # linking some functions from libgomp fails since the linker cannot find
+        # some library files from gcc-8 installed via Homebrew.
+        # The following command fixes this issue by (brew) re-linking files from gcc-8.
+        # cf. https://stackoverflow.com/a/55500164
+        run: brew link --overwrite gcc@8
+        if: ${{ contains(matrix.os, 'macos') }}
+        
       - name: Setup cmake
         uses: lukka/get-cmake@latest
   
@@ -32,19 +49,6 @@ jobs:
       - name: Install Python dependencies
         run: pip install -U --only-binary=numpy,scipy numpy scipy
 
-      - name: Verify gcc-8 / g++-8 is installed
-        run: sudo apt-get install gcc-8 g++-8
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-
-      - name: Workaround for OpenMP link error on mac
-        # In GitHub Actions virtual environment macos-10.15/20201115.1,
-        # linking some functions from libgomp fails since the linker cannot find
-        # some library files from gcc-8 installed via Homebrew.
-        # The following command fixes this issue by (brew) re-linking files from gcc-8.
-        # cf. https://stackoverflow.com/a/55500164
-        run: brew link --overwrite gcc@8
-        if: ${{ contains(matrix.os, 'macos') }}
-        
       - name: Install qulacs for Windows
         run: ./script/build_msvc_2017.bat
         if: ${{ contains(matrix.os, 'windows') }}

--- a/src/cppsim/state_dm.cpp
+++ b/src/cppsim/state_dm.cpp
@@ -34,9 +34,9 @@ namespace state {
             std::cerr << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): invalid qubit count" << std::endl;
             return NULL;
         }
-        DensityMatrix temp(state->qubit_count);
-        temp.load(state);
-        DensityMatrix* qs = partial_trace(&temp, target);
+        UINT qubit_count = state->qubit_count - (UINT)target.size();
+        DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
+        dm_state_partial_trace_from_state_vector(target.data(), (UINT)(target.size()), state->data_c(), qs->data_c(), state->dim);
         return qs;
     }
     DensityMatrixCpu* partial_trace(const DensityMatrixCpu* state, std::vector<UINT> target) {
@@ -46,7 +46,7 @@ namespace state {
         }
         UINT qubit_count = state->qubit_count - (UINT)target.size();
         DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
-        dm_state_partial_trace(target.data(), (UINT)target.size(), state->data_c(), qs->data_c(), state->dim);
+        dm_state_partial_trace_from_density_matrix(target.data(), (UINT)target.size(), state->data_c(), qs->data_c(), state->dim);
         return qs;
     }
 }

--- a/src/csim/stat_ops_dm.h
+++ b/src/csim/stat_ops_dm.h
@@ -9,7 +9,8 @@ DllExport void dm_state_multiply(CTYPE coef, CTYPE *state, ITYPE dim);
 
 DllExport void dm_state_tensor_product(const CTYPE* state_left, ITYPE dim_left, const CTYPE* state_right, ITYPE dim_right, CTYPE* state_dst);
 DllExport void dm_state_permutate_qubit(const UINT* qubit_order, const CTYPE* state_src, CTYPE* state_dst, UINT qubit_count, ITYPE dim);
-DllExport void dm_state_partial_trace(const UINT* target, UINT target_count, const CTYPE* state_src, CTYPE* state_dst, ITYPE dim);
+DllExport void dm_state_partial_trace_from_density_matrix(const UINT* target, UINT target_count, const CTYPE* state_src, CTYPE* state_dst, ITYPE dim);
+DllExport void dm_state_partial_trace_from_state_vector(const UINT* target, UINT target_count, const CTYPE* state_src, CTYPE* state_dst, ITYPE dim);
 
 DllExport double dm_M0_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);
 DllExport double dm_M1_prob(UINT target_qubit_index, const CTYPE* state, ITYPE dim);


### PR DESCRIPTION

When we convert a state vector to a density matrix, the state vector is temporally converted to a density matrix with the same number of qubits. I've updated `partial_trace` function not to use a temporal large density matrix.
Now we can treat partial trace from a 20-qubit state vector to 10-qubit density matrix with a reasonable memory size.

