### PR TITLE
add darwin CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,13 @@ class CMakeBuild(build_ext):
             n_cpus = os.cpu_count()
             build_args += ["--", f"-j{n_cpus}"]
 
+            if sys.platform.startswith("darwin"):
+                # Cross-compile support for macOS - respect ARCHFLAGS if set
+                import re
+                archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+                if archs:
+                    cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
         return build_args, cmake_args
 
 


### PR DESCRIPTION
https://github.com/qulacs/qulacs/pull/438
macosの場合、CMAKE_OSX_ARCHITECTURESを設定するようにsetup.pyを修正しました。