### PR TITLE
Fixed an error when building in a non-x86 environment

### DIFF
--- a/src/csim/update_ops_control_multi_target_single.cpp
+++ b/src/csim/update_ops_control_multi_target_single.cpp
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void create_shift_mask_list_from_list_and_value_buf(const UINT* array,

--- a/src/csim/update_ops_control_single_target_single.cpp
+++ b/src/csim/update_ops_control_single_target_single.cpp
@@ -11,10 +11,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void single_qubit_control_single_qubit_dense_matrix_gate_single(UINT

--- a/src/csim/update_ops_matrix_dense_double.cpp
+++ b/src/csim/update_ops_matrix_dense_double.cpp
@@ -11,10 +11,13 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 #ifdef _USE_SIMD

--- a/src/csim/update_ops_matrix_dense_multi.cpp
+++ b/src/csim/update_ops_matrix_dense_multi.cpp
@@ -10,10 +10,12 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void multi_qubit_dense_matrix_gate_old_single(const UINT*

--- a/src/csim/update_ops_matrix_dense_single.cpp
+++ b/src/csim/update_ops_matrix_dense_single.cpp
@@ -10,10 +10,12 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void single_qubit_dense_matrix_gate_old_single(UINT target_qubit_index, const

--- a/src/csim/update_ops_matrix_diagonal_multi.cpp
+++ b/src/csim/update_ops_matrix_diagonal_multi.cpp
@@ -11,10 +11,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void multi_qubit_diagonal_matrix_gate(const UINT* target_qubit_index_list,

--- a/src/csim/update_ops_matrix_diagonal_single.cpp
+++ b/src/csim/update_ops_matrix_diagonal_single.cpp
@@ -11,10 +11,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void single_qubit_diagonal_matrix_gate_old_single(UINT target_qubit_index,

--- a/src/csim/update_ops_matrix_phase_single.cpp
+++ b/src/csim/update_ops_matrix_phase_single.cpp
@@ -11,10 +11,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void single_qubit_phase_gate_old_single(UINT target_qubit_index, CTYPE phase,

--- a/src/csim/update_ops_named.cpp
+++ b/src/csim/update_ops_named.cpp
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void S_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {

--- a/src/csim/update_ops_named_CNOT.cpp
+++ b/src/csim/update_ops_named_CNOT.cpp
@@ -7,10 +7,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void CNOT_gate_old_single(UINT control_qubit_index, UINT target_qubit_index,

--- a/src/csim/update_ops_named_CZ.cpp
+++ b/src/csim/update_ops_named_CZ.cpp
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void CZ_gate_old_single(UINT control_qubit_index, UINT target_qubit_index,

--- a/src/csim/update_ops_named_H.cpp
+++ b/src/csim/update_ops_named_H.cpp
@@ -6,12 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
-
-#include <iostream>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void H_gate_old_parallel(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_SWAP.cpp
+++ b/src/csim/update_ops_named_SWAP.cpp
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void SWAP_gate_old_single(UINT target_qubit_index_0, UINT

--- a/src/csim/update_ops_named_X.cpp
+++ b/src/csim/update_ops_named_X.cpp
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void X_gate_old(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_Y.cpp
+++ b/src/csim/update_ops_named_Y.cpp
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void Y_gate_old_single(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_Z.cpp
+++ b/src/csim/update_ops_named_Z.cpp
@@ -6,10 +6,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 // void Z_gate_old_single(UINT target_qubit_index, CTYPE *state, ITYPE dim);

--- a/src/csim/update_ops_named_projection.cpp
+++ b/src/csim/update_ops_named_projection.cpp
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void P0_gate(UINT target_qubit_index, CTYPE* state, ITYPE dim) {

--- a/src/csim/update_ops_named_state.cpp
+++ b/src/csim/update_ops_named_state.cpp
@@ -10,10 +10,12 @@
 #include <omp.h>
 #endif
 
+#ifdef _USE_SIMD
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
 #include <x86intrin.h>
+#endif
 #endif
 
 void normalize(double squared_norm, CTYPE* state, ITYPE dim) {


### PR DESCRIPTION
(English after Japanese)
いくつかのソースファイルにおいて、intrin.h/x86intrin.hファイルを読み込んでしまい、エラーとなっている。
_USE_SIMDオプションを指定してビルドした場合に、このファイルを読み込むように修正する。

---
Some source files fail to read an intrin.h/x86intrin.h file.
This file should only be read if it was built with the _USE_SIMD option.