### PR TITLE
Refactor state test

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Test in Ubuntu
         run: |
           cd ./build
-          make coverage
-          make pythontest
+          make coverage -j
+          make pythontest -j
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3
@@ -129,6 +129,7 @@ jobs:
         run: USE_TEST=Yes ./script/build_gcc_with_memory_sanitizer.sh
 
       - name: Test in Ubuntu
+        # -j option is not appended because running this test in parallel is slower than sequential version.
         run: |
           cd ./build
           make test

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Test in Ubuntu
         run: |
           cd ./build
-          make coverage -j
-          make pythontest -j
+          make coverage -j $(nproc)
+          make pythontest -j $(nproc)
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -91,9 +91,6 @@ jobs:
 
   gcc10-build-with-address-sanitizer:
     name: GCC10 build with -fsanitizer=address enabled
-    strategy:
-      matrix:
-        python-version: ["3.7.5"]
     runs-on: "ubuntu-20.04"
     env:
       CXX_COMPILER: "/usr/lib/ccache/g++"
@@ -106,12 +103,6 @@ jobs:
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install ccache
         run: sudo apt install ccache

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -449,6 +449,7 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
 
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -474,6 +475,7 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
 
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -524,6 +526,7 @@ TEST(CircuitTest, CircuitOptimize) {
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
 
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -299,10 +299,8 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -326,10 +324,8 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -353,10 +349,8 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -381,10 +375,8 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -409,10 +401,8 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -437,10 +427,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -465,10 +452,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -493,10 +477,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -521,11 +502,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        // std::cout << state << std::endl << test_state << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -550,10 +527,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -578,10 +552,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -616,10 +587,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -654,10 +622,7 @@ TEST(CircuitTest, CircuitOptimize) {
         qco.optimize(copy_circuit, block_size);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -705,10 +670,7 @@ TEST(CircuitTest, RandomCircuitOptimize) {
             qco.optimize(copy_circuit, block_size);
             state.load(&org_state);
             copy_circuit->update_quantum_state(&state);
-            // std::cout << copy_circuit << std::endl;
-            for (UINT i = 0; i < dim; ++i)
-                ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
-                    0, eps);
+            ASSERT_STATE_NEAR(state, test_state, eps);
             delete copy_circuit;
         }
     }
@@ -763,10 +725,7 @@ TEST(CircuitTest, RandomCircuitOptimize2) {
             qco.optimize(copy_circuit, block_size);
             state.load(&org_state);
             copy_circuit->update_quantum_state(&state);
-            // std::cout << copy_circuit << std::endl;
-            for (UINT i = 0; i < dim; ++i)
-                ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
-                    0, eps);
+            ASSERT_STATE_NEAR(state, test_state, eps);
             delete copy_circuit;
         }
     }
@@ -807,10 +766,7 @@ TEST(CircuitTest, RandomCircuitOptimize3) {
             qco.optimize(copy_circuit, block_size);
             state.load(&org_state);
             copy_circuit->update_quantum_state(&state);
-            // std::cout << copy_circuit << std::endl;
-            for (UINT i = 0; i < dim; ++i)
-                ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
-                    0, eps);
+            ASSERT_STATE_NEAR(state, test_state, eps);
             delete copy_circuit;
         }
     }
@@ -942,18 +898,12 @@ TEST(CircuitTest, RotateDiagonalObservable) {
     state.set_computational_basis(0);
     test_state(0) = 1.;
 
-    // for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(test_state[i] -
-    // state.data_cpp()[i]), 0, eps);
-
     circuit.update_quantum_state(&state);
     test_state = test_circuit * test_state;
 
     res = observable.get_expectation_value(&state);
     test_res = (test_state.adjoint() * test_observable * test_state);
 
-    // for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(test_state[i] -
-    // state.data_cpp()[i]), 0, eps);
-    ASSERT_NEAR(abs(test_res.real() - res.real()) / test_res.real(), 0, 0.01);
     ASSERT_NEAR(res.imag(), 0, eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);
 
@@ -969,8 +919,6 @@ TEST(CircuitTest, RotateDiagonalObservable) {
     res = observable.get_expectation_value(&state);
     test_res = (test_state.adjoint() * test_observable * test_state);
 
-    // for (ITYPE i = 0; i < dim; ++i) ASSERT_NEAR(abs(test_state[i] -
-    // state.data_cpp()[i]), 0, eps);
     ASSERT_NEAR(abs(test_res.real() - res.real()) / test_res.real(), 0, 0.01);
     ASSERT_NEAR(res.imag(), 0, eps);
     ASSERT_NEAR(test_res.imag(), 0, eps);

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -18,21 +18,17 @@
 #include "../util/util.hpp"
 
 TEST(CircuitTest, CircuitBasic) {
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2), H(2, 2),
-        S(2, 2), T(2, 2), sqrtX(2, 2), sqrtY(2, 2), P0(2, 2), P1(2, 2);
-
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -1.i, 1.i, 0;
-    Z << 1, 0, 0, -1;
-    H << 1, 1, 1, -1;
-    H /= sqrt(2.);
-    S << 1, 0, 0, 1.i;
-    T << 1, 0, 0, (1. + 1.i) / sqrt(2.);
-    sqrtX << 0.5 + 0.5i, 0.5 - 0.5i, 0.5 - 0.5i, 0.5 + 0.5i;
-    sqrtY << 0.5 + 0.5i, -0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i;
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
+    const auto H = make_H();
+    const auto S = make_S();
+    const auto T = make_T();
+    const auto sqrtX = make_sqrtX();
+    const auto sqrtY = make_sqrtY();
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     const UINT n = 4;
     const UINT dim = 1ULL << n;
@@ -774,11 +770,10 @@ TEST(CircuitTest, RandomCircuitOptimize3) {
 
 TEST(CircuitTest, SuzukiTrotterExpansion) {
     CPPCTYPE J(0.0, 1.0);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -J, J, 0;
-    Z << 1, 0, 0, -1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     const UINT n = 2;
     const UINT dim = 1ULL << n;
@@ -858,11 +853,10 @@ TEST(CircuitTest, SuzukiTrotterExpansion) {
 
 TEST(CircuitTest, RotateDiagonalObservable) {
     CPPCTYPE J(0.0, 1.0);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -J, J, 0;
-    Z << 1, 0, 0, -1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     const UINT n = 2;
     const UINT dim = 1ULL << n;

--- a/test/cppsim/test_circuit_optimize_light.cpp
+++ b/test/cppsim/test_circuit_optimize_light.cpp
@@ -38,41 +38,12 @@ TEST(CircuitTest, CircuitOptimizeLight) {
         qco.optimize_light(copy_circuit);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
-
-    /*
-{
-    // tensor product, merged
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_X_gate(0);
-    circuit.add_Y_gate(1);
-    UINT block_size = 2;
-    UINT expected_depth = 1;
-    UINT expected_gate_count = 1;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-    */
 
     {
         // do not take tensor product
@@ -92,205 +63,12 @@ expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         qco.optimize_light(copy_circuit);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
     }
-
-    /*
-{
-    // CNOT, control does not commute with X
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_X_gate(0);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_Y_gate(0);
-    UINT block_size = 1;
-    UINT expected_depth = 3;
-    UINT expected_gate_count = 3;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-    */
-
-    /*
-{
-    // CNOT, control does not commute with Z
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_X_gate(0);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_Z_gate(0);
-    UINT block_size = 1;
-    UINT expected_depth = 2;
-    UINT expected_gate_count = 2;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-    */
-
-    /*
-{
-    // CNOT, control commute with Z
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_Z_gate(0);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_Z_gate(0);
-    UINT block_size = 1;
-    UINT expected_depth = 2;
-    UINT expected_gate_count = 2;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-    */
-
-    /*
-{
-    // CNOT, target commute with X
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_X_gate(1);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_X_gate(1);
-    UINT block_size = 1;
-    UINT expected_depth = 2;
-    UINT expected_gate_count = 2;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-
-{
-    // CNOT, target commute with X
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_Z_gate(1);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_X_gate(1);
-    UINT block_size = 1;
-    UINT expected_depth = 2;
-    UINT expected_gate_count = 2;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-
-{
-    // CNOT, target commute with X
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_X_gate(1);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_Z_gate(1);
-    UINT block_size = 1;
-    UINT expected_depth = 2;
-    UINT expected_gate_count = 2;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    //std::cout << state << std::endl << test_state << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-
-{
-    // CNOT, target commute with X
-    QuantumState state(n), test_state(n);
-    state.set_Haar_random_state();
-    test_state.load(&state);
-    QuantumCircuit circuit(n);
-
-    circuit.add_Z_gate(1);
-    circuit.add_CNOT_gate(0, 1);
-    circuit.add_Z_gate(1);
-    UINT block_size = 1;
-    UINT expected_depth = 3;
-    UINT expected_gate_count = 3;
-
-    QuantumCircuit* copy_circuit = circuit.copy();
-    QuantumCircuitOptimizer qco;
-    qco.optimize_light(copy_circuit);
-    circuit.update_quantum_state(&test_state);
-    copy_circuit->update_quantum_state(&state);
-    //std::cout << circuit << std::endl << copy_circuit << std::endl;
-    for (UINT i = 0; i < dim; ++i) ASSERT_NEAR(abs(state.data_cpp()[i] -
-test_state.data_cpp()[i]), 0, eps); ASSERT_EQ(copy_circuit->calculate_depth(),
-expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
-    delete copy_circuit;
-}
-    */
 
     {
         // CNOT, target commute with X
@@ -311,10 +89,8 @@ expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         qco.optimize_light(copy_circuit);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -327,8 +103,8 @@ expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
     };
 
     std::vector<TestParameter> parameter_list = {
-        /*TestParameter{2u, 3u, 3u}*/  // TODO: this test was commented out, but
-                                       // we might have to re-enable it.
+        /*TestParameter{2u, 3u, 3u}*/  // TODO: this test was commented out,
+                                       // but we might have to re-enable it.
         TestParameter{3u, 2u, 2u}};
 
     for (TestParameter param : parameter_list) {
@@ -360,10 +136,8 @@ expected_depth); ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         qco.optimize_light(copy_circuit);
         circuit.update_quantum_state(&test_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << circuit << std::endl << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         ASSERT_EQ(copy_circuit->calculate_depth(), expected_depth);
         ASSERT_EQ(copy_circuit->gate_list.size(), expected_gate_count);
         delete copy_circuit;
@@ -404,16 +178,13 @@ TEST(CircuitTest, RandomCircuitOptimizeLight) {
 
         test_state.load(&org_state);
         circuit.update_quantum_state(&test_state);
-        // std::cout << circuit << std::endl;
         QuantumCircuitOptimizer qco;
         QuantumCircuit* copy_circuit = circuit.copy();
         qco.optimize_light(copy_circuit);
         state.load(&org_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         delete copy_circuit;
     }
 }
@@ -460,31 +231,12 @@ TEST(CircuitTest, RandomCircuitOptimizeLight2) {
 
         test_state.load(&org_state);
         circuit.update_quantum_state(&test_state);
-        // std::cout << circuit << std::endl;
         QuantumCircuitOptimizer qco;
         QuantumCircuit* copy_circuit = circuit.copy();
-        // for (auto gate : copy_circuit->gate_list) {
-        // std::cout << "(";
-        // for (auto val : gate->get_target_index_list()) std::cout << val
-        //<< " ";  for (auto val : gate->get_control_index_list())
-        // std::cout << val << " "; std::cout << ")  ";
-        //}
-        // std::cout << std::endl;
         qco.optimize_light(copy_circuit);
-        // for (auto gate : copy_circuit->gate_list) {
-        // std::cout << "(";
-        // for (auto val : gate->get_target_index_list()) std::cout << val
-        //<< " "; for (auto val : gate->get_control_index_list())
-        // std::cout << val << " "; std::cout << ")  ";
-        //}
         state.load(&org_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << copy_circuit << std::endl;
-        // for (UINT i = 0; i < dim; ++i) std::cout << state.data_cpp()[i] << "
-        // " << test_state.data_cpp()[i] << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         delete copy_circuit;
     }
 }
@@ -517,16 +269,13 @@ TEST(CircuitTest, RandomCircuitOptimizeLight3) {
 
         test_state.load(&org_state);
         circuit.update_quantum_state(&test_state);
-        // std::cout << circuit << std::endl;
         QuantumCircuitOptimizer qco;
         QuantumCircuit* copy_circuit = circuit.copy();
         qco.optimize_light(copy_circuit);
         state.load(&org_state);
         copy_circuit->update_quantum_state(&state);
-        // std::cout << copy_circuit << std::endl;
-        for (UINT i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+
+        ASSERT_STATE_NEAR(state, test_state, eps);
         delete copy_circuit;
     }
 }

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -15,21 +15,17 @@
 #include "../util/util.hpp"
 
 TEST(GateTest, ApplySingleQubitGate) {
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2), H(2, 2),
-        S(2, 2), T(2, 2), sqrtX(2, 2), sqrtY(2, 2), P0(2, 2), P1(2, 2);
-
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -1.i, 1.i, 0;
-    Z << 1, 0, 0, -1;
-    H << 1, 1, 1, -1;
-    H /= sqrt(2.);
-    S << 1, 0, 0, 1.i;
-    T << 1, 0, 0, (1. + 1.i) / sqrt(2.);
-    sqrtX << 0.5 + 0.5i, 0.5 - 0.5i, 0.5 - 0.5i, 0.5 + 0.5i;
-    sqrtY << 0.5 + 0.5i, -0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i;
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
+    const auto H = make_H();
+    const auto S = make_S();
+    const auto T = make_T();
+    const auto sqrtX = make_sqrtX();
+    const auto sqrtY = make_sqrtY();
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     const UINT n = 5;
     const ITYPE dim = 1ULL << n;
@@ -92,12 +88,10 @@ TEST(GateTest, ApplySingleQubitGate) {
 }
 
 TEST(GateTest, ApplySingleQubitRotationGate) {
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -1.i, 1.i, 0;
-    Z << 1, 0, 0, -1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     const UINT n = 5;
     const ITYPE dim = 1ULL << n;

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -256,10 +256,6 @@ TEST(GateTest, ApplyMultiQubitGate) {
         std::function<Eigen::MatrixXcd(UINT, UINT, UINT)>>>
         funclist;
 
-    // gate::DenseMatrix
-    // gate::Pauli
-    // gate::PauliRotation
-
     Eigen::VectorXcd test_state1 = Eigen::VectorXcd::Zero(dim);
     for (UINT repeat = 0; repeat < 10; ++repeat) {
         state.set_Haar_random_state();
@@ -283,11 +279,6 @@ TEST(GateTest, ApplyMultiQubitGate) {
             gate->target_qubit_list, small_mat, gate->control_qubit_list);
         gate_dense->update_quantum_state(&state);
         delete gate_dense;
-
-        // std::cout << state << std::endl << test_state1 << std::endl;
-        // std::cout << small_mat << std::endl << large_mat << std::endl;
-        // for (UINT i = 0; i < 4; ++i) std::cout << small_mat.data()[i] <<
-        // std::endl;
 
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
@@ -419,9 +410,6 @@ TEST(GateTest, MergeTensorProductAndMultiply) {
     Eigen::MatrixXcd mat = get_eigen_matrix_full_qubit_pauli({0, 2});
     test_state_eigen = mat * test_state_eigen;
 
-    // std::cout << iy01 << std::endl << std::endl;
-    // std::cout << mat << std::endl;
-
     for (ITYPE i = 0; i < dim; ++i)
         ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
     for (ITYPE i = 0; i < dim; ++i)
@@ -460,9 +448,7 @@ TEST(GateTest, RandomPauliMerge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
 
         QuantumGateBase* merged_gate = gate::Identity(0);
         QuantumGateMatrix* next_merged_gate = NULL;
@@ -486,11 +472,6 @@ TEST(GateTest, RandomPauliMerge) {
                 new_gate = gate::Z(target);
             else
                 FAIL();
-
-            // std::cout <<
-            // "***************************************************" <<
-            // std::endl; std::cout << " ***** Pauli = " << new_pauli_id << " at
-            // " << target << std::endl;
 
             // create new gate with merge
             next_merged_gate = gate::merge(merged_gate, new_gate);
@@ -521,14 +502,6 @@ TEST(GateTest, RandomPauliMerge) {
                 }
             }
 
-            // std::cout << "current state : " << test_state << std::endl <<
-            // "current eigen state : \n" << test_state_eigen << std::endl;
-            // std::cout << "initial matrix : " <<
-            // (QuantumGateMatrix*)merged_gate << std::endl << "current eigen
-            // matrix : \n" << total_matrix << std::endl; std::cout <<
-            // "***************************************************" <<
-            // std::endl;
-
             // dispose picked pauli
             delete new_gate;
         }
@@ -537,9 +510,7 @@ TEST(GateTest, RandomPauliMerge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
     }
 }
 
@@ -569,9 +540,7 @@ TEST(GateTest, RandomPauliRotationMerge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
 
         QuantumGateBase* merged_gate = gate::Identity(0);
         QuantumGateMatrix* next_merged_gate = NULL;
@@ -594,11 +563,6 @@ TEST(GateTest, RandomPauliRotationMerge) {
                 new_gate = gate::RotZ(target, -angle);
             else
                 FAIL();
-
-            // std::cout <<
-            // "***************************************************" <<
-            // std::endl; std::cout << " ***** Pauli = " << new_pauli_id << " at
-            // " << target << std::endl;
 
             // create new gate with merge
             next_merged_gate = gate::merge(merged_gate, new_gate);
@@ -641,9 +605,7 @@ TEST(GateTest, RandomPauliRotationMerge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
     }
 }
 
@@ -673,9 +635,7 @@ TEST(GateTest, RandomUnitaryMerge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
 
         QuantumGateBase* merged_gate = gate::Identity(0);
         QuantumGateMatrix* next_merged_gate = NULL;
@@ -741,9 +701,7 @@ TEST(GateTest, RandomUnitaryMerge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
     }
 }
 
@@ -773,9 +731,7 @@ TEST(GateTest, RandomUnitaryMergeLarge) {
         // check equivalence
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps);
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
 
         QuantumGateBase* merged_gate1 = gate::Identity(0);
         QuantumGateBase* merged_gate2 = gate::Identity(0);
@@ -850,9 +806,7 @@ TEST(GateTest, RandomUnitaryMergeLarge) {
         delete merged_gate1;
         delete merged_gate2;
         // check equivalence
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
     }
 }
 
@@ -923,13 +877,11 @@ TEST(GateTest, ControlMerge) {
         auto x1 = gate::X(1);
         auto cx01 = gate::CNOT(0, 1);
         auto res = gate::merge(x1, cx01);
-        // std::cout << res << std::endl;
 
         auto mat_x = get_expanded_eigen_matrix_with_identity(
             1, get_eigen_matrix_single_Pauli(1), 2);
         auto mat_cx = get_eigen_matrix_full_qubit_CNOT(0, 1, 2);
         auto mat_res = mat_cx * mat_x;
-        // std::cout << mat_res << std::endl;
 
         ComplexMatrix checkmat;
         res->set_matrix(checkmat);
@@ -948,13 +900,11 @@ TEST(GateTest, ControlMerge) {
         auto x1 = gate::X(1);
         auto cx01 = gate::CNOT(0, 1);
         auto res = gate::merge(cx01, x1);
-        // std::cout << res << std::endl;
 
         auto mat_x = get_expanded_eigen_matrix_with_identity(
             1, get_eigen_matrix_single_Pauli(1), 2);
         auto mat_cx = get_eigen_matrix_full_qubit_CNOT(0, 1, 2);
         auto mat_res = mat_x * mat_cx;
-        // std::cout << mat_res << std::endl;
 
         ComplexMatrix checkmat;
         res->set_matrix(checkmat);
@@ -973,7 +923,6 @@ TEST(GateTest, ControlMerge) {
         auto cz01 = gate::CZ(0, 1);
         auto cx01 = gate::CNOT(0, 1);
         auto res = gate::merge(cx01, cz01);
-        // std::cout << res << std::endl;
 
         ASSERT_EQ(res->control_qubit_list.size(), 1);
         ASSERT_EQ(res->control_qubit_list[0].index(), 0);
@@ -1020,13 +969,11 @@ TEST(GateTest, ControlMerge) {
         auto x2 = gate::X(2);
         auto cx01 = gate::CNOT(0, 1);
         auto res = gate::merge(x2, cx01);
-        // std::cout << res << std::endl;
 
         auto mat_x = get_expanded_eigen_matrix_with_identity(
             2, get_eigen_matrix_single_Pauli(1), n);
         auto mat_cx = get_eigen_matrix_full_qubit_CNOT(0, 1, n);
         auto mat_res = mat_cx * mat_x;
-        // std::cout << mat_res << std::endl;
 
         ComplexMatrix checkmat;
         res->set_matrix(checkmat);
@@ -1045,13 +992,11 @@ TEST(GateTest, ControlMerge) {
         auto x2 = gate::X(2);
         auto cx01 = gate::CNOT(0, 1);
         auto res = gate::merge(cx01, x2);
-        // std::cout << res << std::endl;
 
         auto mat_x = get_expanded_eigen_matrix_with_identity(
             2, get_eigen_matrix_single_Pauli(1), n);
         auto mat_cx = get_eigen_matrix_full_qubit_CNOT(0, 1, n);
         auto mat_res = mat_x * mat_cx;
-        // std::cout << mat_res << std::endl;
 
         ComplexMatrix checkmat;
         res->set_matrix(checkmat);
@@ -1106,9 +1051,7 @@ TEST(GateTest, RandomControlMergeSmall) {
         merge_gate1->update_quantum_state(&state);
         test_state_eigen = mat * test_state_eigen;
 
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps)
                 << state << "\n\n"
@@ -1175,9 +1118,7 @@ TEST(GateTest, RandomControlMergeLarge) {
         merge_gate2->update_quantum_state(&test_state);
         test_state_eigen = mat * test_state_eigen;
 
-        for (ITYPE i = 0; i < dim; ++i)
-            ASSERT_NEAR(
-                abs(state.data_cpp()[i] - test_state.data_cpp()[i]), 0, eps);
+        ASSERT_STATE_NEAR(state, test_state, eps);
         for (ITYPE i = 0; i < dim; ++i)
             ASSERT_NEAR(abs(state.data_cpp()[i] - test_state_eigen[i]), 0, eps)
                 << state << "\n\n"
@@ -1408,32 +1349,6 @@ TEST(GateTest, ReversibleBooleanGate) {
     ASSERT_NEAR(abs(state.data_cpp()[5] - 1.), 0, eps);
     gate->update_quantum_state(&state);
     ASSERT_NEAR(abs(state.data_cpp()[0] - 1.), 0, eps);
-    /*
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    gate->update_quantum_state(&state);
-    std::cout << state.to_string() << std::endl;
-    */
-
     delete gate;
 }
 

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -190,10 +190,7 @@ TEST(GateTest, ApplyTwoQubitGate) {
 
             for (ITYPE i = 0; i < dim; ++i)
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-            for (ITYPE i = 0; i < dim; ++i)
-                ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
-                    0, eps);
-
+            ASSERT_STATE_NEAR(state, test_state, eps);
             delete gate;
         }
     }
@@ -231,9 +228,7 @@ TEST(GateTest, ApplyTwoQubitGate) {
 
             for (ITYPE i = 0; i < dim; ++i)
                 ASSERT_NEAR(abs(state.data_cpp()[i] - test_state1[i]), 0, eps);
-            for (ITYPE i = 0; i < dim; ++i)
-                ASSERT_NEAR(abs(state.data_cpp()[i] - test_state.data_cpp()[i]),
-                    0, eps);
+            ASSERT_STATE_NEAR(state, test_state, eps);
 
             delete gate;
         }

--- a/test/cppsim/test_gate_dm.cpp
+++ b/test/cppsim/test_gate_dm.cpp
@@ -15,21 +15,17 @@
 #include "../util/util.hpp"
 
 TEST(DensityMatrixGateTest, ApplySingleQubitGate) {
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2), H(2, 2),
-        S(2, 2), T(2, 2), sqrtX(2, 2), sqrtY(2, 2), P0(2, 2), P1(2, 2);
-
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -1.i, 1.i, 0;
-    Z << 1, 0, 0, -1;
-    H << 1, 1, 1, -1;
-    H /= sqrt(2.);
-    S << 1, 0, 0, 1.i;
-    T << 1, 0, 0, (1. + 1.i) / sqrt(2.);
-    sqrtX << 0.5 + 0.5i, 0.5 - 0.5i, 0.5 - 0.5i, 0.5 + 0.5i;
-    sqrtY << 0.5 + 0.5i, -0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i;
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
+    const auto H = make_H();
+    const auto S = make_S();
+    const auto T = make_T();
+    const auto sqrtX = make_sqrtX();
+    const auto sqrtY = make_sqrtY();
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     const UINT n = 5;
     const ITYPE dim = 1ULL << n;
@@ -85,12 +81,10 @@ TEST(DensityMatrixGateTest, ApplySingleQubitGate) {
 }
 
 TEST(DensityMatrixGateTest, ApplySingleQubitRotationGate) {
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -1.i, 1.i, 0;
-    Z << 1, 0, 0, -1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     const UINT n = 5;
     const ITYPE dim = 1ULL << n;

--- a/test/cppsim/test_hamiltonian.cpp
+++ b/test/cppsim/test_hamiltonian.cpp
@@ -30,8 +30,7 @@ TEST(ObservableTest, CheckExpectationValue) {
     CPPCTYPE test_res;
     Random random;
 
-    Eigen::MatrixXcd X(2, 2);
-    X << 0, 1, 1, 0;
+    const auto X = make_X();
 
     QuantumState state(n);
     state.set_computational_basis(0);

--- a/test/cppsim/test_hamiltonian_dm.cpp
+++ b/test/cppsim/test_hamiltonian_dm.cpp
@@ -16,26 +16,21 @@
 TEST(DensityMatrixObservableTest, CheckExpectationValue) {
     const UINT n = 4;
     const UINT dim = 1ULL << n;
-
-    double coef;
-    CPPCTYPE res_vec, res_mat;
-    CPPCTYPE test_res;
     Random random;
 
-    Eigen::MatrixXcd X(2, 2);
-    X << 0, 1, 1, 0;
+    const auto X = make_X();
 
     QuantumState vector_state(n);
     DensityMatrix density_matrix(n);
     vector_state.set_computational_basis(0);
     density_matrix.load(&vector_state);
 
-    coef = random.uniform();
+    double coef = random.uniform();
     Observable observable(n);
     observable.add_operator(coef, "X 0");
 
-    res_vec = observable.get_expectation_value(&vector_state);
-    res_mat = observable.get_expectation_value(&density_matrix);
+    CPPCTYPE res_vec = observable.get_expectation_value(&vector_state);
+    CPPCTYPE res_mat = observable.get_expectation_value(&density_matrix);
     ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
     ASSERT_NEAR(res_vec.imag(), 0, eps);
     ASSERT_NEAR(res_mat.imag(), 0, eps);
@@ -103,22 +98,16 @@ TEST(DensityMatrixObservableTest, CheckParsedObservableFromOpenFermionText) {
         std::vector<std::string> lines = split(str, "\n");
 
         for (std::string line : lines) {
-            // std::cout << state->get_norm() << std::endl;
-
             std::vector<std::string> elems;
             elems = split(line, "()j[]+");
 
             chfmt(elems[3]);
 
             CPPCTYPE coef(std::stod(elems[0]), std::stod(elems[1]));
-            // std::cout << elems[3].c_str() << std::endl;
 
             PauliOperator mpt(elems[3].c_str(), coef.real());
 
-            // std::cout << mpt.get_coef() << " ";
-            // std::cout << elems[3].c_str() << std::endl;
             energy += mpt.get_expectation_value(state);
-            // mpt.get_expectation_value(state);
         }
         return energy;
     };
@@ -140,11 +129,9 @@ TEST(DensityMatrixObservableTest, CheckParsedObservableFromOpenFermionText) {
         "(0.17434925+0j) [Z1 Z3] +\n"
         "(-0.22279649999999998+0j) [Z2]";
 
-    CPPCTYPE res_vec, res_mat;
-
-    Observable* observable;
-    observable = observable::create_observable_from_openfermion_text(text);
-    ASSERT_NE(observable, (Observable*)NULL);
+    Observable* observable =
+        observable::create_observable_from_openfermion_text(text);
+    ASSERT_NE(observable, nullptr);
     UINT qubit_count = observable->get_qubit_count();
 
     QuantumState vector_state(qubit_count);
@@ -152,8 +139,8 @@ TEST(DensityMatrixObservableTest, CheckParsedObservableFromOpenFermionText) {
 
     vector_state.set_computational_basis(0);
     density_matrix.load(&vector_state);
-    res_vec = observable->get_expectation_value(&vector_state);
-    res_mat = observable->get_expectation_value(&density_matrix);
+    CPPCTYPE res_vec = observable->get_expectation_value(&vector_state);
+    CPPCTYPE res_mat = observable->get_expectation_value(&density_matrix);
     ASSERT_NEAR(res_vec.real(), res_mat.real(), eps);
     ASSERT_NEAR(res_vec.imag(), res_mat.imag(), eps);
 

--- a/test/cppsim/test_pauli_operator.cpp
+++ b/test/cppsim/test_pauli_operator.cpp
@@ -31,7 +31,6 @@ TEST(PauliOperatorTest, PauliQubitOverflow) {
 }
 
 TEST(PauliOperatorTest, BrokenPauliStringA) {
-    int n = 5;
     double coef = 2.0;
     std::string Pauli_string = "X 0 X Z 1 Y 2";
     EXPECT_THROW(
@@ -39,7 +38,6 @@ TEST(PauliOperatorTest, BrokenPauliStringA) {
 }
 
 TEST(PauliOperatorTest, BrokenPauliStringB) {
-    int n = 5;
     double coef = 2.0;
     std::string Pauli_string = "X {i}";
     EXPECT_THROW(
@@ -47,7 +45,6 @@ TEST(PauliOperatorTest, BrokenPauliStringB) {
 }
 
 TEST(PauliOperatorTest, BrokenPauliStringC) {
-    int n = 5;
     double coef = 2.0;
     std::string Pauli_string = "X 4x";
     EXPECT_THROW(
@@ -55,7 +52,6 @@ TEST(PauliOperatorTest, BrokenPauliStringC) {
 }
 
 TEST(PauliOperatorTest, BrokenPauliStringD) {
-    int n = 5;
     double coef = 2.0;
     std::string Pauli_string = "4 X";
     EXPECT_THROW(
@@ -63,7 +59,6 @@ TEST(PauliOperatorTest, BrokenPauliStringD) {
 }
 
 TEST(PauliOperatorTest, SpacedPauliString) {
-    int n = 5;
     double coef = 2.0;
     std::string Pauli_string = "X 0 Y 1 ";
     PauliOperator pauli = PauliOperator(Pauli_string, coef);
@@ -72,7 +67,6 @@ TEST(PauliOperatorTest, SpacedPauliString) {
 }
 
 TEST(PauliOperatorTest, PartedPauliString) {
-    int n = 5;
     double coef = 2.0;
     std::string Pauli_string = "X 0 Y ";
     EXPECT_THROW(

--- a/test/csim/test_stat.cpp
+++ b/test/csim/test_stat.cpp
@@ -14,9 +14,8 @@ TEST(StatOperationTest, ProbTest) {
     const UINT max_repeat = 10;
 
     CTYPE* state = allocate_quantum_state(dim);
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -50,10 +49,9 @@ TEST(StatOperationTest, MarginalProbTest) {
     const UINT max_repeat = 10;
 
     CTYPE* state = allocate_quantum_state(dim);
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2), Identity(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
-    Identity << 1, 0, 0, 1;
+    const auto Identity = make_Identity();
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -153,12 +151,11 @@ TEST(StatOperationTest, SingleQubitExpectationValueTest) {
     const UINT max_repeat = 10;
 
     CTYPE* state = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -200,12 +197,11 @@ TEST(StatOperationTest, MultiQubitExpectationValueWholeTest) {
     const UINT max_repeat = 10;
 
     CTYPE* state = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -250,12 +246,11 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopWholeTest) {
     const UINT max_repeat = 10;
 
     CTYPE* state = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -294,8 +289,12 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopWholeTest) {
 TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
     const UINT n = 6;
     const ITYPE dim = 1ULL << n;
-
     const UINT max_repeat = 10;
+
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     CTYPE* state = allocate_quantum_state(dim);
     for (UINT rep = 0; rep < max_repeat; ++rep) {
@@ -303,12 +302,6 @@ TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
         ASSERT_NEAR(state_norm_squared(state, dim), 1, eps);
         Eigen::VectorXcd test_state(dim);
         for (ITYPE i = 0; i < dim; ++i) test_state[i] = state[i];
-
-        Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-        Identity << 1, 0, 0, 1;
-        X << 0, 1, 1, 0;
-        Z << 1, 0, 0, -1;
-        Y << 0, -1.i, 1.i, 0;
 
         for (UINT target = 0; target < n; ++target) {
             // multi qubit expectation partial list value check
@@ -359,18 +352,17 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopPartialTest) {
 
     const UINT max_repeat = 10;
 
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
+
     CTYPE* state = allocate_quantum_state(dim);
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
         ASSERT_NEAR(state_norm_squared(state, dim), 1, eps);
         Eigen::VectorXcd test_state(dim);
         for (ITYPE i = 0; i < dim; ++i) test_state[i] = state[i];
-
-        Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-        Identity << 1, 0, 0, 1;
-        X << 0, 1, 1, 0;
-        Z << 1, 0, 0, -1;
-        Y << 0, -1.i, 1.i, 0;
 
         for (UINT target = 0; target < n; ++target) {
             // multi qubit expectation partial list value check
@@ -419,12 +411,11 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeWholeTest) {
 
     CTYPE* state_ket = allocate_quantum_state(dim);
     CTYPE* state_bra = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state_ket, dim);
@@ -477,12 +468,11 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopWholeTest) {
 
     CTYPE* state_ket = allocate_quantum_state(dim);
     CTYPE* state_bra = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state_ket, dim);
@@ -532,12 +522,11 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudePartialTest) {
 
     CTYPE* state_ket = allocate_quantum_state(dim);
     CTYPE* state_bra = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state_ket, dim);
@@ -602,12 +591,11 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopPartialTest) {
 
     CTYPE* state_ket = allocate_quantum_state(dim);
     CTYPE* state_bra = allocate_quantum_state(dim);
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
     Eigen::MatrixXcd pauli_op;
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Z << 1, 0, 0, -1;
-    Y << 0, -1.i, 1.i, 0;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state_ket, dim);

--- a/test/csim/test_update_control.cpp
+++ b/test/csim/test_update_control.cpp
@@ -18,9 +18,8 @@ void test_single_control_single_target(
     const ITYPE dim = 1ULL << n;
     const UINT max_repeat = 10;
 
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U;
 
@@ -94,9 +93,8 @@ void test_two_control_single_target(std::function<void(
     std::vector<UINT> index_list;
     for (UINT i = 0; i < n; ++i) index_list.push_back(i);
 
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U;
 
@@ -168,9 +166,8 @@ TEST(UpdateTest, SingleQubitControlTwoQubitDenseMatrixTest) {
     std::vector<UINT> index_list;
     for (UINT i = 0; i < n; ++i) index_list.push_back(i);
 
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U, U2;
     Eigen::Matrix<std::complex<double>, 4, 4, Eigen::RowMajor> Umerge;
@@ -216,9 +213,8 @@ TEST(UpdateTest, TwoQubitControlTwoQubitDenseMatrixTest) {
     std::vector<UINT> index_list;
     for (UINT i = 0; i < n; ++i) index_list.push_back(i);
 
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U, U2;
     Eigen::Matrix<std::complex<double>, 4, 4, Eigen::RowMajor> Umerge;

--- a/test/csim/test_update_diagonal.cpp
+++ b/test/csim/test_update_diagonal.cpp
@@ -18,14 +18,10 @@ void test_single_diagonal_matrix_gate(
     const ITYPE dim = 1ULL << n;
     const UINT max_repeat = 10;
 
-    Eigen::MatrixXcd Identity(2, 2), Z(2, 2);
-    Identity << 1, 0, 0, 1;
-    Z << 1, 0, 0, -1;
+    const auto Identity = make_Identity();
+    const auto Z = make_Z();
 
     Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U;
-
-    UINT target;
-    double icoef, zcoef, norm;
 
     auto state = allocate_quantum_state(dim);
     initialize_Haar_random_state(state, dim);
@@ -36,10 +32,10 @@ void test_single_diagonal_matrix_gate(
 
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // single qubit diagonal matrix gate
-        target = rand_int(n);
-        icoef = rand_real();
-        zcoef = rand_real();
-        norm = sqrt(icoef * icoef + zcoef * zcoef);
+        const UINT target = rand_int(n);
+        double icoef = rand_real();
+        double zcoef = rand_real();
+        const double norm = sqrt(icoef * icoef + zcoef * zcoef);
         icoef /= norm;
         zcoef /= norm;
         U = icoef * Identity + 1.i * zcoef * Z;

--- a/test/csim/test_update_diagonal_multi.cpp
+++ b/test/csim/test_update_diagonal_multi.cpp
@@ -103,9 +103,8 @@ TEST(UpdateTest, TwoQubitControlTwoQubitDiagonalMatrixTest) {
     std::vector<UINT> index_list;
     for (UINT i = 0; i < n; ++i) index_list.push_back(i);
 
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
 
     Eigen::VectorXcd d, d2;
 

--- a/test/csim/test_update_named.cpp
+++ b/test/csim/test_update_named.cpp
@@ -178,9 +178,8 @@ void test_projection_gate(std::function<void(UINT, CTYPE*, ITYPE)> func,
 }
 
 TEST(UpdateTest, ProjectionAndNormalizeTest) {
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
+    const auto P0 = make_P0();
+    const auto P1 = make_P1();
     test_projection_gate(P0_gate, M0_prob, P0);
     test_projection_gate(P1_gate, M1_prob, P1);
     test_projection_gate(P0_gate_single, M0_prob, P0);
@@ -196,11 +195,10 @@ TEST(UpdateTest, SingleQubitRotationGateTest) {
     const ITYPE dim = 1ULL << n;
     const UINT max_repeat = 10;
 
-    Eigen::MatrixXcd Identity(2, 2), X(2, 2), Y(2, 2), Z(2, 2);
-    Identity << 1, 0, 0, 1;
-    X << 0, 1, 1, 0;
-    Y << 0, -1.i, 1.i, 0;
-    Z << 1, 0, 0, -1;
+    const auto Identity = make_Identity();
+    const auto X = make_X();
+    const auto Y = make_Y();
+    const auto Z = make_Z();
 
     UINT target;
     double angle;

--- a/test/csim/test_update_pauli.cpp
+++ b/test/csim/test_update_pauli.cpp
@@ -19,8 +19,7 @@ TEST(UpdateTest, SingleQubitPauliTest) {
 
     UINT target, pauli;
 
-    Eigen::MatrixXcd Identity(2, 2);
-    Identity << 1, 0, 0, 1;
+    const auto Identity = make_Identity();
 
     auto state = allocate_quantum_state(dim);
     initialize_Haar_random_state(state, dim);
@@ -48,8 +47,7 @@ TEST(UpdateTest, SingleQubitPauliRotationTest) {
     UINT target, pauli;
     double angle;
 
-    Eigen::MatrixXcd Identity(2, 2);
-    Identity << 1, 0, 0, 1;
+    const auto Identity = make_Identity();
 
     auto state = allocate_quantum_state(dim);
     initialize_Haar_random_state(state, dim);

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -201,6 +201,13 @@ static void state_equal(const CTYPE* state, const Eigen::VectorXcd& test_state,
 static testing::AssertionResult _assert_state_near(const char* state1_name,
     const char* state2_name, const char* eps_name, const QuantumState& state1,
     const QuantumState& state2, const double eps) {
+    if (state1.dim != state2.dim) {
+        return testing::AssertionFailure()
+               << "The dimension is different\nDimension of " << state1_name
+               << " is " << state1.dim << ",\n"
+               << "Dimension of " << state2_name << " is " << state2.dim << ".";
+    }
+
     for (UINT i = 0; i < state1.dim; i++) {
         const double real_diff = std::fabs(
             state1.data_cpp()[i].real() - state2.data_cpp()[i].real());

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -303,3 +303,44 @@ static std::string _check_ge(T val1, T val2, std::string val1_name,
                          << "), actual: " << val1 << " vs " << val2 << "\n";
     return error_message_stream.str();
 }
+
+static Eigen::MatrixXcd make_2x2_matrix(const Eigen::dcomplex a00,
+    const Eigen::dcomplex a01, const Eigen::dcomplex a10,
+    const Eigen::dcomplex a11) {
+    Eigen::MatrixXcd m(2, 2);
+    m << a00, a01, a10, a11;
+    return m;
+}
+
+static Eigen::MatrixXcd make_Identity() {
+    return Eigen::MatrixXcd::Identity(2, 2);
+}
+
+static Eigen::MatrixXcd make_X() { return make_2x2_matrix(0, 1, 1, 0); }
+
+static Eigen::MatrixXcd make_Y() { return make_2x2_matrix(0, -1.i, 1.i, 0); }
+
+static Eigen::MatrixXcd make_Z() { return make_2x2_matrix(1, 0, 0, -1); }
+
+static Eigen::MatrixXcd make_H() {
+    return make_2x2_matrix(
+        1 / sqrt(2.), 1 / sqrt(2.), 1 / sqrt(2.), -1 / sqrt(2.));
+}
+
+static Eigen::MatrixXcd make_S() { return make_2x2_matrix(1, 0, 0, 1.i); }
+
+static Eigen::MatrixXcd make_T() {
+    return make_2x2_matrix(1, 0, 0, (1. + 1.i) / sqrt(2.));
+}
+
+static Eigen::MatrixXcd make_sqrtX() {
+    return make_2x2_matrix(0.5 + 0.5i, 0.5 - 0.5i, 0.5 - 0.5i, 0.5 + 0.5i);
+}
+
+static Eigen::MatrixXcd make_sqrtY() {
+    return make_2x2_matrix(0.5 + 0.5i, -0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i);
+}
+
+static Eigen::MatrixXcd make_P0() { return make_2x2_matrix(1, 0, 0, 0); }
+
+static Eigen::MatrixXcd make_P1() { return make_2x2_matrix(0, 0, 0, 1); }

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <gtest/gtest.h>
+
 #include <Eigen/Core>
 #include <array>
+#include <cmath>
 #include <csim/type.hpp>
 #include <string>
+
+#include "cppsim/state.hpp"
 
 #ifdef __GNUC__
 #if __GNUC__ >= 8
@@ -185,6 +190,48 @@ static void state_equal(const CTYPE* state, const Eigen::VectorXcd& test_state,
             << "CSIM : " << convert_CTYPE_array_to_string(state, dim)
             << std::endl;
     }
+}
+
+#define ASSERT_STATE_NEAR(state, other, eps) \
+    ASSERT_PRED_FORMAT3(_assert_state_near, state, other, eps)
+
+#define EXPECT_STATE_NEAR(state, other, eps) \
+    EXPECT_PRED_FORMAT3(_assert_state_near, state, other, eps)
+
+static testing::AssertionResult _assert_state_near(const char* state1_name,
+    const char* state2_name, const char* eps_name, const QuantumState& state1,
+    const QuantumState& state2, const double eps) {
+    for (UINT i = 0; i < state1.dim; i++) {
+        const double real_diff = std::fabs(
+            state1.data_cpp()[i].real() - state2.data_cpp()[i].real());
+        if (real_diff > eps) {
+            return testing::AssertionFailure()
+                   << "The difference between " << i << "-th real part of "
+                   << state1_name << " and " << state2_name << " is "
+                   << real_diff << ", which exceeds " << eps << ", where\n"
+                   << state1_name << " evaluates to "
+                   << state1.data_cpp()[i].real() << ",\n"
+                   << state2_name << " evaluates to "
+                   << state2.data_cpp()[i].real() << ", and\n"
+                   << eps_name << " evaluates to " << eps << ".";
+        }
+
+        const double imag_diff = std::fabs(
+            state1.data_cpp()[i].real() - state2.data_cpp()[i].real());
+        if (imag_diff > eps) {
+            return testing::AssertionFailure()
+                   << "The difference between " << i << "-th imaginary part of "
+                   << state1_name << " and " << state2_name << " is "
+                   << imag_diff << ", which exceeds " << eps << ", where\n"
+                   << state1_name << " evaluates to "
+                   << state1.data_cpp()[i].imag() << ",\n"
+                   << state2_name << " evaluates to "
+                   << state2.data_cpp()[i].imag() << ", and\n"
+                   << eps_name << " evaluates to " << eps << ".";
+        }
+    }
+
+    return testing::AssertionSuccess();
 }
 
 #define _CHECK_NEAR(val1, val2, eps) \

--- a/test/vqcsim/test_backprop.cpp
+++ b/test/vqcsim/test_backprop.cpp
@@ -41,7 +41,6 @@ TEST(Backprop, BackpropCircuit) {
 
     auto bk = kairo.backprop(&observable);
     for (int i = 0; i < 9; i++) {
-        cerr << bk[i] << " " << bibun[i].real() << endl;
         ASSERT_NEAR(bk[i], bibun[i].real(), 1e-10);
     }
 }
@@ -88,7 +87,6 @@ TEST(Backprop, BackpropCircuitInpro) {
         kairo.update_quantum_state(&Astate);
         CPPCTYPE gen_sco = state::inner_product(&state_soku, &Astate);
 
-        cerr << (gen_sco - mto_sco) * 10000.0 << " " << bk[h] << endl;
         ASSERT_NEAR(((gen_sco - mto_sco) * 10000.0).real(), bk[h], 1e-2);
 
         kairo.set_parameter(h, kaku[h]);
@@ -133,7 +131,6 @@ TEST(Backprop, BackpropPauliRotationCircuit) {
     auto bk = kairo.backprop(&observable);
     // 数値微分との比較
     for (int i = 0; i < 9; i++) {
-        cerr << bk[i] << " " << bibun[i].real() << endl;
         ASSERT_NEAR(bk[i], bibun[i].real(), 1e-10);
     }
 }


### PR DESCRIPTION
- Define `ASSERT_STATE_NEAR` macro to test `QuantumState` easily
- Define factory function to create gate matrices in test
- Fix test that only checks absolute value of complex numbers; check the real and imaginary part

Thank you for reviewing the large diff 🙏 