### PR TITLE
Fix a bug in the calculation of expectation values on odd-number Pauli-Y observable for density matrix

### DIFF
--- a/test/cppsim/test_hamiltonian_dm.cpp
+++ b/test/cppsim/test_hamiltonian_dm.cpp
@@ -80,8 +80,8 @@ TEST(DensityMatrixObservableTest, CheckExpectationValue) {
 		vector_state.set_Haar_random_state();
 		density_matrix.load(&vector_state);
 
-		res_vec = observable.get_expectation_value(&vector_state);
-		res_mat = observable.get_expectation_value(&density_matrix);
+		res_vec = rand_observable.get_expectation_value(&vector_state);
+		res_mat = rand_observable.get_expectation_value(&density_matrix);
 		ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
 		ASSERT_NEAR(res_vec.imag(), 0, eps);
 		ASSERT_NEAR(res_mat.imag(), 0, eps);


### PR DESCRIPTION
In the previous version, the sign of observable evaluation for density matrices is flipped when it contains a term with an odd number of Pauli-Y operators, such as "Y 0" or "Z 0 Y 1". Although the expectation-value calculations are tested with random Pauli operations and a specific open-fermion text, this bug happens since random tests are not random due to another bug, and an open-fermion example contains an even number of Pauli-Y operators. 
I have replaced the calculation function of expectation values for density matrices with a stable one and fixed the bug in the tests of random observable. This bug is reported in #314 and is expected to be included from the first implementation of density matrices. We are very sorry for being unaware of the bug in such a fundamental part.
