### PR TITLE
Execute and get state

### DIFF
--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -37,6 +37,7 @@ __all__ = [
     "QuantumGate_SingleParameter",
     "QuantumState",
     "QuantumStateBase",
+    "SimulationResult",
     "StateVector",
     "circuit",
     "gate",
@@ -269,6 +270,10 @@ class NoiseSimulator():
     def execute(self, arg0: int) -> typing.List[int]: 
         """
         Sampling & Return result [array]
+        """
+    def execute_and_get_result(self, arg0: int) -> SimulationResult: 
+        """
+        Simulate & Return ressult [array of (state, frequency)]
         """
     pass
 class Observable(GeneralQuantumOperator):
@@ -1005,6 +1010,20 @@ class DensityMatrix(QuantumStateBase):
     def to_string(self) -> str: 
         """
         to string
+        """
+    pass
+class SimulationResult():
+    def get_count(self) -> int: 
+        """
+        get state count
+        """
+    def get_frequency(self, arg0: int) -> int: 
+        """
+        get state frequency
+        """
+    def get_state(self, arg0: int) -> QuantumState: 
+        """
+        get state
         """
     pass
 def StateVector(arg0: int) -> QuantumState:

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -1322,8 +1322,31 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("get_coef_list", &CausalConeSimulator::get_coef_list,
             "Return coef_list");
 
+    py::class_<NoiseSimulator::Result>(m, "SimulationResult")
+        .def(
+            "get_count",
+            [](const NoiseSimulator::Result& result) -> UINT {
+                return result.result.size();
+            },
+            "get state count")
+        .def(
+            "get_state",
+            [](const NoiseSimulator::Result& result, UINT i) -> QuantumState* {
+                return result.result[i].first->copy();
+            },
+            "get state", py::return_value_policy::take_ownership)
+        .def(
+            "get_frequency",
+            [](const NoiseSimulator::Result& result, UINT i) -> UINT {
+                return result.result[i].second;
+            },
+            "get state frequency");
+
     py::class_<NoiseSimulator>(m, "NoiseSimulator")
         .def(py::init<QuantumCircuit*, QuantumState*>(), "Constructor")
         .def("execute", &NoiseSimulator::execute,
-            "Sampling & Return result [array]");
+            "Sampling & Return result [array]",
+            py::return_value_policy::take_ownership)
+        .def("execute_and_get_result", &NoiseSimulator::execute_and_get_result,
+            "Simulate & Return ressult [array of (state, frequency)]");
 }

--- a/src/cppsim/noisesimulator.cpp
+++ b/src/cppsim/noisesimulator.cpp
@@ -59,7 +59,6 @@ std::vector<ITYPE> NoiseSimulator::Result::sampling() const {
         std::vector<ITYPE> sampling_result_p = p.first->sampling(p.second);
         std::copy(sampling_result_p.begin(), sampling_result_p.end(),
             std::back_inserter(sampling_result));
-        delete p.first;
     }
     return sampling_result;
 }

--- a/src/cppsim/noisesimulator.hpp
+++ b/src/cppsim/noisesimulator.hpp
@@ -63,13 +63,25 @@ private:
     /**
      * \~japanese-en
      *
-     * SamplingRequestの計画通りにシミュレーションを行い、結果を配列で返す。
+     * SamplingRequestの計画通りにシミュレーションを行い、結果をpairの配列で返す。
      * @param[in] sampling_request_vector SamplingRequestのvector
      */
     std::vector<std::pair<QuantumState*, UINT>> simulate(
         std::vector<SamplingRequest> sampling_request_vector);
 
 public:
+    /**
+     * \~japanese-en 複数回の実行結果をまとめた構造体
+     */
+    struct Result {
+    public:
+        std::vector<std::pair<QuantumState*, UINT>> result;
+
+        Result(const std::vector<std::pair<QuantumState*, UINT>>& result_);
+        ~Result();
+        std::vector<ITYPE> sampling() const;
+    };
+
     /**
      * \~japanese-en
      * コンストラクタ。
@@ -102,8 +114,7 @@ public:
      * 実際にサンプリングまではせずにノイズがランダムにかかった量子状態の列を返す。
      * @param[in] execution_count 実行回数
      * @return
-     * 量子状態の列。pairの配列で、同じ量子状態は1つの要素にまとまっている。firstは量子状態、secondはその個数
+     * 量子状態の列。Resultクラスに入れられる。
      */
-    virtual std::vector<std::pair<QuantumState*, UINT>> execute_and_get_state(
-        const UINT execution_count);
+    virtual Result* execute_and_get_result(const UINT execution_count);
 };

--- a/src/cppsim/noisesimulator.hpp
+++ b/src/cppsim/noisesimulator.hpp
@@ -63,10 +63,10 @@ private:
     /**
      * \~japanese-en
      *
-     * SamplingRequestの計画通りにサンプリングを行い、結果を配列で返す。
+     * SamplingRequestの計画通りにシミュレーションを行い、結果を配列で返す。
      * @param[in] sampling_request_vector SamplingRequestのvector
      */
-    std::vector<ITYPE> execute_sampling(
+    std::vector<std::pair<QuantumState*, UINT>> simulate(
         std::vector<SamplingRequest> sampling_request_vector);
 
 public:
@@ -95,4 +95,15 @@ public:
      * @param[in] sample_count 行うsamplingの回数
      */
     virtual std::vector<ITYPE> execute(const UINT sample_count);
+
+    /**
+     * \~japanese-en
+     *
+     * 実際にサンプリングまではせずにノイズがランダムにかかった量子状態の列を返す。
+     * @param[in] execution_count 実行回数
+     * @return
+     * 量子状態の列。pairの配列で、同じ量子状態は1つの要素にまとまっている。firstは量子状態、secondはその個数
+     */
+    virtual std::vector<std::pair<QuantumState*, UINT>> execute_and_get_state(
+        const UINT execution_count);
 };


### PR DESCRIPTION
close #445 
サンプリングまではせずにノイズの乗り方ごとの量子状態と頻度を返す`execute_and_get_result()`を実装しました。

本当は直接`std::vector<std::pair<QuantumState*, UINT>>` (`List[Tuple[QuantumState, int]]`)を返したいのですが、Pybind11では返り値のコンテナの中のポインタの所有権を奪うまでは不可能であり、そのままポインタを返したところでC++に返されることはなくメモリ開放をするタイミングがないという問題があってデストラクタを定義し直した`Result`という構造体に入れて返すようにしました。

```python
from qulacs import NoiseSimulator, QuantumCircuit, QuantumState
from qulacs.gate import DepolarizingNoise

circ = QuantumCircuit(1)
circ.add_H_gate(0)
circ.add_gate(DepolarizingNoise(0, 0.1))
circ.add_H_gate(0)
state = QuantumState(1)

sim = NoiseSimulator(circ, state)
res = sim.execute_and_get_result(1000)

for i in range(res.get_count()):
    s = res.get_state(i)
    print(res.get_frequency(i), 'x', s.get_vector())
```
```
37 x [1.+0.j 0.+0.j]
32 x [0.+0.j 1.+0.j]
33 x [0.+0.j 0.-1.j]
898 x [1.+0.j 0.+0.j]
```

のようにして使います。