### PR TITLE
[dev] update pybind11 v2.7.1 -> v2.10.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,7 @@ RUN git clone https://github.com/google/googletest.git -b release-1.8.1 --depth 
     && rm -rf /tmp/gtest
 
 # Install pybind11
-RUN git clone https://github.com/pybind/pybind11.git -b v2.7.1 --depth 1 /tmp/pybind11 \
+RUN git clone https://github.com/pybind/pybind11.git -b v2.10.0 --depth 1 /tmp/pybind11 \
     && cp -r /tmp/pybind11/include/pybind11 /usr/local/include \
     && rm -rf /tmp/pybind11
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -43,7 +43,6 @@ jobs:
       # cf. https://stackoverflow.com/a/55500164
       CIBW_BEFORE_BUILD_MACOS: "brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost"
       CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
-      CIBW_SKIP: "cp311-*"
 
       # necessary for compiling python pillow library required to install numpy,scipy,openfermion.
       CIBW_BEFORE_TEST_LINUX: "yum install libjpeg-devel -y"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,20 +142,20 @@ if(USE_PYTHON)
 		set(PYBIND11_INCLUDE_DIR ${PYBIND11_INSTALL_DIR}/include)
 		ExternalProject_Add(
 			pybind11_pop
-			URL http://github.com/pybind/pybind11/archive/v2.7.1.tar.gz
+			URL http://github.com/pybind/pybind11/archive/v2.10.0.tar.gz
 			PREFIX ${PYBIND11_BUILD_DIR}
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ""
 			INSTALL_COMMAND
 			${CMAKE_COMMAND} -E copy_directory ${PYBIND11_BUILD_DIR}/src/pybind11_pop ${PYBIND11_INSTALL_DIR}
-			TEST_COMMAND ""
+			TEST_COMMAND "",
 		)
 		include_directories(SYSTEM ${PYBIND11_INCLUDE_DIR})
 	else()
 		FetchContent_Declare(
 			pybind11_fetch
 			GIT_REPOSITORY https://github.com/pybind/pybind11
-			GIT_TAG v2.7.1
+			GIT_TAG v2.10.0
 		)
 		FetchContent_GetProperties(pybind11_fetch)
 		if(NOT pybind11_fetch_POPULATED)


### PR DESCRIPTION
This PR updates pybind11 version from v2.7.1 to v2.10.0 and reenable wheel build for python 3.11.

Since pybind11 v2.7.1 does not support python 3.11, we need to update pybind11 to latest version for wheel build.
