### PR TITLE
do not define OPT_FLAGS in script_build.sh if not specified

### DIFF
--- a/script/build_gcc.sh
+++ b/script/build_gcc.sh
@@ -4,10 +4,13 @@ set -eux
 
 GCC_COMMAND=${C_COMPILER:-"gcc"}
 GXX_COMMAND=${CXX_COMPILER:-"g++"}
-OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 
 mkdir -p ./build
 cd ./build
-cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="$OPT_FLAGS" -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=No -D USE_TEST="${USE_TEST:-No}" ..
+if [ "${QULACS_OPT_FLAGS:-"__UNSET__"}" = "__UNSET__" ]; then
+  cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=No -D USE_TEST="${USE_TEST:-No}" ..
+else
+  cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="${QULACS_OPT_FLAGS}" -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=No -D USE_TEST="${USE_TEST:-No}" ..
+fi
 make -j $(nproc)
 cd ../


### PR DESCRIPTION
cf: #277 
OPT_FLAGSは本来cmake側で環境に合わせてセットするので`$QULACS_OPT_FLAGS`がセットされてないときに`build_gcc.sh`で勝手にSIMD用のオプションを設定するのは少し不便でした。
(少なくともDevcontainer環境の)`/bin/sh`はBashとは違って`[ -v ]`が使えないしセットされてない状態で読みだしたら空文字列ではなくエラーになってしまうのでこのような分岐の書き方しかできませんでした。