### PR TITLE
Remove duplicate OUTPUT_LANGUAGE setting

### DIFF
--- a/doc/ja/source/conf.py
+++ b/doc/ja/source/conf.py
@@ -63,7 +63,6 @@ exhale_args = {
         MACRO_EXPANSION        = YES \n \
         PREDEFINED             += __attribute__(x)= \n \
         PREDEFINED             += DllExport= \n \
-        OUTPUT_LANGUAGE = English \n \
         GENERATE_LEGEND        = YES \n \
         GRAPHICAL_HIERARCHY    = YES \n \
         CLASS_GRAPH            = YES \n \


### PR DESCRIPTION
- Close #412 

## 概要

`OUTPUT_LANGUAGE`の項目が重複して設定されていたために、`OUTPUT_LANGUAGE = Japanese-en`の項目が上書きされてしまっている問題を修正しました。
これは、DoxygenによるAPIドキュメントの生成に影響します。

この修正によって、C++ APIドキュメントに関しては、日本語と英語ドキュメントで出力する内容を切り替えることができるようになります。