### PR TITLE
Fix deps to build documentaiton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,6 @@ doc = [
     "myst-parser",
     "sphinx-copybutton",
     "ipykernel",
-    "qulacs",
-    "scipy",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
- Close #411 

## 概要

pyproject.tomlに記述したドキュメントに必要な依存パッケージから、qulacsとscipyを削除しました。
scipyについては、指摘があったように、qulacsをインストールする際に依存としてインストールされることから、冗長だと判断して、削除することにしました。