### PR TITLE
copy_types

### DIFF
--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -103,7 +103,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_Probabilistic* copy() const override {
         return new QuantumGate_Probabilistic(_distribution, _gate_list);
     };
 
@@ -207,7 +207,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_ProbabilisticInstrument* copy() const override {
         return new QuantumGate_ProbabilisticInstrument(
             _distribution, _gate_list, _classical_register_address);
     };
@@ -291,7 +291,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_CPTP* copy() const override {
         return new QuantumGate_CPTP(_gate_list);
     };
     /**
@@ -410,7 +410,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_CP* copy() const override {
         return new QuantumGate_CP(_gate_list, _state_normalize,
             _probability_normalize, _assign_zero_if_not_matched);
     };
@@ -491,7 +491,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_Instrument* copy() const override {
         return new QuantumGate_Instrument(
             _gate_list, _classical_register_address);
     };
@@ -554,7 +554,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_Adaptive* copy() const override {
         if (_id == -1) {
             return new QuantumGate_Adaptive(_gate, _func_without_id);
         } else {

--- a/src/cppsim/gate_matrix.hpp
+++ b/src/cppsim/gate_matrix.hpp
@@ -110,7 +110,7 @@ public:
      *
      * @return コピーされたゲートのインスタンス
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGateMatrix* copy() const override {
         return new QuantumGateMatrix(*this);
     };
 

--- a/src/cppsim/gate_matrix_diagonal.hpp
+++ b/src/cppsim/gate_matrix_diagonal.hpp
@@ -110,7 +110,7 @@ public:
      *
      * @return コピーされたゲートのインスタンス
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGateDiagonalMatrix* copy() const override {
         return new QuantumGateDiagonalMatrix(*this);
     };
 

--- a/src/cppsim/gate_matrix_sparse.hpp
+++ b/src/cppsim/gate_matrix_sparse.hpp
@@ -111,7 +111,7 @@ public:
      *
      * @return コピーされたゲートのインスタンス
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGateSparseMatrix* copy() const override {
         return new QuantumGateSparseMatrix(*this);
     };
 

--- a/src/cppsim/gate_named.hpp
+++ b/src/cppsim/gate_named.hpp
@@ -50,7 +50,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_OneQubit* copy() const override {
         return new QuantumGate_OneQubit(*this);
     };
     /**
@@ -111,7 +111,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_TwoQubit* copy() const override {
         return new QuantumGate_TwoQubit(*this);
     };
     /**
@@ -173,7 +173,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_OneControlOneTarget* copy() const override {
         return new QuantumGate_OneControlOneTarget(*this);
     };
     /**
@@ -232,7 +232,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual QuantumGate_OneQubitRotation* copy() const override {
         return new QuantumGate_OneQubitRotation(*this);
     };
     /**

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -83,7 +83,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual ClsPauliGate* copy() const override {
         return new ClsPauliGate(_pauli->copy());
     };
 
@@ -173,7 +173,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual ClsPauliRotationGate* copy() const override {
         return new ClsPauliRotationGate(_angle, _pauli->copy());
     };
 

--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -274,7 +274,7 @@ public:
      */
     virtual void set_seed(int seed) override { _random.set_seed(seed); };
 
-    virtual QuantumGateBase* copy() const override {
+    virtual ClsNoisyEvolution* copy() const override {
         return new ClsNoisyEvolution(_hamiltonian, _c_ops, _time, _dt);
     }
 
@@ -657,7 +657,7 @@ public:
      */
     virtual void set_seed(int seed) override { _random.set_seed(seed); };
 
-    virtual QuantumGateBase* copy() const override {
+    virtual ClsNoisyEvolution_fast* copy() const override {
         return new ClsNoisyEvolution_fast(_hamiltonian, _c_ops, _time);
     }
 

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -71,7 +71,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual ClsStateReflectionGate* copy() const override {
         return new ClsStateReflectionGate(this->reflection_state);
     };
     /**

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -67,7 +67,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual QuantumGateBase* copy() const override {
+    virtual ClsReversibleBooleanGate* copy() const override {
         return new ClsReversibleBooleanGate(*this);
     };
     /**

--- a/test/cppsim/test_noisyevolution.cpp
+++ b/test/cppsim/test_noisyevolution.cpp
@@ -547,8 +547,7 @@ TEST(NoisyEvolutionTest, EmptyCops) {
 
     QuantumState state(n);
     QuantumCircuit circuit(n);
-    auto gate = dynamic_cast<ClsNoisyEvolution*>(
-        gate::NoisyEvolution(&hamiltonian, c_ops, time, dt));
+    auto gate = gate::NoisyEvolution_fast(&hamiltonian, c_ops, time);
     circuit.add_gate(gate);
     for (int k = 0; k < n; k++) {
         std::cout << "set_computational_basis:" << k << std::endl;


### PR DESCRIPTION
copyの型を元の型と同じに変更しました。
ほかのコードは一切修正せずに通ったので、　他に与える影響は低いと思われます。

それと、あまりにもNoisyEvolutionTest, EmptyCops　の成功率が低いので、fast版の成功率を試すように変更しました