### PR TITLE
Avoid memory leak in test

### DIFF
--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -84,6 +84,8 @@ TEST(GateTest, ApplySingleQubitGate) {
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
             for (ITYPE i = 0; i < dim; ++i)
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state2[i]), 0, eps);
+
+            delete gate;
         }
     }
 }
@@ -140,6 +142,8 @@ TEST(GateTest, ApplySingleQubitRotationGate) {
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
             for (ITYPE i = 0; i < dim; ++i)
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state2[i]), 0, eps);
+
+            delete gate;
         }
     }
 }
@@ -194,6 +198,8 @@ TEST(GateTest, ApplyTwoQubitGate) {
             for (ITYPE i = 0; i < dim; ++i)
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
                     0, eps);
+
+            delete gate;
         }
     }
 
@@ -233,6 +239,8 @@ TEST(GateTest, ApplyTwoQubitGate) {
             for (ITYPE i = 0; i < dim; ++i)
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
                     0, eps);
+
+            delete gate;
         }
     }
 }
@@ -282,6 +290,8 @@ TEST(GateTest, ApplyMultiQubitGate) {
 
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
+
+        delete gate;
     }
 
     for (UINT repeat = 0; repeat < 10; ++repeat) {
@@ -313,6 +323,8 @@ TEST(GateTest, ApplyMultiQubitGate) {
 
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
+
+        delete gate;
     }
 }
 
@@ -847,6 +859,10 @@ TEST(GateTest, U3MergeIBMQGate) {
     auto gate1 = gate::U3(0, 0.1, 0.1, 0.1);
     auto gate2 = gate::U3(0, 0.1, 0.1, 0.1);
     auto gate3 = gate::merge(gate1, gate2);
+
+    delete gate1;
+    delete gate2;
+    delete gate3;
 }
 
 TEST(GateTest, ControlMerge) {
@@ -893,6 +909,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete x0;
+        delete cx01;
+        delete res;
     }
 
     {
@@ -914,6 +934,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete x1;
+        delete cx01;
+        delete res;
     }
 
     {
@@ -935,6 +959,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete x1;
+        delete cx01;
+        delete res;
     }
 
     {
@@ -954,6 +982,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete cz01;
+        delete cx01;
+        delete res;
     }
 
     {
@@ -972,6 +1004,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete cz10;
+        delete cx01;
+        delete res;
     }
 
     n = 3;
@@ -995,6 +1031,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete x2;
+        delete cx01;
+        delete res;
     }
 
     {
@@ -1016,6 +1056,10 @@ TEST(GateTest, ControlMerge) {
                 ASSERT_NEAR(abs(checkmat(x, y) - (mat_res(x, y))), 0, eps)
                     << res << "\n\n"
                     << mat_res << std::endl;
+
+        delete x2;
+        delete cx01;
+        delete res;
     }
 }
 
@@ -1038,19 +1082,22 @@ TEST(GateTest, RandomControlMergeSmall) {
         for (ITYPE i = 0; i < dim; ++i)
             test_state_eigen[i] = state.data_cpp()[i];
         auto merge_gate1 = gate::Identity(0);
-        auto merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
             std::random_shuffle(arr.begin(), arr.end());
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
-            merge_gate1 = gate::merge(merge_gate1, new_gate);
+            auto next_merge_gate1 = gate::merge(merge_gate1, new_gate);
+            delete merge_gate1;
+            merge_gate1 = next_merge_gate1;
 
             new_gate->update_quantum_state(&test_state);
 
             auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
             mat = cmat * mat;
+
+            delete new_gate;
         }
         merge_gate1->update_quantum_state(&state);
         test_state_eigen = mat * test_state_eigen;
@@ -1062,6 +1109,8 @@ TEST(GateTest, RandomControlMergeSmall) {
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps)
                 << state << "\n\n"
                 << test_state_eigen << "\n";
+
+        delete merge_gate1;
     }
 }
 
@@ -1091,10 +1140,14 @@ TEST(GateTest, RandomControlMergeLarge) {
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
-            merge_gate1 = gate::merge(merge_gate1, new_gate);
+            auto next_merge_gate1 = gate::merge(merge_gate1, new_gate);
+            delete merge_gate1;
+            merge_gate1 = next_merge_gate1;
 
             auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
             mat = cmat * mat;
+
+            delete new_gate;
         }
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
@@ -1102,10 +1155,14 @@ TEST(GateTest, RandomControlMergeLarge) {
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
-            merge_gate2 = gate::merge(merge_gate2, new_gate);
+            auto next_merge_gate2 = gate::merge(merge_gate2, new_gate);
+            delete merge_gate2;
+            merge_gate2 = next_merge_gate2;
 
             auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
             mat = cmat * mat;
+
+            delete new_gate;
         }
 
         auto merge_gate = gate::merge(merge_gate1, merge_gate2);
@@ -1121,6 +1178,10 @@ TEST(GateTest, RandomControlMergeLarge) {
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps)
                 << state << "\n\n"
                 << test_state_eigen << "\n";
+
+        delete merge_gate1;
+        delete merge_gate2;
+        delete merge_gate;
     }
 }
 
@@ -1146,6 +1207,10 @@ TEST(GateTest, CPTPGate) {
     auto gate4 = gate::merge(gate::P1(0), gate::P1(1));
 
     auto CPTP = gate::CPTP({gate3, gate2, gate1, gate4});
+    delete gate1;
+    delete gate2;
+    delete gate3;
+    delete gate4;
     QuantumState s(3);
     s.set_computational_basis(0);
     CPTP->update_quantum_state(&s);
@@ -1161,6 +1226,10 @@ TEST(GateTest, InstrumentGate) {
     auto gate4 = gate::merge(gate::P1(0), gate::P1(1));
 
     auto Inst = gate::Instrument({gate3, gate2, gate1, gate4}, 1);
+    delete gate1;
+    delete gate2;
+    delete gate3;
+    delete gate4;
     QuantumState s(3);
     s.set_computational_basis(0);
     Inst->update_quantum_state(&s);
@@ -1176,6 +1245,7 @@ TEST(GateTest, AdaptiveGateWithoutID) {
     auto x = gate::X(0);
     auto adaptive = gate::Adaptive(
         x, [](const std::vector<UINT>& vec) { return vec[2] == 1; });
+    delete x;
     QuantumState s(1);
     s.set_computational_basis(0);
     s.set_classical_value(2, 1);
@@ -1192,6 +1262,7 @@ TEST(GateTest, AdaptiveGateWithID) {
     auto adaptive = gate::Adaptive(
         x, [](const std::vector<UINT>& vec, UINT id) { return vec[id] == 1; },
         2);
+    delete x;
     QuantumState s(1);
     s.set_computational_basis(0);
     s.set_classical_value(2, 1);
@@ -1213,10 +1284,31 @@ TEST(GateTest, GateAdd) {
     auto a2 = gate::add(g1, g3);
     auto a3 = gate::add(g1, g4);
     auto a4 = gate::add(g3, g4);
-    auto a5 = gate::add(gate::P0(0), gate::P1(0));
-    auto a6 = gate::add(gate::merge(gate::P0(0), gate::P0(1)),
-        gate::merge(gate::P1(0), gate::P1(1)));
+    auto p00 = gate::P0(0);
+    auto p01 = gate::P0(1);
+    auto p10 = gate::P1(0);
+    auto p11 = gate::P1(1);
+    auto a5 = gate::add(p00, p10);
+    auto p0_merge = gate::merge(p00, p01);
+    auto p1_merge = gate::merge(p10, p11);
+    auto a6 = gate::add(p0_merge, p1_merge);
     // TODO assert matrix element
+    delete g1;
+    delete g2;
+    delete g3;
+    delete g4;
+    delete a1;
+    delete a2;
+    delete a3;
+    delete a4;
+    delete p00;
+    delete p01;
+    delete p10;
+    delete p11;
+    delete a5;
+    delete p0_merge;
+    delete p1_merge;
+    delete a6;
 }
 
 TEST(GateTest, RandomUnitaryGate) {
@@ -1239,6 +1331,8 @@ TEST(GateTest, RandomUnitaryGate) {
                 }
             }
         }
+
+        delete gate;
     }
 }
 
@@ -1283,6 +1377,8 @@ TEST(GateTest, ReversibleBooleanGate) {
     gate->update_quantum_state(&state);
     std::cout << state.to_string() << std::endl;
     */
+
+    delete gate;
 }
 
 TEST(GateTest, TestNoise) {
@@ -1434,4 +1530,6 @@ TEST(GateTest, GetControlList) {
     std::vector<std::pair<unsigned int, unsigned int>> true_ivl = {
         {1, 0}, {2, 1}, {3, 0}};
     EXPECT_EQ(index_value_list, true_ivl);
+
+    delete gateA;
 }

--- a/test/cppsim/test_gate_dm.cpp
+++ b/test/cppsim/test_gate_dm.cpp
@@ -137,13 +137,9 @@ TEST(DensityMatrixGateTest, ApplyTwoQubitGate) {
     Random random;
     DensityMatrix state(n);
     QuantumState test_state(n);
-    std::vector<std::pair<std::function<QuantumGateBase*(UINT, UINT)>,
-        std::function<Eigen::MatrixXcd(UINT, UINT, UINT)>>>
-        funclist;
-    funclist.push_back(
-        std::make_pair(gate::CNOT, get_eigen_matrix_full_qubit_CNOT));
-    funclist.push_back(
-        std::make_pair(gate::CZ, get_eigen_matrix_full_qubit_CZ));
+    std::vector<std::function<QuantumGateBase*(UINT, UINT)>> funclist;
+    funclist.push_back(gate::CNOT);
+    funclist.push_back(gate::CZ);
 
     for (UINT repeat = 0; repeat < 10; ++repeat) {
         for (auto func_mat : funclist) {
@@ -151,8 +147,7 @@ TEST(DensityMatrixGateTest, ApplyTwoQubitGate) {
             UINT target = random.int32() % n;
             if (target == control) target = (target + 1) % n;
 
-            auto func = func_mat.first;
-            auto func_eig = func_mat.second;
+            auto func = func_mat;
 
             test_state.set_Haar_random_state();
             state.load(&test_state);
@@ -169,20 +164,20 @@ TEST(DensityMatrixGateTest, ApplyTwoQubitGate) {
                     ASSERT_NEAR(abs(state.data_cpp()[i * dim + j] -
                                     dm_test.data_cpp()[i * dim + j]),
                         0, eps);
+
+            delete gate;
         }
     }
 
     funclist.clear();
-    funclist.push_back(
-        std::make_pair(gate::SWAP, get_eigen_matrix_full_qubit_SWAP));
+    funclist.push_back(gate::SWAP);
     for (UINT repeat = 0; repeat < 10; ++repeat) {
         for (auto func_mat : funclist) {
             UINT control = random.int32() % n;
             UINT target = random.int32() % n;
             if (target == control) target = (target + 1) % n;
 
-            auto func = func_mat.first;
-            auto func_eig = func_mat.second;
+            auto func = func_mat;
 
             test_state.set_Haar_random_state();
             state.load(&test_state);
@@ -209,9 +204,6 @@ TEST(DensityMatrixGateTest, ApplyMultiQubitGate) {
     Random random;
     DensityMatrix state(n);
     QuantumState test_state(n);
-    std::vector<std::pair<std::function<QuantumGateBase*(UINT, UINT)>,
-        std::function<Eigen::MatrixXcd(UINT, UINT, UINT)>>>
-        funclist;
 
     // gate::DenseMatrix
     // gate::Pauli
@@ -237,6 +229,8 @@ TEST(DensityMatrixGateTest, ApplyMultiQubitGate) {
                 ASSERT_NEAR(abs(state.data_cpp()[i * dim + j] -
                                 dm_test.data_cpp()[i * dim + j]),
                     0, eps);
+
+        delete gate;
     }
 
     for (UINT repeat = 0; repeat < 10; ++repeat) {
@@ -262,6 +256,8 @@ TEST(DensityMatrixGateTest, ApplyMultiQubitGate) {
                 ASSERT_NEAR(abs(state.data_cpp()[i * dim + j] -
                                 dm_test.data_cpp()[i * dim + j]),
                     0, eps);
+
+        delete gate;
     }
 }
 
@@ -687,10 +683,14 @@ TEST(DensityMatrixGateTest, RandomControlMergeSmall) {
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
-            merge_gate1 = gate::merge(merge_gate1, new_gate);
+            auto next_merge_gate1 = gate::merge(merge_gate1, new_gate);
+            delete merge_gate1;
+            merge_gate1 = next_merge_gate1;
 
             auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
             mat = cmat * mat;
+
+            delete new_gate;
         }
         merge_gate1->update_quantum_state(&state);
         merge_gate1->update_quantum_state(&test_state);
@@ -702,6 +702,8 @@ TEST(DensityMatrixGateTest, RandomControlMergeSmall) {
                 ASSERT_NEAR(abs(state.data_cpp()[i * dim + j] -
                                 dm.data_cpp()[i * dim + j]),
                     0, eps);
+
+        delete merge_gate1;
     }
 }
 
@@ -732,10 +734,14 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
-            merge_gate1 = gate::merge(merge_gate1, new_gate);
+            auto next_merge_gate1 = gate::merge(merge_gate1, new_gate);
+            delete merge_gate1;
+            merge_gate1 = next_merge_gate1;
 
             auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
             mat = cmat * mat;
+
+            delete new_gate;
         }
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
@@ -743,10 +749,14 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
-            merge_gate2 = gate::merge(merge_gate2, new_gate);
+            auto next_merge_gate2 = gate::merge(merge_gate2, new_gate);
+            delete merge_gate2;
+            merge_gate2 = next_merge_gate2;
 
             auto cmat = get_eigen_matrix_full_qubit_CNOT(control, target, n);
             mat = cmat * mat;
+
+            delete new_gate;
         }
 
         auto merge_gate = gate::merge(merge_gate1, merge_gate2);
@@ -767,6 +777,10 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
                 ASSERT_NEAR(abs(state.data_cpp()[i * dim + j] -
                                 state2.data_cpp()[i * dim + j]),
                     0, eps);
+
+        delete merge_gate1;
+        delete merge_gate2;
+        delete merge_gate;
     }
 }
 

--- a/test/cppsim/test_hamiltonian.cpp
+++ b/test/cppsim/test_hamiltonian.cpp
@@ -174,6 +174,8 @@ TEST(ObservableTest, CheckParsedObservableFromOpenFermionText) {
     ASSERT_NEAR(test_res.real(), res.real(), eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);
     ASSERT_NEAR(res.imag(), 0, eps);
+
+    delete observable;
 }
 
 /*
@@ -560,6 +562,8 @@ TEST(ObservableTest, ObservableAndStateHaveDifferentQubitCountTest) {
     ASSERT_NEAR(res.real(), test_res.real(), eps);
     ASSERT_NEAR(0, test_res.imag(), eps);
     ASSERT_NEAR(0, res.imag(), eps);
+
+    delete observable;
 }
 
 TEST(ObservableTest, ApplyIdentityToState) {

--- a/test/cppsim/test_hamiltonian_dm.cpp
+++ b/test/cppsim/test_hamiltonian_dm.cpp
@@ -163,4 +163,6 @@ TEST(DensityMatrixObservableTest, CheckParsedObservableFromOpenFermionText) {
     res_mat = observable->get_expectation_value(&density_matrix);
     ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
     ASSERT_NEAR(res_vec.imag(), res_mat.imag(), eps);
+
+    delete observable;
 }

--- a/test/cppsim/test_noise_dm.cpp
+++ b/test/cppsim/test_noise_dm.cpp
@@ -30,10 +30,14 @@ TEST(DensityMatrixGeneralGateTest, ProbabilisticGate) {
 }
 
 TEST(DensityMatrixGeneralGateTest, CPTPGate) {
-    auto gate1 = gate::merge(gate::P0(0), gate::P0(1));
-    auto gate2 = gate::merge(gate::P0(0), gate::P1(1));
-    auto gate3 = gate::merge(gate::P1(0), gate::P0(1));
-    auto gate4 = gate::merge(gate::P1(0), gate::P1(1));
+    auto p00 = gate::P0(0);
+    auto p01 = gate::P0(1);
+    auto p10 = gate::P1(0);
+    auto p11 = gate::P1(1);
+    auto gate1 = gate::merge(p00, p01);
+    auto gate2 = gate::merge(p00, p11);
+    auto gate3 = gate::merge(p10, p01);
+    auto gate4 = gate::merge(p10, p11);
 
     auto CPTP = gate::CPTP({gate3, gate2, gate1, gate4});
     DensityMatrix s(3);
@@ -41,14 +45,26 @@ TEST(DensityMatrixGeneralGateTest, CPTPGate) {
     CPTP->update_quantum_state(&s);
     s.set_Haar_random_state();
     CPTP->update_quantum_state(&s);
+    delete p00;
+    delete p01;
+    delete p10;
+    delete p11;
+    delete gate1;
+    delete gate2;
+    delete gate3;
+    delete gate4;
     delete CPTP;
 }
 
 TEST(DensityMatrixGeneralGateTest, InstrumentGate) {
-    auto gate1 = gate::merge(gate::P0(0), gate::P0(1));
-    auto gate2 = gate::merge(gate::P0(0), gate::P1(1));
-    auto gate3 = gate::merge(gate::P1(0), gate::P0(1));
-    auto gate4 = gate::merge(gate::P1(0), gate::P1(1));
+    auto p00 = gate::P0(0);
+    auto p01 = gate::P0(1);
+    auto p10 = gate::P1(0);
+    auto p11 = gate::P1(1);
+    auto gate1 = gate::merge(p00, p01);
+    auto gate2 = gate::merge(p00, p11);
+    auto gate3 = gate::merge(p10, p01);
+    auto gate4 = gate::merge(p10, p11);
 
     auto Inst = gate::Instrument({gate3, gate2, gate1, gate4}, 1);
     DensityMatrix s(3);
@@ -59,6 +75,14 @@ TEST(DensityMatrixGeneralGateTest, InstrumentGate) {
     s.set_Haar_random_state();
     Inst->update_quantum_state(&s);
     UINT res2 = s.get_classical_value(1);
+    delete p00;
+    delete p01;
+    delete p10;
+    delete p11;
+    delete gate1;
+    delete gate2;
+    delete gate3;
+    delete gate4;
     delete Inst;
 }
 
@@ -72,6 +96,7 @@ TEST(DensityMatrixGeneralGateTest, AdaptiveGate) {
     adaptive->update_quantum_state(&s);
     s.set_classical_value(2, 0);
     adaptive->update_quantum_state(&s);
+    delete x;
     delete adaptive;
 }
 

--- a/test/cppsim/test_state_dm.cpp
+++ b/test/cppsim/test_state_dm.cpp
@@ -61,10 +61,15 @@ TEST(DensityMatrixTest, Sampling) {
 TEST(DensityMatrixTest, Probabilistic) {
     DensityMatrix state_noI(2);
     DensityMatrix state_yesI(2);
-    auto proba_gate_noI =
-        QuantumGate_Probabilistic({0.2, 0.2}, {gate::X(0), gate::H(1)});
-    auto proba_gate_yesI = QuantumGate_Probabilistic(
-        {0.2, 0.2, 0.6}, {gate::X(0), gate::H(1), gate::Identity(0)});
+    auto x0 = gate::X(0);
+    auto h1 = gate::H(1);
+    auto i0 = gate::Identity(0);
+    auto proba_gate_noI = QuantumGate_Probabilistic({0.2, 0.2}, {x0, h1});
+    auto proba_gate_yesI =
+        QuantumGate_Probabilistic({0.2, 0.2, 0.6}, {x0, h1, i0});
+    delete x0;
+    delete h1;
+    delete i0;
 
     proba_gate_noI.update_quantum_state(&state_noI);
     proba_gate_yesI.update_quantum_state(&state_yesI);

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -101,8 +101,8 @@ TEST(ParametricCircuit, ParametricGatePosition) {
     circuit.add_parametric_gate_copy(prz0);
     delete prz0;
     auto cz01 = gate::CNOT(0, 1);
-    delete cz01;
     circuit.add_gate_copy(cz01);
+    delete cz01;
     circuit.add_parametric_RY_gate(1, 0.);
     circuit.add_parametric_gate(gate::ParametricRY(2), 2);
     circuit.add_gate_copy(gate::X(0), 2);
@@ -111,6 +111,7 @@ TEST(ParametricCircuit, ParametricGatePosition) {
     circuit.remove_gate(5);
     auto ppr1 = gate::ParametricPauliRotation({1}, {0}, 0.);
     circuit.add_parametric_gate_copy(ppr1, 6);
+    delete ppr1;
 
     ASSERT_EQ(circuit.get_parameter_count(), 5);
     ASSERT_EQ(circuit.get_parametric_gate_position(0), 1);

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -97,16 +97,20 @@ TEST(ParametricCircuit, ParametricGatePosition) {
     auto circuit = ParametricQuantumCircuit(3);
     circuit.add_parametric_RX_gate(0, 0.);
     circuit.add_H_gate(0);
-    circuit.add_parametric_gate_copy(gate::ParametricRZ(0, 0.));
-    circuit.add_gate_copy(gate::CNOT(0, 1));
+    auto prz0 = gate::ParametricRZ(0, 0.);
+    circuit.add_parametric_gate_copy(prz0);
+    delete prz0;
+    auto cz01 = gate::CNOT(0, 1);
+    delete cz01;
+    circuit.add_gate_copy(cz01);
     circuit.add_parametric_RY_gate(1, 0.);
     circuit.add_parametric_gate(gate::ParametricRY(2), 2);
     circuit.add_gate_copy(gate::X(0), 2);
     circuit.add_parametric_gate(gate::ParametricRZ(1), 0);
     circuit.remove_gate(4);
     circuit.remove_gate(5);
-    circuit.add_parametric_gate_copy(
-        gate::ParametricPauliRotation({1}, {0}, 0.), 6);
+    auto ppr1 = gate::ParametricPauliRotation({1}, {0}, 0.);
+    circuit.add_parametric_gate_copy(ppr1, 6);
 
     ASSERT_EQ(circuit.get_parameter_count(), 5);
     ASSERT_EQ(circuit.get_parametric_gate_position(0), 1);
@@ -170,6 +174,8 @@ TEST(EnergyMinimization, SingleQubitClassical) {
     double diag_loss = dems.get_loss();
 
     EXPECT_NEAR(qc_loss, diag_loss, 1e-2);
+
+    delete observable;
 }
 
 TEST(EnergyMinimization, SingleQubitComplex) {
@@ -205,6 +211,8 @@ TEST(EnergyMinimization, SingleQubitComplex) {
     double diag_loss = dems.get_loss();
 
     EXPECT_NEAR(qc_loss, diag_loss, 1e-2);
+
+    delete emp;
 }
 
 TEST(EnergyMinimization, MultiQubit) {
@@ -249,6 +257,8 @@ TEST(EnergyMinimization, MultiQubit) {
     // std::cout << qc_loss << " " << diag_loss << std::endl;
     ASSERT_GT(qc_loss, diag_loss);
     EXPECT_NEAR(qc_loss, diag_loss, 1e-1);
+
+    delete emp;
 }
 
 TEST(ParametricGate, DuplicateIndex) {


### PR DESCRIPTION
テストのコード中でデスクトラクタの呼ばれてないオブジェクトがいくらかあったので修正しました
ゲートを指定する関数で何でもかんでもコピーしてるけど使いまわししない場合コピー元の解放を忘れることが結構ありそうで難しいですね…