### PR TITLE
General Gate <=> ptree

### DIFF
--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -697,31 +697,55 @@ QuantumGateBase* from_ptree(const boost::property_tree::ptree& pt) {
             pt.get_child("gate_list")) {
             gate_list.push_back(from_ptree(gate_pair.second));
         }
-        QuantumGate_Probabilistic* prob_gate =
-            new QuantumGate_Probabilistic(distribution, gate_list);
-        for (QuantumGateBase* gate : gate_list) {
-            free(gate);
+        bool is_instrument = pt.get<bool>("is_instrument");
+        QuantumGate_Probabilistic* gate;
+        if (is_instrument) {
+            UINT classical_register_address =
+                pt.get<UINT>("classical_register_address");
+            gate = new QuantumGate_Probabilistic(
+                distribution, gate_list, classical_register_address);
+        } else {
+            gate = new QuantumGate_Probabilistic(distribution, gate_list);
         }
-        return prob_gate;
-    } else if (name == "ProbabilisticInstrument") {
-        UINT classical_refister_address =
-            pt.get<UINT>("classical_register_address");
-        std::vector<double> distribution;
-        for (const boost::property_tree::ptree::value_type& p_pair :
-            pt.get_child("distribution")) {
-            distribution.push_back(p_pair.second.get<double>(""));
+        for (QuantumGateBase* gate_option : gate_list) {
+            free(gate_option);
         }
+        return gate;
+    } else if (name == "CPTPMapGate") {
         std::vector<QuantumGateBase*> gate_list;
         for (const boost::property_tree::ptree::value_type& gate_pair :
             pt.get_child("gate_list")) {
             gate_list.push_back(from_ptree(gate_pair.second));
         }
-        QuantumGate_Probabilistic* prob_gate = new QuantumGate_Probabilistic(
-            distribution, gate_list, classical_refister_address);
-        for (QuantumGateBase* gate : gate_list) {
-            free(gate);
+        bool is_instrument = pt.get<bool>("is_instrument");
+        QuantumGate_CPTP* gate;
+        if (is_instrument) {
+            UINT classical_register_address =
+                pt.get<UINT>("classical_register_address");
+            gate = new QuantumGate_CPTP(gate_list, classical_register_address);
+        } else {
+            gate = new QuantumGate_CPTP(gate_list);
         }
-        return prob_gate;
+        for (QuantumGateBase* gate_option : gate_list) {
+            free(gate_option);
+        }
+        return gate;
+    } else if (name == "CPMapGate") {
+        std::vector<QuantumGateBase*> gate_list;
+        for (const boost::property_tree::ptree::value_type& gate_pair :
+            pt.get_child("gate_list")) {
+            gate_list.push_back(from_ptree(gate_pair.second));
+        }
+        bool state_normalize = pt.get<bool>("state_normalize");
+        bool probability_normalize = pt.get<bool>("probability_normalize");
+        bool assign_zero_if_not_matched =
+            pt.get<bool>("assign_zero_if_not_matched");
+        QuantumGate_CP* gate = new QuantumGate_CP(gate_list, state_normalize,
+            probability_normalize, assign_zero_if_not_matched);
+        for (QuantumGateBase* gate_option : gate_list) {
+            free(gate_option);
+        }
+        return gate;
     } else {
         throw UnknownPTreePropertyValueException(
             "unknown value for property \"name\":" + name);

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -686,6 +686,42 @@ QuantumGateBase* from_ptree(const boost::property_tree::ptree& pt) {
         ClsStateReflectionGate* gate = StateReflection(state);
         free(state);
         return gate;
+    } else if (name == "ProbabilisticGate") {
+        std::vector<double> distribution;
+        for (const boost::property_tree::ptree::value_type& p_pair :
+            pt.get_child("distribution")) {
+            distribution.push_back(p_pair.second.get<double>(""));
+        }
+        std::vector<QuantumGateBase*> gate_list;
+        for (const boost::property_tree::ptree::value_type& gate_pair :
+            pt.get_child("gate_list")) {
+            gate_list.push_back(from_ptree(gate_pair.second));
+        }
+        QuantumGate_Probabilistic* prob_gate =
+            new QuantumGate_Probabilistic(distribution, gate_list);
+        for (QuantumGateBase* gate : gate_list) {
+            free(gate);
+        }
+        return prob_gate;
+    } else if (name == "ProbabilisticInstrument") {
+        UINT classical_refister_address =
+            pt.get<UINT>("classical_register_address");
+        std::vector<double> distribution;
+        for (const boost::property_tree::ptree::value_type& p_pair :
+            pt.get_child("distribution")) {
+            distribution.push_back(p_pair.second.get<double>(""));
+        }
+        std::vector<QuantumGateBase*> gate_list;
+        for (const boost::property_tree::ptree::value_type& gate_pair :
+            pt.get_child("gate_list")) {
+            gate_list.push_back(from_ptree(gate_pair.second));
+        }
+        QuantumGate_Probabilistic* prob_gate = new QuantumGate_Probabilistic(
+            distribution, gate_list, classical_refister_address);
+        for (QuantumGateBase* gate : gate_list) {
+            free(gate);
+        }
+        return prob_gate;
     } else {
         throw UnknownPTreePropertyValueException(
             "unknown value for property \"name\":" + name);

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -22,6 +22,7 @@
 #include "gate_named_two.hpp"
 #include "gate_reflect.hpp"
 #include "gate_reversible.hpp"
+#include "state_dm.hpp"
 #include "type.hpp"
 
 namespace gate {
@@ -679,6 +680,12 @@ QuantumGateBase* from_ptree(const boost::property_tree::ptree& pt) {
         UINT control_qubit = pt.get<UINT>("control_qubit");
         UINT target_qubit = pt.get<UINT>("target_qubit");
         return CZ(control_qubit, target_qubit);
+    } else if (name == "StateReflectionGate") {
+        QuantumStateBase* state =
+            state::from_ptree(pt.get_child("reflection_state"));
+        ClsStateReflectionGate* gate = StateReflection(state);
+        free(state);
+        return gate;
     } else {
         throw UnknownPTreePropertyValueException(
             "unknown value for property \"name\":" + name);

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -746,6 +746,38 @@ QuantumGateBase* from_ptree(const boost::property_tree::ptree& pt) {
             free(gate_option);
         }
         return gate;
+    } else if (name == "NoisyEvolutionGate") {
+        Observable* hamiltonian =
+            observable::from_ptree(pt.get_child("hamiltonian"));
+        std::vector<GeneralQuantumOperator*> c_ops;
+        for (const boost::property_tree::ptree::value_type& c_op_pair :
+            pt.get_child("c_ops")) {
+            c_ops.push_back(observable::from_ptree(c_op_pair.second));
+        }
+        double time = pt.get<double>("time");
+        double dt = pt.get<double>("dt");
+        ClsNoisyEvolution* gate = NoisyEvolution(hamiltonian, c_ops, time, dt);
+        free(hamiltonian);
+        for (GeneralQuantumOperator* c_op : c_ops) {
+            free(c_op);
+        }
+        return gate;
+    } else if (name == "NoisyEvolutionFastGate") {
+        Observable* hamiltonian =
+            observable::from_ptree(pt.get_child("hamiltonian"));
+        std::vector<GeneralQuantumOperator*> c_ops;
+        for (const boost::property_tree::ptree::value_type& c_op_pair :
+            pt.get_child("c_ops")) {
+            c_ops.push_back(observable::from_ptree(c_op_pair.second));
+        }
+        double time = pt.get<double>("time");
+        ClsNoisyEvolution_fast* gate =
+            NoisyEvolution_fast(hamiltonian, c_ops, time);
+        free(hamiltonian);
+        for (GeneralQuantumOperator* c_op : c_ops) {
+            free(c_op);
+        }
+        return gate;
     } else {
         throw UnknownPTreePropertyValueException(
             "unknown value for property \"name\":" + name);

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -200,6 +200,7 @@ public:
         } else {
             pt.put("is_instrument", false);
         }
+        return pt;
     }
 
     /*
@@ -393,6 +394,7 @@ public:
         } else {
             pt.put("is_instrument", false);
         }
+        return pt;
     }
 };
 
@@ -550,6 +552,7 @@ public:
         pt.put("state_normalize", _state_normalize);
         pt.put("probability_normalize", _probability_normalize);
         pt.put("assign_zero_if_not_matched", _assign_zero_if_not_matched);
+        return pt;
     }
 };
 

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -191,7 +191,7 @@ public:
         pt.put_child("distribution", distribution_pt);
         boost::property_tree::ptree gate_list_pt;
         for (const QuantumGateBase* gate : _gate_list) {
-            gate_list_pt.put_child("", gate->to_ptree());
+            gate_list_pt.push_back(std::make_pair("", gate->to_ptree()));
         }
         pt.put_child("gate_list", gate_list_pt);
         if (is_instrument) {
@@ -384,7 +384,7 @@ public:
         pt.put("name", "CPTPMapGate");
         boost::property_tree::ptree gate_list_pt;
         for (const QuantumGateBase* gate : _gate_list) {
-            gate_list_pt.put_child("", gate->to_ptree());
+            gate_list_pt.push_back(std::make_pair("", gate->to_ptree()));
         }
         pt.put_child("gate_list", gate_list_pt);
         if (is_instrument) {
@@ -544,7 +544,7 @@ public:
         pt.put("name", "CPMapGate");
         boost::property_tree::ptree gate_list_pt;
         for (const QuantumGateBase* gate : _gate_list) {
-            gate_list_pt.put_child("", gate->to_ptree());
+            gate_list_pt.push_back(std::make_pair("", gate->to_ptree()));
         }
         pt.put_child("gate_list", gate_list_pt);
         pt.put("state_normalize", _state_normalize);

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -174,6 +174,33 @@ public:
         matrix = Eigen::MatrixXcd::Ones(1, 1);
     }
 
+    /**
+     * \~japanese-en ptreeに変換する
+     *
+     * @return ptree
+     */
+    virtual boost::property_tree::ptree to_ptree() const override {
+        boost::property_tree::ptree pt;
+        if (is_instrument) {
+            pt.put("name", "ProbabilisticInstrument");
+            pt.put("classical_register_address", _classical_register_address);
+        } else {
+            pt.put("name", "ProbabilisticGate");
+        }
+        boost::property_tree::ptree distribution_pt;
+        for (double p : _distribution) {
+            boost::property_tree::ptree child;
+            child.put("", p);
+            distribution_pt.push_back(std::make_pair("", child));
+        }
+        pt.put_child("distribution", distribution_pt);
+        boost::property_tree::ptree gate_list_pt;
+        for (const QuantumGateBase* gate : _gate_list) {
+            gate_list_pt.put_child("", gate->to_ptree());
+        }
+        pt.put_child("gate_list", gate_list_pt);
+    }
+
     /*
     added by kotamanegi.
     */

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -181,12 +181,7 @@ public:
      */
     virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
-        if (is_instrument) {
-            pt.put("name", "ProbabilisticInstrument");
-            pt.put("classical_register_address", _classical_register_address);
-        } else {
-            pt.put("name", "ProbabilisticGate");
-        }
+        pt.put("name", "ProbabilisticGate");
         boost::property_tree::ptree distribution_pt;
         for (double p : _distribution) {
             boost::property_tree::ptree child;
@@ -199,6 +194,12 @@ public:
             gate_list_pt.put_child("", gate->to_ptree());
         }
         pt.put_child("gate_list", gate_list_pt);
+        if (is_instrument) {
+            pt.put("is_instrument", true);
+            pt.put("classical_register_address", _classical_register_address);
+        } else {
+            pt.put("is_instrument", false);
+        }
     }
 
     /*
@@ -372,6 +373,27 @@ public:
                   << std::endl;
         matrix = Eigen::MatrixXcd::Ones(1, 1);
     }
+
+    /**
+     * \~japanese-en ptreeに変換する
+     *
+     * @return ptree
+     */
+    virtual boost::property_tree::ptree to_ptree() const override {
+        boost::property_tree::ptree pt;
+        pt.put("name", "CPTPMapGate");
+        boost::property_tree::ptree gate_list_pt;
+        for (const QuantumGateBase* gate : _gate_list) {
+            gate_list_pt.put_child("", gate->to_ptree());
+        }
+        pt.put_child("gate_list", gate_list_pt);
+        if (is_instrument) {
+            pt.put("is_instrument", true);
+            pt.put("classical_register_address", _classical_register_address);
+        } else {
+            pt.put("is_instrument", false);
+        }
+    }
 };
 
 /**
@@ -510,6 +532,24 @@ public:
                      "Identity matrix is returned."
                   << std::endl;
         matrix = Eigen::MatrixXcd::Ones(1, 1);
+    }
+
+    /**
+     * \~japanese-en ptreeに変換する
+     *
+     * @return ptree
+     */
+    virtual boost::property_tree::ptree to_ptree() const override {
+        boost::property_tree::ptree pt;
+        pt.put("name", "CPMapGate");
+        boost::property_tree::ptree gate_list_pt;
+        for (const QuantumGateBase* gate : _gate_list) {
+            gate_list_pt.put_child("", gate->to_ptree());
+        }
+        pt.put_child("gate_list", gate_list_pt);
+        pt.put("state_normalize", _state_normalize);
+        pt.put("probability_normalize", _probability_normalize);
+        pt.put("assign_zero_if_not_matched", _assign_zero_if_not_matched);
     }
 };
 

--- a/src/cppsim/gate_noisy_evolution.cpp
+++ b/src/cppsim/gate_noisy_evolution.cpp
@@ -308,6 +308,20 @@ void ClsNoisyEvolution::update_quantum_state(QuantumStateBase* state) {
     delete buffer;
 }
 
+boost::property_tree::ptree ClsNoisyEvolution::to_ptree() const {
+    boost::property_tree::ptree pt;
+    pt.put("name", "NoisyEvolutionGate");
+    pt.put_child("hamiltonian", _hamiltonian->to_ptree());
+    boost::property_tree::ptree c_ops_pt;
+    for (const GeneralQuantumOperator* c_op : _c_ops) {
+        c_ops_pt.push_back(std::make_pair("", c_op->to_ptree()));
+    }
+    pt.put_child("c_ops", c_ops_pt);
+    pt.put("time", _time);
+    pt.put("dt", _dt);
+    return pt;
+}
+
 //ここからfast
 
 double ClsNoisyEvolution_fast::_find_collapse(QuantumStateBase* prev_state,
@@ -582,4 +596,17 @@ void ClsNoisyEvolution_fast::update_quantum_state(QuantumStateBase* state) {
         state->get_squared_norm_single_thread() / initial_squared_norm);
 
     delete buffer;
+}
+
+boost::property_tree::ptree ClsNoisyEvolution_fast::to_ptree() const {
+    boost::property_tree::ptree pt;
+    pt.put("name", "NoisyEvolutionFastGate");
+    pt.put_child("hamiltonian", _hamiltonian->to_ptree());
+    boost::property_tree::ptree c_ops_pt;
+    for (const GeneralQuantumOperator* c_op : _c_ops) {
+        c_ops_pt.push_back(std::make_pair("", c_op->to_ptree()));
+    }
+    pt.put_child("c_ops", c_ops_pt);
+    pt.put("time", _time);
+    return pt;
 }

--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -98,6 +98,11 @@ public:
     }
 
     virtual void update_quantum_state(QuantumStateBase* state);
+
+    /**
+     * \~japanese-en ptreeに変換する
+     */
+    virtual boost::property_tree::ptree to_ptree() const;
 };
 
 /*
@@ -204,6 +209,11 @@ public:
      * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state);
+
+    /**
+     * \~japanese-en ptreeに変換する
+     */
+    virtual boost::property_tree::ptree to_ptree() const;
 };
 
 // noisyEvolution_auto

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -84,4 +84,15 @@ public:
         throw NotImplementedException(
             "ReflectionGate::set_matrix is not implemented");
     }
+    /**
+     * \~japanese-en ptreeに変換する
+     *
+     * @param ptree ptree
+     */
+    virtual boost::property_tree::ptree to_ptree() const override {
+        boost::property_tree::ptree pt;
+        pt.put("name", "StateReflectionGate");
+        pt.put_child("reflection_state", reflection_state->to_ptree());
+        return pt;
+    }
 };


### PR DESCRIPTION
- StateReflectionGate
- Probabilistic系Gate
- NoisyEvolutionGate
のptreeとの相互変換を実装しました。
pybindされているcppsimのゲートのうち実装されていないものはReversibleBooleanGateとQuantumGate_Adaptiveのみになります(これらは関数を使って構築するゲートなので、現時点でシリアライズは困難と判断しました。