### PR TITLE
specify type for lambda arguments

### DIFF
--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -229,12 +229,12 @@ QuantumCircuit::~QuantumCircuit() {
 
 bool QuantumCircuit::is_Clifford() const {
     return std::all_of(this->_gate_list.cbegin(), this->_gate_list.cend(),
-        [](auto gate) { return gate->is_Clifford(); });
+        [](const QuantumGateBase* gate) { return gate->is_Clifford(); });
 }
 
 bool QuantumCircuit::is_Gaussian() const {
     return std::all_of(this->_gate_list.cbegin(), this->_gate_list.cend(),
-        [](auto gate) { return gate->is_Gaussian(); });
+        [](const QuantumGateBase* gate) { return gate->is_Gaussian(); });
 }
 
 UINT QuantumCircuit::calculate_depth() const {

--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -39,7 +39,7 @@ UINT QuantumCircuitOptimizer::get_merged_gate_size(
             std::vector<UINT> index_list;
             std::transform(info_list.cbegin(), info_list.cend(),
                 std::back_inserter(index_list),
-                [](auto info) { return info.index(); });
+                [](const TargetQubitInfo& info) { return info.index(); });
             return index_list;
         };
     auto fetch_control_index =
@@ -47,7 +47,7 @@ UINT QuantumCircuitOptimizer::get_merged_gate_size(
             std::vector<UINT> index_list;
             std::transform(info_list.cbegin(), info_list.cend(),
                 std::back_inserter(index_list),
-                [](auto info) { return info.index(); });
+                [](const ControlQubitInfo& info) { return info.index(); });
             return index_list;
         };
 

--- a/src/cppsim/gate.cpp
+++ b/src/cppsim/gate.cpp
@@ -48,7 +48,9 @@ bool QuantumGateBase::is_diagonal() const {
     // in Z basis
     return std::all_of(this->_target_qubit_list.cbegin(),
         this->_target_qubit_list.cend(),
-        [](auto target_qubit) { return target_qubit.is_commute_Z(); });
+        [](const TargetQubitInfo& target_qubit) {
+            return target_qubit.is_commute_Z();
+        });
     // for (auto val : this->_target_qubit_list) {
     //     if (val.is_commute_Z() == false) {
     //         return false;

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -59,7 +59,7 @@ public:
         }
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(this->_gate_list),
-            [](auto gate) { return gate->copy(); });
+            [](const QuantumGateBase* gate) { return gate->copy(); });
         this->_name = "Probabilistic";
 
         bool fullsum = (sum > 1 - 1e-6);
@@ -226,7 +226,7 @@ public:
     explicit QuantumGate_CPTP(std::vector<QuantumGateBase*> gate_list) {
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(_gate_list),
-            [](auto gate) { return gate->copy(); });
+            [](const QuantumGateBase* gate) { return gate->copy(); });
         this->_name = "CPTP";
 
         for (UINT i = 0; i < _gate_list.size(); i++) {
@@ -367,7 +367,7 @@ public:
           _assign_zero_if_not_matched(assign_zero_if_not_matched) {
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(_gate_list),
-            [](auto gate) { return gate->copy(); });
+            [](const QuantumGateBase* gate) { return gate->copy(); });
         this->_name = "CP";
 
         for (UINT i = 0; i < _gate_list.size(); i++) {

--- a/src/cppsim/gate_matrix.cpp
+++ b/src/cppsim/gate_matrix.cpp
@@ -96,7 +96,7 @@ void QuantumGateMatrix::update_quantum_state(QuantumStateBase* state) {
     std::vector<UINT> control_value;
     std::transform(this->_target_qubit_list.cbegin(),
         this->_target_qubit_list.cend(), std::back_inserter(target_index),
-        [](auto value) { return value.index(); });
+        [](const TargetQubitInfo& value) { return value.index(); });
     for (auto val : this->_control_qubit_list) {
         control_index.push_back(val.index());
         control_value.push_back(val.control_value());

--- a/src/cppsim/gate_matrix_diagonal.cpp
+++ b/src/cppsim/gate_matrix_diagonal.cpp
@@ -78,7 +78,7 @@ void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
     std::vector<UINT> control_value;
     std::transform(this->_target_qubit_list.cbegin(),
         this->_target_qubit_list.cend(), std::back_inserter(target_index),
-        [](auto value) { return value.index(); });
+        [](const TargetQubitInfo& value) { return value.index(); });
     for (auto val : this->_control_qubit_list) {
         control_index.push_back(val.index());
         control_value.push_back(val.control_value());

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -79,7 +79,7 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     std::vector<UINT> target_index;
     std::transform(this->_target_qubit_list.cbegin(),
         this->_target_qubit_list.cend(), std::back_inserter(target_index),
-        [](auto value) { return value.index(); });
+        [](const TargetQubitInfo& value) { return value.index(); });
 
     if (state->is_state_vector()) {
 #ifdef _USE_GPU

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -39,7 +39,7 @@ public:
         std::vector<UINT> target_index;
         std::transform(this->_target_qubit_list.cbegin(),
             this->_target_qubit_list.cend(), std::back_inserter(target_index),
-            [](auto value) { return value.index(); });
+            [](const TargetQubitInfo& value) { return value.index(); });
         if (state->is_state_vector()) {
 #ifdef _USE_GPU
             if (state->get_device_name() == "gpu") {

--- a/src/cppsim/noisesimulator.cpp
+++ b/src/cppsim/noisesimulator.cpp
@@ -84,7 +84,10 @@ NoiseSimulator::generate_sampling_request(const UINT sample_count) {
 std::vector<ITYPE> NoiseSimulator::execute_sampling(
     std::vector<NoiseSimulator::SamplingRequest> sampling_requests) {
     std::sort(begin(sampling_requests), end(sampling_requests),
-        [](auto l, auto r) { return l.gate_pos > r.gate_pos; });
+        [](const NoiseSimulator::SamplingRequest& l,
+            const NoiseSimulator::SamplingRequest& r) {
+            return l.gate_pos > r.gate_pos;
+        });
 
     std::vector<ITYPE> sampling_result;
 

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -93,7 +93,7 @@ public:
         std::vector<UINT> index_list;
         std::transform(_pauli_list.cbegin(), _pauli_list.cend(),
             std::back_inserter(index_list),
-            [](auto val) { return val.index(); });
+            [](const SinglePauliOperator& val) { return val.index(); });
         return index_list;
     }
 
@@ -123,7 +123,7 @@ public:
         std::vector<UINT> pauli_id_list;
         std::transform(_pauli_list.cbegin(), _pauli_list.cend(),
             std::back_inserter(pauli_id_list),
-            [](auto val) { return val.pauli_id(); });
+            [](const SinglePauliOperator& val) { return val.pauli_id(); });
         return pauli_id_list;
     }
 


### PR DESCRIPTION
close #450
I think using "const reference" if possible is better for performance, so I used that when resolving `auto`.