### PR TITLE
Fix to reduce build warnings

### DIFF
--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -235,7 +235,7 @@ public:
         // bit_numberを決めて、実際に独立なゲートに振り分ける
         UINT n_qubit = hamiltonian->get_qubit_count();
         bit_number = std::vector<int>(n_qubit, -1);
-        int i;
+        UINT i;
         for (auto pauli : hamiltonian->get_terms()) {
             for (int bit : pauli->get_index_list()) {
                 bit_number[bit] = bit;
@@ -281,7 +281,7 @@ public:
             aru[bit_number[i]] = true;
         }
         std::vector<UINT> taiou(n_qubit);
-        int kaz = 0;
+        UINT kaz = 0;
         for (i = 0; i < n_qubit; i++) {
             if (aru[i]) {
                 taiou[i] = kaz;

--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -235,7 +235,6 @@ public:
         // bit_numberを決めて、実際に独立なゲートに振り分ける
         UINT n_qubit = hamiltonian->get_qubit_count();
         bit_number = std::vector<int>(n_qubit, -1);
-        UINT i;
         for (auto pauli : hamiltonian->get_terms()) {
             for (int bit : pauli->get_index_list()) {
                 bit_number[bit] = bit;
@@ -274,7 +273,7 @@ public:
         }
 
         std::vector<bool> aru(n_qubit);
-        for (i = 0; i < n_qubit; i++) {
+        for (UINT i = 0; i < n_qubit; i++) {
             if (bit_number[i] == -1) {
                 continue;
             }
@@ -282,17 +281,17 @@ public:
         }
         std::vector<UINT> taiou(n_qubit);
         UINT kaz = 0;
-        for (i = 0; i < n_qubit; i++) {
+        for (UINT i = 0; i < n_qubit; i++) {
             if (aru[i]) {
                 taiou[i] = kaz;
                 kaz++;
             }
         }
-        for (i = 0; i < n_qubit; i++) {
+        for (UINT i = 0; i < n_qubit; i++) {
             bit_number[i] = taiou[bit_number[i]];
         }
         std::vector<Observable*> hamiltonians(kaz);
-        for (i = 0; i < kaz; i++) {
+        for (UINT i = 0; i < kaz; i++) {
             hamiltonians[i] = new Observable(n_qubit);
         }
         std::vector<std::vector<GeneralQuantumOperator*>> c_opss(kaz);
@@ -321,7 +320,7 @@ public:
             c_opss[uf_a].push_back(c_ops[k]);
         }
         gates.resize(kaz);
-        for (i = 0; i < kaz; i++) {
+        for (UINT i = 0; i < kaz; i++) {
             gates[i] =
                 new ClsNoisyEvolution_fast(hamiltonians[i], c_opss[i], time);
         }


### PR DESCRIPTION
開発時の修正部分でのミスを見つけるために、ビルド時のワーニングは少なくしておきたいです。
20+個のワーニングが3つになります。

@WATLE さん、
こちらで確認した限り、0で初期化してカウントアップしかしていないようです。
念のため、設計的に問題ないか確認をお願いできないでしょうか。
