### PR TITLE
I fix submenu to corrected the columns.

### DIFF
--- a/doc/en/source/intro/4.1_python_tutorial.ipynb
+++ b/doc/en/source/intro/4.1_python_tutorial.ipynb
@@ -829,17 +829,19 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Quantum circuit"
+    "## Quantum circuit"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Construct the quantum circuit"
+    "### Construct the quantum circuit"
    ]
   },
   {
@@ -948,7 +950,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.2 64-bit",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -962,11 +964,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.10.4 (main, May  9 2022, 18:28:02) [GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+    "hash": "84aa2c67dae1159a9469e7ac93262a46ff5158e6dcd4abab35ce17cbce36ce1e"
    }
   }
  },


### PR DESCRIPTION
`Quantum circuit` page title had three #.
It was have to two #.
And `Construct the quantum circuit` title had for #.
I changed three #.