### PR TITLE
Json dev general gate test

### DIFF
--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -767,11 +767,19 @@ class QuantumGateSparseMatrix(QuantumGateBase):
 class QuantumGate_Adaptive(QuantumGateBase):
     pass
 class QuantumGate_CP(QuantumGateBase):
+    def get_gate_list(self) -> typing.List[QuantumGateBase]: 
+        """
+        get_gate_list
+        """
     pass
 class QuantumGate_CPTP(QuantumGateBase):
     """
     QuantumGate_Instrument
     """
+    def get_gate_list(self) -> typing.List[QuantumGateBase]: 
+        """
+        get_gate_list
+        """
     pass
 class QuantumGate_Probabilistic(QuantumGateBase):
     """

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -726,7 +726,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,
-            "get_gate_list")
+            py::return_value_policy::reference, "get_gate_list")
         .def("optimize_ProbablisticGate",
             &QuantumGate_Probabilistic::optimize_ProbablisticGate,
             "optimize_ProbablisticGate")
@@ -736,8 +736,12 @@ PYBIND11_MODULE(qulacs_core, m) {
             &QuantumGate_Probabilistic::get_cumulative_distribution,
             "get_cumulative_distribution");
     py::class_<QuantumGate_CPTP, QuantumGateBase>(
-        m, "QuantumGate_CPTP", "QuantumGate_Instrument");
-    py::class_<QuantumGate_CP, QuantumGateBase>(m, "QuantumGate_CP");
+        m, "QuantumGate_CPTP", "QuantumGate_Instrument")
+        .def("get_gate_list", &QuantumGate_CPTP::get_gate_list,
+            py::return_value_policy::reference, "get_gate_list");
+    py::class_<QuantumGate_CP, QuantumGateBase>(m, "QuantumGate_CP")
+        .def("get_gate_list", &QuantumGate_CP::get_gate_list,
+            py::return_value_policy::reference, "get_gate_list");
     py::class_<QuantumGate_Adaptive, QuantumGateBase>(
         m, "QuantumGate_Adaptive");
     py::class_<QuantumGateDiagonalMatrix, QuantumGateBase>(

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1134,6 +1134,111 @@ class TestJSON(unittest.TestCase):
         for _ in range(10):
             execute_test_gate()
 
+    def test_noisy_evolution_gate(self):
+        from qulacs import QuantumState, GeneralQuantumOperator, Observable, gate
+        from qulacs.gate import NoisyEvolution, NoisyEvolution_fast
+        import json
+
+        n = 4
+
+        def execute_test_gate():
+
+            gamma = 0.5474999999999999
+            depth = 10
+            step = 0.8
+            time = step * depth
+
+            c_ops = []
+
+            op = GeneralQuantumOperator(n)
+            op2 = GeneralQuantumOperator(n)
+            op.add_operator(1., "Z 0")
+            op2.add_operator(1., "Z 1")
+            c_ops.append(op)
+            c_ops.append(op2)
+
+            # hamiltonian
+            hamiltonian = Observable(n)
+            # X-term
+            for i in range(n):
+                hamiltonian.add_operator(gamma, "X {0}".format(i))
+
+            g = NoisyEvolution(hamiltonian, c_ops, time, step)
+            json_string = g.to_json()
+            # print(json_string)
+            json.loads(json_string)
+            g_json = gate.from_json(json_string)
+
+            state = QuantumState(n)
+            state_json = QuantumState(n)
+
+            for i in range(2**n):
+                state.set_computational_basis(i)
+                state_json.set_computational_basis(i)
+                g.update_quantum_state(state)
+                g_json.update_quantum_state(state_json)
+
+            # TODO: gamma値にjsonで誤差がでる
+            # for i in range(n):
+            #     self.assertAlmostEqual(state.get_zero_probability(
+            #         i), state_json.get_zero_probability(i))
+
+            state = None
+            state_json = None
+            g = None
+            g_json = None
+
+        def execute_test_fast_gate():
+
+            gamma = 0.5474999999999999
+            depth = 10
+            step = 0.8
+            time = step * depth
+
+            c_ops = []
+
+            op = GeneralQuantumOperator(n)
+            op2 = GeneralQuantumOperator(n)
+            op.add_operator(1., "Z 0")
+            op2.add_operator(1., "Z 1")
+            c_ops.append(op)
+            c_ops.append(op2)
+
+            # hamiltonian
+            hamiltonian = Observable(n)
+            # X-term
+            for i in range(n):
+                hamiltonian.add_operator(gamma, "X {0}".format(i))
+
+            g = NoisyEvolution_fast(hamiltonian, c_ops, time)
+            json_string = g.to_json()
+            # print(json_string)
+            json.loads(json_string)
+            g_json = gate.from_json(json_string)
+
+            state = QuantumState(n)
+            state_json = QuantumState(n)
+
+            for i in range(2**n):
+                state.set_computational_basis(i)
+                state_json.set_computational_basis(i)
+                g.update_quantum_state(state)
+                g_json.update_quantum_state(state_json)
+
+            # TODO: gamma値にjsonで誤差がでる
+            # for i in range(n):
+            #     self.assertAlmostEqual(state.get_zero_probability(
+            #         i), state_json.get_zero_probability(i))
+
+            state = None
+            state_json = None
+            g = None
+            g_json = None
+
+        for _ in range(10):
+            execute_test_gate()
+            execute_test_fast_gate()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1242,6 +1242,7 @@ class TestJSON(unittest.TestCase):
             for i in range(len(g_list)):
                 gg = g_list[i]
                 gg_json = g_json_list[i]
+                self.assertEqual(gg.get_name(), gg_json.get_name())
                 qs.set_Haar_random_state()
                 qs_json = qs.copy()
                 gg.update_quantum_state(qs)

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1130,102 +1130,87 @@ class TestJSON(unittest.TestCase):
             for i in range(len(ds)):
                 self.assertAlmostEqual(ds[i], ds_json[i])
 
-    # AmplitudeDampingNoise(0, random.random()),
-    #  CPTP([P0(0), P1(0)]), Instrument([P0(0), P1(0)], 1), Adaptive(X(0), adap),
-
     def test_cptp_gate(self):
         from qulacs import QuantumState, gate
-        from qulacs.gate import P0, P1, CPTP, AmplitudeDampingNoise, Measurement
+        from qulacs.gate import P0, P1, CPTP, AmplitudeDampingNoise,Instrument, Measurement, Adaptive
         import json
         import random
 
         n = 2
-        cp = CPTP([P0(0), P1(0)])
-        json_string = cp.to_json()
-        # print(cp)
-        print(json_string)
-        print(dir(cp))
-        #gl = cp.gate_list()
-        # print(gl)
+        gates = [
+            AmplitudeDampingNoise(0, random.random()),
+            CPTP([P0(0), P1(0)]), 
+            Instrument([P0(0), P1(0)], 0), Measurement(0,0),
+        ]
 
-        # def execute_test_gate():
-        #     # qs = QuantumState(n)
-        #     g = AmplitudeDampingNoise(0, random.random())
-        #     json_string = g.to_json()
-        #     json.loads(json_string)
-        #     g_json = gate.from_json(json_string)
-        #     print(dir(g))
-        #     # qg = QuantumGate_CPTP()
-        #     # print(g)
-        #     # print(json_string)
-        #     # for gg in g.get_gate_list():
-        #     #     if gg.get_name == "DenseMatrixGate":
-        #     #         print(gg.get_matrix())
+        for g in gates:
+            g_list = g.get_gate_list()
+            json_string = g.to_json()
+            g_json = gate.from_json(json_string)
+            g_json_list = g_json.get_gate_list()
 
-        #     # g.get_cumulative_distribution()
-        #     # g.get_distribution()
-        #     # g.get_matrix()
-        #     # print(g.get_matrix())
+            qs = QuantumState(n)
 
-        #     # qs.set_Haar_random_state()
-        #     # qs_json = qs.copy()
-        #     # g.update_quantum_state(qs)
-        #     # g_json.update_quantum_state(qs_json)
-        #     # for i in range(n):
-        #     #     self.assertAlmostEqual(qs.get_zero_probability(
-        #     #         i), qs_json.get_zero_probability(i))
+            for i in range(len(g_list)):
+                gg = g_list[i]
+                gg_json = g_json_list[i]
+                qs.set_Haar_random_state()
+                qs_json = qs.copy()
+                gg.update_quantum_state(qs)
+                gg_json.update_quantum_state(qs_json)
+                for i in range(n):
+                    self.assertAlmostEqual(qs.get_zero_probability(
+                        i), qs_json.get_zero_probability(i))
 
-        # for _ in range(1):
-        #     execute_test_gate()
 
-    # def test_noisy_evolution_gate(self):
-    #     from qulacs import QuantumState, GeneralQuantumOperator, Observable, gate
-    #     from qulacs.gate import NoisyEvolution, NoisyEvolution_fast, PauliRotation, H
-    #     import json
+    def test_noisy_evolution_gate(self):
+        from qulacs import QuantumState, GeneralQuantumOperator, Observable, gate
+        from qulacs.gate import NoisyEvolution, NoisyEvolution_fast, PauliRotation, H
+        import json
 
-    #     n = 2
+        n = 2
 
-    #     def execute_test_gate(is_fast):
-    #         observable = Observable(n)
-    #         observable.add_operator(1., "X 0")
+        def execute_test_gate(is_fast):
+            observable = Observable(n)
+            observable.add_operator(1., "X 0")
 
-    #         hamiltonian = Observable(n)
-    #         hamiltonian.add_operator(1., "Z 0 Z 1")
+            hamiltonian = Observable(n)
+            hamiltonian.add_operator(1., "Z 0 Z 1")
 
-    #         c_ops = []
-    #         op = GeneralQuantumOperator(n)
-    #         op.add_operator(0., "Z 0")
-    #         c_ops.append(op)
+            c_ops = []
+            op = GeneralQuantumOperator(n)
+            op.add_operator(0., "Z 0")
+            c_ops.append(op)
 
-    #         step = 10
-    #         time = 3.14 / step
-    #         dt = .001
-    #         if is_fast:
-    #             g = NoisyEvolution_fast(hamiltonian, c_ops, time)
-    #         else:
-    #             g = NoisyEvolution(hamiltonian, c_ops, time, dt)
-    #         json_string = g.to_json()
-    #         json.loads(json_string)
-    #         g_json = gate.from_json(json_string)
+            step = 10
+            time = 3.14 / step
+            dt = .001
+            if is_fast:
+                g = NoisyEvolution_fast(hamiltonian, c_ops, time)
+            else:
+                g = NoisyEvolution(hamiltonian, c_ops, time, dt)
+            json_string = g.to_json()
+            json.loads(json_string)
+            g_json = gate.from_json(json_string)
 
-    #         # reference gate
-    #         g_ref = PauliRotation([0, 1], [3, 3], -time * 2)
+            # reference gate
+            g_ref = PauliRotation([0, 1], [3, 3], -time * 2)
 
-    #         state = QuantumState(n)
-    #         state_ref = QuantumState(n)
-    #         h0 = H(0)
-    #         h0.update_quantum_state(state)
-    #         h0.update_quantum_state(state_ref)
-    #         for k in range(step):
-    #             g_json.update_quantum_state(state)
-    #             g_ref.update_quantum_state(state_ref)
-    #             exp = observable.get_expectation_value(state)
-    #             exp_ref = observable.get_expectation_value(state_ref)
-    #             self.assertAlmostEqual(exp.real, exp_ref.real)
+            state = QuantumState(n)
+            state_ref = QuantumState(n)
+            h0 = H(0)
+            h0.update_quantum_state(state)
+            h0.update_quantum_state(state_ref)
+            for k in range(step):
+                g_json.update_quantum_state(state)
+                g_ref.update_quantum_state(state_ref)
+                exp = observable.get_expectation_value(state)
+                exp_ref = observable.get_expectation_value(state_ref)
+                self.assertAlmostEqual(exp.real, exp_ref.real)
 
-    #     for _ in range(10):
-    #         execute_test_gate(False)
-    #         execute_test_gate(True)
+        for _ in range(10):
+            execute_test_gate(False)
+            execute_test_gate(True)
 
 
 if __name__ == "__main__":

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1061,6 +1061,7 @@ class TestJSON(unittest.TestCase):
                                  SparseMatrix, T, Tdag,
                                  TwoQubitDepolarizingNoise, X, Y, Z, add,
                                  merge, sqrtX, sqrtXdag, sqrtY, sqrtYdag,
+                                 Instrument, StateReflection,
                                  to_matrix_gate)
         from scipy.sparse import lil_matrix
         import json
@@ -1083,18 +1084,20 @@ class TestJSON(unittest.TestCase):
 
             r = random.random()
 
+            ref.set_Haar_random_state()
+
             gates = [
                 Identity(get_index()), X(get_index()), Y(get_index()), Z(get_index()), H(get_index()), S(get_index()), Sdag(get_index()), T(
                     get_index()), Tdag(get_index()), sqrtX(get_index()), sqrtXdag(get_index()),
                 sqrtY(get_index()), sqrtYdag(get_index()),
                 Probabilistic([r, 1.0 - r], [X(0), Y(0)]), CPTP(
-                    [P0(get_index()), P1(get_index())]),  # Instrument([P0(0), P1(0)], 1), Adaptive(X(0), adap),
+                    [P0(get_index()), P1(get_index())]),  Instrument([P0(0), P1(0)], 1),
                 CNOT(0, 1), CZ(0, 1), SWAP(0, 1), TOFFOLI(0, 1, 2), FREDKIN(
                     0, 1, 2), Pauli([0, 1], [1, 2]), PauliRotation([0, 1], [1, 2], random.random()),
                 DenseMatrix(0, np.eye(2)), DenseMatrix(
                     [0, 1], np.eye(4)), SparseMatrix([0, 1], sparse_mat),
                 DiagonalMatrix([0, 1], np.ones(4)), RandomUnitary(
-                    [0, 1]),  # ReversibleBoolean([0, 1], func), StateReflection(ref),
+                    [0, 1]),  StateReflection(ref),
                 BitFlipNoise(get_index(), random.random()), DephasingNoise(get_index(), random.random()), IndependentXZNoise(
                     get_index(), random.random()), DepolarizingNoise(get_index(), random.random()), TwoQubitDepolarizingNoise(0, 1, random.random()),
                 AmplitudeDampingNoise(0, 0.1), Measurement(0, 1), merge(
@@ -1126,6 +1129,7 @@ class TestJSON(unittest.TestCase):
             for g in gates:
                 g = None
             gates = None
+            ref = None
 
         for _ in range(10):
             execute_test_gate()

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1098,6 +1098,40 @@ class TestJSON(unittest.TestCase):
         for _ in range(10):
             execute_test_gate()
 
+    def test_probabilistic_gate(self):
+        from qulacs import gate
+        from qulacs.gate import (X, Y, BitFlipNoise,
+                                 DephasingNoise, Probabilistic,
+                                 DepolarizingNoise, IndependentXZNoise,
+                                 TwoQubitDepolarizingNoise)
+        import json
+        import random
+
+        n = 3
+        r = random.random()
+        gates = [
+            Probabilistic([r, 1. - r], [X(0), Y(0)]),
+            BitFlipNoise(0, random.random()), DephasingNoise(
+                0, random.random()),
+            IndependentXZNoise(0, random.random()), DepolarizingNoise(
+                0, random.random()),
+            TwoQubitDepolarizingNoise(0, 1, random.random(
+            )),
+        ]
+
+        for g in gates:
+            json_string = g.to_json()
+            json.loads(json_string)
+            g_json = gate.from_json(json_string)
+
+            ds = g.get_distribution()
+            ds_json = g_json.get_distribution()
+
+            for i in range(len(ds)):
+                self.assertAlmostEqual(ds[i], ds_json[i])
+
+    # AmplitudeDampingNoise(0, random.random()),
+
     def test_noisy_evolution_gate(self):
         from qulacs import QuantumState, GeneralQuantumOperator, Observable, gate
         from qulacs.gate import NoisyEvolution, NoisyEvolution_fast, PauliRotation, H

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1131,55 +1131,101 @@ class TestJSON(unittest.TestCase):
                 self.assertAlmostEqual(ds[i], ds_json[i])
 
     # AmplitudeDampingNoise(0, random.random()),
+    #  CPTP([P0(0), P1(0)]), Instrument([P0(0), P1(0)], 1), Adaptive(X(0), adap),
 
-    def test_noisy_evolution_gate(self):
-        from qulacs import QuantumState, GeneralQuantumOperator, Observable, gate
-        from qulacs.gate import NoisyEvolution, NoisyEvolution_fast, PauliRotation, H
+    def test_cptp_gate(self):
+        from qulacs import QuantumState, gate
+        from qulacs.gate import P0, P1, CPTP, AmplitudeDampingNoise, Measurement
         import json
+        import random
 
         n = 2
+        cp = CPTP([P0(0), P1(0)])
+        json_string = cp.to_json()
+        # print(cp)
+        print(json_string)
+        print(dir(cp))
+        #gl = cp.gate_list()
+        # print(gl)
 
-        def execute_test_gate(is_fast):
-            observable = Observable(n)
-            observable.add_operator(1., "X 0")
+        # def execute_test_gate():
+        #     # qs = QuantumState(n)
+        #     g = AmplitudeDampingNoise(0, random.random())
+        #     json_string = g.to_json()
+        #     json.loads(json_string)
+        #     g_json = gate.from_json(json_string)
+        #     print(dir(g))
+        #     # qg = QuantumGate_CPTP()
+        #     # print(g)
+        #     # print(json_string)
+        #     # for gg in g.get_gate_list():
+        #     #     if gg.get_name == "DenseMatrixGate":
+        #     #         print(gg.get_matrix())
 
-            hamiltonian = Observable(n)
-            hamiltonian.add_operator(1., "Z 0 Z 1")
+        #     # g.get_cumulative_distribution()
+        #     # g.get_distribution()
+        #     # g.get_matrix()
+        #     # print(g.get_matrix())
 
-            c_ops = []
-            op = GeneralQuantumOperator(n)
-            op.add_operator(0., "Z 0")
-            c_ops.append(op)
+        #     # qs.set_Haar_random_state()
+        #     # qs_json = qs.copy()
+        #     # g.update_quantum_state(qs)
+        #     # g_json.update_quantum_state(qs_json)
+        #     # for i in range(n):
+        #     #     self.assertAlmostEqual(qs.get_zero_probability(
+        #     #         i), qs_json.get_zero_probability(i))
 
-            step = 10
-            time = 3.14 / step
-            dt = .001
-            if is_fast:
-                g = NoisyEvolution_fast(hamiltonian, c_ops, time)
-            else:
-                g = NoisyEvolution(hamiltonian, c_ops, time, dt)
-            json_string = g.to_json()
-            json.loads(json_string)
-            g_json = gate.from_json(json_string)
+        # for _ in range(1):
+        #     execute_test_gate()
 
-            # reference gate
-            g_ref = PauliRotation([0, 1], [3, 3], -time * 2)
+    # def test_noisy_evolution_gate(self):
+    #     from qulacs import QuantumState, GeneralQuantumOperator, Observable, gate
+    #     from qulacs.gate import NoisyEvolution, NoisyEvolution_fast, PauliRotation, H
+    #     import json
 
-            state = QuantumState(n)
-            state_ref = QuantumState(n)
-            h0 = H(0)
-            h0.update_quantum_state(state)
-            h0.update_quantum_state(state_ref)
-            for k in range(step):
-                g_json.update_quantum_state(state)
-                g_ref.update_quantum_state(state_ref)
-                exp = observable.get_expectation_value(state)
-                exp_ref = observable.get_expectation_value(state_ref)
-                self.assertAlmostEqual(exp.real, exp_ref.real)
+    #     n = 2
 
-        for _ in range(10):
-            execute_test_gate(False)
-            execute_test_gate(True)
+    #     def execute_test_gate(is_fast):
+    #         observable = Observable(n)
+    #         observable.add_operator(1., "X 0")
+
+    #         hamiltonian = Observable(n)
+    #         hamiltonian.add_operator(1., "Z 0 Z 1")
+
+    #         c_ops = []
+    #         op = GeneralQuantumOperator(n)
+    #         op.add_operator(0., "Z 0")
+    #         c_ops.append(op)
+
+    #         step = 10
+    #         time = 3.14 / step
+    #         dt = .001
+    #         if is_fast:
+    #             g = NoisyEvolution_fast(hamiltonian, c_ops, time)
+    #         else:
+    #             g = NoisyEvolution(hamiltonian, c_ops, time, dt)
+    #         json_string = g.to_json()
+    #         json.loads(json_string)
+    #         g_json = gate.from_json(json_string)
+
+    #         # reference gate
+    #         g_ref = PauliRotation([0, 1], [3, 3], -time * 2)
+
+    #         state = QuantumState(n)
+    #         state_ref = QuantumState(n)
+    #         h0 = H(0)
+    #         h0.update_quantum_state(state)
+    #         h0.update_quantum_state(state_ref)
+    #         for k in range(step):
+    #             g_json.update_quantum_state(state)
+    #             g_ref.update_quantum_state(state_ref)
+    #             exp = observable.get_expectation_value(state)
+    #             exp_ref = observable.get_expectation_value(state_ref)
+    #             self.assertAlmostEqual(exp.real, exp_ref.real)
+
+    #     for _ in range(10):
+    #         execute_test_gate(False)
+    #         execute_test_gate(True)
 
 
 if __name__ == "__main__":

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -396,6 +396,7 @@ public:
         }
         return pt;
     }
+    virtual std::vector<QuantumGateBase*> get_gate_list() { return _gate_list; }
 };
 
 /**
@@ -554,6 +555,7 @@ public:
         pt.put("assign_zero_if_not_matched", _assign_zero_if_not_matched);
         return pt;
     }
+    virtual std::vector<QuantumGateBase*> get_gate_list() { return _gate_list; }
 };
 
 /**


### PR DESCRIPTION
- TestJSON に Instrument, StateReflection, NoisyEvolution, NoisyEvolution_fast gate を追加しました
- <del>NoisyEvolution, NoisyEvolution_fast で jsonのdobule値の精度の問題があります。。</del>
- 各テスト関数とゲートの対応は、 https://github.com/qulacs/qulacs/pull/469#issuecomment-1381209368 を参照
- テストのため、QuantumGate_CPTP,QuantumGate_Instrument,QuantumGate_CPでPythonからget_gate_listを呼べるようにしました。
- QuantumGate_Probabilisticのget_gate_listにpy::return_value_policy::referenceを付与しました。（segmentation fault対策）
