### PR TITLE
Fix wheel build macos arm64

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:
-        python-version: ["3.7.5"]
+        python-version: ["3.10.8"]
         os: ["ubuntu-20.04", "windows-2019", "macos-11"]
     runs-on: ${{ matrix.os }}
     env:
@@ -75,12 +75,12 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:
-        python-version: ["3.7.5"]
+        python-version: ["3.10.8"]
         os: ["ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     env:
-      CXX_COMPILER: "g++-8"
-      C_COMPILER: "gcc-8"
+      CXX_COMPILER: "g++-10"
+      C_COMPILER: "gcc-10"
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
       TWINE_USERNAME: "__token__"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install boost if windows
         if: ${{ contains(matrix.os, 'windows') }}
-        uses: MarkusJx/install-boost@v2.0.0
+        uses: MarkusJx/install-boost@v2.4.0
         id: install-boost
         with:
           boost_version: 1.77.0

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -7,10 +7,10 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-    # branches:
-    #   - "main"
-    # tags:
-    #   - "v*"
+    branches:
+      - "main"
+    tags:
+      - "v*"
   pull_request:
   pull_request_review:
     types: [submitted, edited]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -7,10 +7,10 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-    branches:
-      - "main"
-    tags:
-      - "v*"
+    # branches:
+    #   - "main"
+    # tags:
+    #   - "v*"
   pull_request:
   pull_request_review:
     types: [submitted, edited]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,8 +27,8 @@ jobs:
         os: ["ubuntu-20.04", "windows-2019", "macos-11"]
     runs-on: ${{ matrix.os }}
     env:
-      CXX_COMPILER: "g++-8"
-      C_COMPILER: "gcc-8"
+      CXX_COMPILER: "g++-10"
+      C_COMPILER: "gcc-10"
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
       TWINE_USERNAME: "__token__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ include-package-data = true
 zip-safe = false
 
 [tool.cibuildwheel]
-build = "cp3*-macosx_x86_64 cp3*-macosx_arm64 cp3*-manylinux_x86_64 cp3*-win_amd64"
+build = "cp3*-macosx_arm64 cp3*-manylinux_x86_64 cp3*-win_amd64"
 skip = "cp311-* cp36-*"
 
 environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ include-package-data = true
 zip-safe = false
 
 [tool.cibuildwheel]
-build = "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
+build = "cp3*-macosx_x86_64 cp3*-macosx_arm64 cp3*-manylinux_x86_64 cp3*-win_amd64"
 skip = "cp311-* cp36-*"
 
 environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,7 @@ before-test = "rm -rf {project}/build"
 
 
 [tool.cibuildwheel.macos]
-# In GitHub Actions virtual environment macos-10.15/20201115.1,
-# linking some functions from libgomp fails since the linker cannot find
-# some library files from gcc-8 installed via Homebrew.
-# The following command fixes this issue by (brew) re-linking files from gcc-8.
-# cf. https://stackoverflow.com/a/55500164
 before-build = """\
-brew install gcc@8 && brew link --overwrite gcc@8 && \
 brew upgrade && brew install -f boost && \
 brew link boost && rm -rf {project}/build\
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,4 +93,5 @@ brew install gcc@8 && brew link --overwrite gcc@8 && \
 brew upgrade && brew install -f boost && \
 brew link boost && rm -rf {project}/build\
 """
+archs = ["x86_64", "arm64"]
 repair-wheel-command = "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ include-package-data = true
 zip-safe = false
 
 [tool.cibuildwheel]
-build = "cp3*-macosx_arm64 cp3*-manylinux_x86_64 cp3*-win_amd64"
+build = "cp3*-macosx_x86_64 cp3*-macosx_arm64 cp3*-manylinux_x86_64 cp3*-win_amd64"
 skip = "cp311-* cp36-*"
 
 environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }


### PR DESCRIPTION
close #392 
I fixed the build error of wheel build on macOS arm64 by using `gcc-10/g++-10`. But the cause is still unknown.