### PR TITLE
Cache devcontainer image to GHCR

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/python-3/.devcontainer/base.Dockerfile
 
-# Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+# Pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 # Append -bullseye or -buster to pin to an OS version.
 # Use -bullseye variants on local on arm64/Apple Silicon.
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9-bullseye

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,9 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/python-3/.devcontainer/base.Dockerfile
 
-ARG VARIANT
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+# Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+# Append -bullseye or -buster to pin to an OS version.
+# Use -bullseye variants on local on arm64/Apple Silicon.
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,12 +4,7 @@
 	"name": "C++",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-		// Append -bullseye or -buster to pin to an OS version.
-		// Use -bullseye variants on local on arm64/Apple Silicon.
-		"args": {
-			"VARIANT": "3.9-bullseye"
-		}
+		"cacheFrom": "ghcr.io/qulacs/qulacs-devcontainer"
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "C++",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"cacheFrom": "ghcr.io/qulacs/qulacs-devcontainer"
+		"cacheFrom": "ghcr.io/qulacs/qulacs-devcontainer:latest"
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/.github/workflows/build_devcontainer_image.yml
+++ b/.github/workflows/build_devcontainer_image.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           imageName: ghcr.io/qulacs/qulacs-devcontainer
           push: always
-          # eventFilterForPush: |
-          #   push
-          #   schedule
+          eventFilterForPush: |
+            push
+            schedule
           runCmd: |
             ':'

--- a/.github/workflows/build_devcontainer_image.yml
+++ b/.github/workflows/build_devcontainer_image.yml
@@ -1,0 +1,39 @@
+name: 'Build devcontainer Image' 
+on:
+  schedule:
+    - cron: '0 0 * * *'  # At 00:00, every day
+  pull_request:
+    paths:
+      - '.devcontainer/**'
+  push:
+    paths:
+      - '.devcontainer/**'
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and run dev container task
+        uses: devcontainers/ci@v0.2
+        with:
+          imageName: ghcr.io/qulacs/qulacs-devcontainer
+          push: always
+          # eventFilterForPush: |
+          #   push
+          #   schedule
+          # Commands to run in a devcontainer to check its behavior.
+          runCmd: |
+            ''

--- a/.github/workflows/build_devcontainer_image.yml
+++ b/.github/workflows/build_devcontainer_image.yml
@@ -30,7 +30,6 @@ jobs:
         uses: devcontainers/ci@v0.2
         with:
           imageName: ghcr.io/qulacs/qulacs-devcontainer
-          push: always
           eventFilterForPush: |
             push
             schedule

--- a/.github/workflows/build_devcontainer_image.yml
+++ b/.github/workflows/build_devcontainer_image.yml
@@ -34,6 +34,5 @@ jobs:
           # eventFilterForPush: |
           #   push
           #   schedule
-          # Commands to run in a devcontainer to check its behavior.
           runCmd: |
-            ''
+            ':'


### PR DESCRIPTION
We can run VS Code devcontainer based on existing image.
So build the image for devcontainer on GitHub Actions, push it to GitHub Container Registry and use it local.
This should reduce builds at local environment by using the pre-built image.