### PR TITLE
update pybind11 v2.7.1 -> v2.10.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,7 @@ RUN git clone https://github.com/google/googletest.git -b release-1.8.1 --depth 
     && rm -rf /tmp/gtest
 
 # Install pybind11
-RUN git clone https://github.com/pybind/pybind11.git -b v2.7.1 --depth 1 /tmp/pybind11 \
+RUN git clone https://github.com/pybind/pybind11.git -b v2.10.0 --depth 1 /tmp/pybind11 \
     && cp -r /tmp/pybind11/include/pybind11 /usr/local/include \
     && rm -rf /tmp/pybind11
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -32,16 +32,16 @@ jobs:
       COVERAGE: "ON"
       CIBW_TEST_COMMAND: "python {project}/python/test/test_qulacs.py"
       CIBW_TEST_REQUIRES: "numpy scipy openfermion"
-      CIBW_BEFORE_BUILD: "pip install cmake"
+      CIBW_BEFORE_BUILD_WINDOWS: "pip install cmake && rm -rf {project}/build"
       CIBW_BEFORE_BUILD_LINUX:
         "pip install cmake && yum install wget -y && wget -q https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz && tar -zxf boost_1_76_0.tar.gz &&
-        cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && cp -r boost /usr/local/include" #install boost and cmake
+        cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && cp -r boost /usr/local/include && rm -rf {project}/build" #install boost and cmake
       # In GitHub Actions virtual environment macos-10.15/20201115.1,
       # linking some functions from libgomp fails since the linker cannot find
       # some library files from gcc-8 installed via Homebrew.
       # The following command fixes this issue by (brew) re-linking files from gcc-8.
       # cf. https://stackoverflow.com/a/55500164
-      CIBW_BEFORE_BUILD_MACOS: "brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost"
+      CIBW_BEFORE_BUILD_MACOS: "brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost && rm -rf {project}/build"
       CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
       CIBW_SKIP: "cp311-*"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if(USE_PYTHON)
 		set(PYBIND11_INCLUDE_DIR ${PYBIND11_INSTALL_DIR}/include)
 		ExternalProject_Add(
 			pybind11_pop
-			URL http://github.com/pybind/pybind11/archive/v2.7.1.tar.gz
+			URL http://github.com/pybind/pybind11/archive/v2.10.0.tar.gz
 			PREFIX ${PYBIND11_BUILD_DIR}
 			CONFIGURE_COMMAND ""
 			BUILD_COMMAND ""
@@ -155,7 +155,7 @@ if(USE_PYTHON)
 		FetchContent_Declare(
 			pybind11_fetch
 			GIT_REPOSITORY https://github.com/pybind/pybind11
-			GIT_TAG v2.7.1
+			GIT_TAG v2.10.0
 		)
 		FetchContent_GetProperties(pybind11_fetch)
 		if(NOT pybind11_fetch_POPULATED)


### PR DESCRIPTION
This PR updates pybind11 version from v2.7.1 to v2.10.0 for preparation to python 3.11 support.
This PR also adds cleaning build artifacts step during wheel build for avoiding mixture of different python version.

python 3.11 support will be added after test-dependency library `scipy` supports python 3.11.