### PR TITLE
Run wheel build in parallel

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -36,6 +36,11 @@ jobs:
             os-arch: "macosx_x86_64"
           - os: "macos-11"
             os-arch: "macosx_arm64"
+        exclude:
+          # cibuildwheel does not support Python 3.7 on macOS arm64.
+          - cibw-python: "cp37"
+            os: "macos-11"
+            os-arch: "macosx_arm64"
     runs-on: ${{ matrix.os }}
     env:
       CXX_COMPILER: "g++-10"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -7,10 +7,10 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-    branches:
-      - "main"
-    tags:
-      - "v*"
+    # branches:
+    #   - "main"
+    # tags:
+    #   - "v*"
   pull_request:
   pull_request_review:
     types: [submitted, edited]
@@ -23,12 +23,24 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:
-        python-version: ["3.7.5"]
+        python-version: ["3.10.8"]
+        cibw-python: ["cp37", "cp38", "cp39", "cp310"]
         os: ["ubuntu-20.04", "windows-2019", "macos-11"]
+        # Documentation for `include`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
+        include:
+          - os: "ubuntu-20.04"
+            os-arch: "manylinux_x86_64"
+          - os: "windows-2019"
+            os-arch: "win_amd64"
+          - os: "macos-11"
+            os-arch: "macosx_x86_64"
+          - os: "macos-11"
+            os-arch: "macosx_arm64"
     runs-on: ${{ matrix.os }}
     env:
-      CXX_COMPILER: "g++-8"
-      C_COMPILER: "gcc-8"
+      CXX_COMPILER: "g++-10"
+      C_COMPILER: "gcc-10"
+      CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
       TWINE_USERNAME: "__token__"
@@ -75,12 +87,12 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:
-        python-version: ["3.7.5"]
+        python-version: ["3.10.8"]
         os: ["ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     env:
-      CXX_COMPILER: "g++-8"
-      C_COMPILER: "gcc-8"
+      CXX_COMPILER: "g++-10"
+      C_COMPILER: "gcc-10"
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
       TWINE_USERNAME: "__token__"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,22 +25,22 @@ jobs:
       matrix:
         python-version: ["3.10.8"]
         cibw-python: ["cp37", "cp38", "cp39", "cp310"]
-        os: ["ubuntu-20.04", "windows-2019", "macos-11"]
-        # Documentation for `include`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
-        include:
-          - os: "ubuntu-20.04"
-            os-arch: "manylinux_x86_64"
-          - os: "windows-2019"
-            os-arch: "win_amd64"
-          - os: "macos-11"
-            os-arch: "macosx_x86_64"
-          - os: "macos-11"
-            os-arch: "macosx_arm64"
+        os-arch: ["manylinux_x86_64", "win_amd64", "macosx_x86_64", "macosx_arm64"]
         exclude:
           # cibuildwheel does not support Python 3.7 on macOS arm64.
           - cibw-python: "cp37"
-            os: "macos-11"
             os-arch: "macosx_arm64"
+        # Documentation for `include`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
+        # `include` is processed after `exclude`.
+        include:
+          - os-arch: "manylinux_x86_64"
+            os: "ubuntu-20.04"
+          - os-arch: "win_amd64"
+            os: "windows-2019"
+          - os-arch: "macosx_x86_64"
+            os: "macos-11"
+          - os-arch: "macosx_arm64"
+            os: "macos-11"
     runs-on: ${{ matrix.os }}
     env:
       CXX_COMPILER: "g++-10"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -7,10 +7,10 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-    # branches:
-    #   - "main"
-    # tags:
-    #   - "v*"
+    branches:
+      - "main"
+    tags:
+      - "v*"
   pull_request:
   pull_request_review:
     types: [submitted, edited]
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install boost if windows
         if: ${{ contains(matrix.os, 'windows') }}
-        uses: MarkusJx/install-boost@v2.0.0
+        uses: MarkusJx/install-boost@v2.4.0
         id: install-boost
         with:
           boost_version: 1.77.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,4 +83,5 @@ before-build = """\
 brew upgrade && brew install -f boost && \
 brew link boost && rm -rf {project}/build\
 """
+archs = ["x86_64", "arm64"]
 repair-wheel-command = "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ include-package-data = true
 zip-safe = false
 
 [tool.cibuildwheel]
-build = "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
-skip = "cp311-* cp36-*"
-
 environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }
 build-verbosity = "1"
 
@@ -81,15 +78,8 @@ cp -r boost /usr/local/include && rm -rf {project}/build \
 [tool.cibuildwheel.windows]
 before-test = "rm -rf {project}/build"
 
-
 [tool.cibuildwheel.macos]
-# In GitHub Actions virtual environment macos-10.15/20201115.1,
-# linking some functions from libgomp fails since the linker cannot find
-# some library files from gcc-8 installed via Homebrew.
-# The following command fixes this issue by (brew) re-linking files from gcc-8.
-# cf. https://stackoverflow.com/a/55500164
 before-build = """\
-brew install gcc@8 && brew link --overwrite gcc@8 && \
 brew upgrade && brew install -f boost && \
 brew link boost && rm -rf {project}/build\
 """


### PR DESCRIPTION
close #393 
As it tooks so long time to complete wheel build CI, parallelize it by using matrix.

This PR includes the changes in #394 because this branch diverges from the same commit as #394.
So we can close #394 and merge only this PR.