### PR TITLE
Fix typo DensityMatrix in Python advanced tutorial

### DIFF
--- a/doc/ja/source/guide/2.0_python_advanced.md
+++ b/doc/ja/source/guide/2.0_python_advanced.md
@@ -414,7 +414,7 @@ $p_i$ の確率で $\ket{\psi_i}$ であるとき、$\sum_i p_i\ket{\psi_i}\bra{
 `__repr__` 関数のオーバーライドにより状態ベクトルのフォーマットされた表示を提供します。
 
 ```python
-from qulacs import QuantumState
+from qulacs import DensityMatrix
 n = 2
 state = DensityMatrix(n)
 print(state)


### PR DESCRIPTION
## 概要

Python上級 DensityMatrixのチュートリアル内で、importするものを間違えていたので修正しました