### PR TITLE
Add pyproject.toml

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -37,7 +37,7 @@ jobs:
           architecture: x64
 
       - name: Setup cmake
-        run: pip install cmake
+        uses: lukka/get-cmake@latest
         
       - name: Install ccache
         run: brew install ccache

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -58,7 +58,7 @@ jobs:
         run: USE_TEST=Yes ./script/build_gcc.sh
 
       - name: Install qulacs Python module
-        run: pip install .[ci]
+        run: pip install --no-build-isolation .[ci]
 
       - name: Test if stub is working
         run: |
@@ -67,8 +67,9 @@ jobs:
 
       - name: Test in macOS
         run: |
-          cmake --build build --target coverage
-          cmake --build build --target pythontest
+          cd ./build
+          make test -j
+          make pythontest -j
 
       - name: Show cache stats
         run: ccache -s -v

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -30,9 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
-
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -30,14 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+        
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
         
       - name: Install ccache
         run: brew install ccache

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -67,9 +67,8 @@ jobs:
 
       - name: Test in macOS
         run: |
-          cd ./build
-          make test -j
-          make pythontest -j
+          cmake --build build --target coverage
+          cmake --build build --target pythontest
 
       - name: Show cache stats
         run: ccache -s -v

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
-        
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-        
+
       - name: Install ccache
         run: brew install ccache
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Install ccache
         run: brew install ccache
 
-      - name: Install Python dependencies
-        run: pip install -U --only-binary=numpy,scipy numpy scipy openfermion mypy
-
       - name: Install Boost for macOS
         run: |
           brew upgrade
@@ -61,7 +58,7 @@ jobs:
         run: USE_TEST=Yes ./script/build_gcc.sh
 
       - name: Install qulacs Python module
-        run: python setup.py install
+        run: pip install .[ci]
 
       - name: Test if stub is working
         run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -58,7 +58,7 @@ jobs:
         run: USE_TEST=Yes ./script/build_gcc.sh
 
       - name: Install qulacs Python module
-        run: pip install --no-build-isolation .[ci]
+        run: pip install .[ci]
 
       - name: Test if stub is working
         run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -36,6 +36,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
+      - name: Setup cmake
+        run: pip install cmake
+        
       - name: Install ccache
         run: brew install ccache
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -58,14 +58,11 @@ jobs:
           cd lcov
           sudo make install
 
-      - name: Install Python dependencies
-        run: pip install -U --only-binary=numpy,scipy numpy scipy openfermion mypy pybind11-stubgen
-
       - name: Install qulacs for Ubuntu
         run: USE_TEST=Yes ./script/build_gcc.sh
 
       - name: Install qulacs Python module
-        run: python setup.py install
+        run: pip install .[ci]
       
       - name: Check stubs
         run: |
@@ -123,9 +120,6 @@ jobs:
           path: ~/.ccache
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}
 
-      - name: Install Python dependencies
-        run: pip install -U --only-binary=numpy,scipy numpy scipy openfermion
-
       - name: Install boost
         run: sudo apt install libboost-dev
 
@@ -137,7 +131,7 @@ jobs:
         run: ./script/build_gcc_with_gpu.sh
 
       - name: Install qulacs Python module
-        run: USE_GPU=Yes python setup.py install
+        run: USE_GPU=Yes pip install .[test]
 
       # Testing is removed because GPU is not available for GitHub-Hosted Runner.
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-        
+
       - name: Install ccache
         run: sudo apt install ccache
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
           architecture: x64
 
       - name: Setup cmake
-        run: pip install cmake
+        uses: lukka/get-cmake@latest
         
       - name: Install ccache
         run: sudo apt install ccache

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -79,9 +79,8 @@ jobs:
 
       - name: Test in Ubuntu
         run: |
-          cd ./build
-          make coverage
-          make pythontest
+          cmake --build build --target coverage
+          cmake --build build --target pythontest
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -31,9 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
-
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -31,14 +31,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
         
       - name: Install ccache
         run: sudo apt install ccache

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
           architecture: x64
 
       - name: Setup cmake
-        run: pip install cmake wheel setuptools
+        run: pip install cmake
         
       - name: Install ccache
         run: sudo apt install ccache
@@ -62,7 +62,7 @@ jobs:
         run: USE_TEST=Yes ./script/build_gcc.sh
 
       - name: Install qulacs Python module
-        run: pip install --no-build-isolation .[ci]
+        run: pip install .[ci]
       
       - name: Check stubs
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
           architecture: x64
 
       - name: Setup cmake
-        run: pip install cmake
+        run: pip install cmake wheel setuptools
         
       - name: Install ccache
         run: sudo apt install ccache

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -62,7 +62,7 @@ jobs:
         run: USE_TEST=Yes ./script/build_gcc.sh
 
       - name: Install qulacs Python module
-        run: pip install .[ci]
+        run: pip install --no-build-isolation .[ci]
       
       - name: Check stubs
         run: |
@@ -79,8 +79,9 @@ jobs:
 
       - name: Test in Ubuntu
         run: |
-          cmake --build build --target coverage
-          cmake --build build --target pythontest
+          cd ./build
+          make coverage
+          make pythontest
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -37,6 +37,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
+      - name: Setup cmake
+        run: pip install cmake
+        
       - name: Install ccache
         run: sudo apt install ccache
 

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -37,7 +37,7 @@ jobs:
           architecture: x64
 
       - name: Setup cmake
-        run: pip install cmake
+        uses: lukka/get-cmake@latest
         
       - name: Install boost
         uses: MarkusJx/install-boost@v2.0.0

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
-        
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-        
+
       - name: Install boost
         uses: MarkusJx/install-boost@v2.0.0
         id: install-boost

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -36,6 +36,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
+      - name: Setup cmake
+        run: pip install cmake
+        
       - name: Install boost
         uses: MarkusJx/install-boost@v2.0.0
         id: install-boost

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -30,9 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
-
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -39,9 +39,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Install Python dependencies
-        run: pip install -U --only-binary=numpy,scipy numpy scipy openfermion mypy
-
       - name: Install boost
         uses: MarkusJx/install-boost@v2.0.0
         id: install-boost
@@ -58,7 +55,7 @@ jobs:
       - name: Install qulacs Python module
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
-        run: python setup.py install
+        run: pip install .[ci]
 
       - name: Test if stub is working
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -30,14 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+        
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
         
       - name: Install boost
         uses: MarkusJx/install-boost@v2.0.0

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -12,6 +12,7 @@ on:
     #  - "dev"
     #tags:
     #  - "v*"
+  pull_request:
   pull_request_review:
     types: [submitted, edited]
   workflow_dispatch:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -30,27 +30,6 @@ jobs:
       C_COMPILER: "gcc-8"
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
-      CIBW_TEST_COMMAND: "python {project}/python/test/test_qulacs.py"
-      CIBW_TEST_REQUIRES: "numpy scipy openfermion"
-      CIBW_BEFORE_BUILD_WINDOWS: "pip install cmake && rm -rf {project}/build"
-      CIBW_BEFORE_BUILD_LINUX:
-        "pip install cmake && yum install wget -y && wget -q https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz && tar -zxf boost_1_76_0.tar.gz &&
-        cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && cp -r boost /usr/local/include && rm -rf {project}/build" #install boost and cmake
-      # In GitHub Actions virtual environment macos-10.15/20201115.1,
-      # linking some functions from libgomp fails since the linker cannot find
-      # some library files from gcc-8 installed via Homebrew.
-      # The following command fixes this issue by (brew) re-linking files from gcc-8.
-      # cf. https://stackoverflow.com/a/55500164
-      CIBW_BEFORE_BUILD_MACOS: "brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost && rm -rf {project}/build"
-      CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
-      CIBW_SKIP: "cp311-*"
-
-      # necessary for compiling python pillow library required to install numpy,scipy,openfermion.
-      CIBW_BEFORE_TEST_LINUX: "yum install libjpeg-devel -y"
-
-      CIBW_BUILD_VERBOSITY: "1"
-      CIBW_ENVIRONMENT: 'QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
-      CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"
       TWINE_USERNAME: "__token__"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -22,7 +22,7 @@ jobs:
   wheel-build:
     name: Python wheel build
     # For jobs triggered by pull_request_review, build task should run only if is in `approved` state.
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:
         python-version: ["3.7.5"]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -2,18 +2,20 @@ name: Wheel build
 
 on:
   push:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
-    branches:
-      - "dev"
-    tags:
-      - "v*"
+    # commented out for debug.
+    #paths-ignore:
+    #  - ".devcontainer/**"
+    #  - ".vscode/**"
+    #  - "doc/**"
+    #  - "*.md"
+    #branches:
+    #  - "dev"
+    #tags:
+    #  - "v*"
   pull_request_review:
     types: [submitted, edited]
   workflow_dispatch:
+
 
 jobs:
   wheel-build:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -21,7 +21,6 @@ on:
 jobs:
   wheel-build:
     name: Python wheel build
-    # For jobs triggered by pull_request_review, build task should run only if is in `approved` state.
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,13 +27,14 @@
             "type": "shell",
             "command": "make pythontest -C build -j $(nproc)",
             "dependsOn": [
-                "build gcc"
+                "build gcc",
+                "install"
             ]
         },
         {
             "label": "install",
             "type": "shell",
-            "command": "python setup.py bdist_wheel",
+            "command": "pip install .",
             "dependsOn": [
                 "build gcc"
             ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,7 +34,7 @@
         {
             "label": "install",
             "type": "shell",
-            "command": "pip install .",
+            "command": "pip install .[dev]",
             "dependsOn": [
                 "build gcc"
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["wheel", "setuptools", "setuptools_scm", "cmake"]
+requires = ["wheel", "setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -36,8 +36,7 @@ dev = [
     "flake8",
     "openfermion",
     "mypy",
-    "pybind11-stubgen",
-    "cmake"
+    "pybind11-stubgen"
 ]
 
 test = [
@@ -47,8 +46,7 @@ test = [
 ci = [
     "openfermion",
     "mypy",
-    "pybind11-stubgen",
-    "cmake"
+    "pybind11-stubgen"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,8 @@ before-test = "pip install cmake && rm -rf {project}/build"
 # The following command fixes this issue by (brew) re-linking files from gcc-8.
 # cf. https://stackoverflow.com/a/55500164
 before-build = """\
-brew install gcc@8 && brew link --overwrite gcc@8 && \
+rm -rf {project}/build && brew install gcc@8 && brew link --overwrite gcc@8 && \
 pip install cmake && brew upgrade && brew install -f boost && \
-brew link boost && rm -rf {project}/build \
+brew link boost\
 """
 repair-wheel-command = "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,17 @@ classifiers = [
 [project.urls]
 homepage = "http://www.qulacs.org"
 
+[project.optional-dependencies]
+test = [
+    "openfermion"
+]
+
+ci = [
+    "openfermion",
+    "mypy",
+    "pybind11-stubgen"
+]
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ test-requires = "numpy scipy openfermion"
 
 [tool.cibuildwheel.linux]
 before-build = """\
-pip install cmake && yum install wget -y && \
+yum install wget -y && \
 wget -q https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz && \
 tar -zxf boost_1_76_0.tar.gz && \
 cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && \
@@ -73,7 +73,7 @@ cp -r boost /usr/local/include && rm -rf {project}/build \
 """
 
 [tool.cibuildwheel.windows]
-before-test = "pip install cmake && rm -rf {project}/build"
+before-test = "rm -rf {project}/build"
 
 
 [tool.cibuildwheel.macos]
@@ -84,7 +84,7 @@ before-test = "pip install cmake && rm -rf {project}/build"
 # cf. https://stackoverflow.com/a/55500164
 before-build = """\
 brew install gcc@8 && brew link --overwrite gcc@8 && \
-pip install cmake && brew upgrade && brew install -f boost && \
-brew link boost \
+brew upgrade && brew install -f boost && \
+brew link boost && rm -rf {project}/build\
 """
 repair-wheel-command = "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,14 @@ classifiers = [
 homepage = "http://www.qulacs.org"
 
 [project.optional-dependencies]
+dev = [
+    "black",
+    "flake8",
+    "openfermion",
+    "mypy",
+    "pybind11-stubgen"
+]
+
 test = [
     "openfermion"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dev = [
     "flake8",
     "openfermion",
     "mypy",
-    "pybind11-stubgen"
+    "pybind11-stubgen",
+    "cmake"
 ]
 
 test = [
@@ -46,7 +47,8 @@ test = [
 ci = [
     "openfermion",
     "mypy",
-    "pybind11-stubgen"
+    "pybind11-stubgen",
+    "cmake"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["wheel", "setuptools", "setuptools_scm"]
+requires = ["wheel", "setuptools", "setuptools_scm", "cmake"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -83,8 +83,8 @@ before-test = "pip install cmake && rm -rf {project}/build"
 # The following command fixes this issue by (brew) re-linking files from gcc-8.
 # cf. https://stackoverflow.com/a/55500164
 before-build = """\
-rm -rf {project}/build && brew install gcc@8 && brew link --overwrite gcc@8 && \
+brew install gcc@8 && brew link --overwrite gcc@8 && \
 pip install cmake && brew upgrade && brew install -f boost && \
-brew link boost\
+brew link boost \
 """
 repair-wheel-command = "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["wheel", "setuptools", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qulacs"
+version = "0.5.0"
+description = "Quantum circuit simulator for research"
+authors = [ 
+    { name = "QunaSys", Email = "qulacs@qunasys.com" }
+]
+readme = "README.md"
+license = { file = "LICENSE" }
+dependencies = [
+    "numpy",
+    "scipy"
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Programming Language :: Python",
+    "Topic :: Communications :: Email"
+]
+
+[project.urls]
+homepage = "http://www.qulacs.org"
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false
+
+[tool.cibuildwheel]
+build = "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
+skip = "cp311-*"
+
+environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }
+build-verbosity = "1"
+
+test-command = "python {project}/python/test/test_qulacs.py"
+test-requires = "numpy scipy openfermion"
+
+[tool.cibuildwheel.linux]
+before-build = """\
+pip install cmake && yum install wget -y && \
+wget -q https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz && \
+tar -zxf boost_1_76_0.tar.gz && \
+cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && \
+cp -r boost /usr/local/include && rm -rf {project}/build \
+"""
+
+[tool.cibuildwheel.windows]
+before-test = "pip install cmake && rm -rf {project}/build"
+
+
+[tool.cibuildwheel.macos]
+# In GitHub Actions virtual environment macos-10.15/20201115.1,
+# linking some functions from libgomp fails since the linker cannot find
+# some library files from gcc-8 installed via Homebrew.
+# The following command fixes this issue by (brew) re-linking files from gcc-8.
+# cf. https://stackoverflow.com/a/55500164
+before-build = """\
+brew install gcc@8 && brew link --overwrite gcc@8 && \
+pip install cmake && brew upgrade && brew install -f boost && \
+brew link boost && rm -rf {project}/build \
+"""
+repair-wheel-command = "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"


### PR DESCRIPTION
設定情報を`pyproject.toml`ファイルで一元管理するために、以下の3つの設定を`pyproject.toml`ファイルにまとめました。

- wheel buildの情報をGitHub Actionsの環境変数から移行
- 依存ライブラリの情報を追加
  - numpyとscipyを必須ライブラリ、openfermionや各種linter類を追加ライブラリとして設定しています
  - `pip install .[dev]` とすると全てのライブラリが入ります
-  setup.pyの情報を一部移行
    - プロジェクト名やバージョンなどの情報を移行しています
    -  C++のビルド部分はそのまま残しています

この結果として、`cibuildwheel --platform linux`を実行すると、Dockerを使って手元でwheelビルドが走るようになります。