### PR TITLE
remove "build gcc" dependency

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,7 +27,6 @@
             "type": "shell",
             "command": "make pythontest -C build -j $(nproc)",
             "dependsOn": [
-                "build gcc",
                 "install"
             ]
         },


### PR DESCRIPTION
close #367 
pythontestのdependsOnに"build gcc"と"install"を両方入れてたのですが、並列実行されて"install"のdependencyの"build gcc"と合わせて2つ同時に実行されてしまっていたので、修正しました。