### PR TITLE
Resolve clang warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,19 +204,34 @@ endif()
 
 ##### set warnings #####
 if(NOT USE_GPU)
-	set(WARNING_C "-Wall -Wextra -Werror=undef -Wlogical-op -Wmissing-include-dirs \
-	 -Wpointer-arith -Winit-self -Wfloat-equal -Wsuggest-attribute=noreturn \
-	 -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=missing-declarations -Werror=return-type \
-	 -Werror=incompatible-pointer-types -Werror=format=2 -Wredundant-decls -Wmissing-noreturn \
-	 -Wimplicit-fallthrough=5 -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Wdate-time \
-	 -Wnested-externs -fdiagnostics-color=auto")
-	set(WARNING_CPP "-Wall -Wextra -Wlogical-op -Wmissing-include-dirs \
-	 -Wpointer-arith -Winit-self -Wfloat-equal -Wsuggest-attribute=noreturn \
-	 -Werror=missing-declarations -Werror=return-type \
-	 -Werror=format=2 -Wredundant-decls -Wmissing-noreturn \
-	 -Wimplicit-fallthrough=5 -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Wdate-time \
-	 -fdiagnostics-color=auto")
-	 # -Werror=undef is eliminated due to conflict with boost
+	if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+		set(WARNING_C "-Wall -Wextra -Werror=undef -Wlogical-op -Wmissing-include-dirs \
+			-Wpointer-arith -Winit-self -Wfloat-equal -Wsuggest-attribute=noreturn \
+			-Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=missing-declarations -Werror=return-type \
+			-Werror=incompatible-pointer-types -Werror=format=2 -Wredundant-decls -Wmissing-noreturn \
+			-Wimplicit-fallthrough=5 -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Wdate-time \
+			-Wnested-externs -fdiagnostics-color=auto")
+		set(WARNING_CPP "-Wall -Wextra -Wlogical-op -Wmissing-include-dirs \
+			-Wpointer-arith -Winit-self -Wfloat-equal -Wsuggest-attribute=noreturn \
+			-Werror=missing-declarations -Werror=return-type \
+			-Werror=format=2 -Wredundant-decls -Wmissing-noreturn \
+			-Wimplicit-fallthrough=5 -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Wdate-time \
+			-fdiagnostics-color=auto")
+		# -Werror=undef is eliminated due to conflict with boost
+	elseif ((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") OR (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang"))
+		set(WARNING_C "-Wall -Wextra -Werror=undef -Wmissing-include-dirs \
+			-Wpointer-arith -Winit-self -Wfloat-equal \
+			-Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=missing-declarations -Werror=return-type \
+			-Werror=incompatible-pointer-types -Werror=format=2 -Wredundant-decls -Wmissing-noreturn \
+			-Wimplicit-fallthrough -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Wdate-time \
+			-Wnested-externs -fdiagnostics-color=auto")
+		set(WARNING_CPP "-Wall -Wextra -Wmissing-include-dirs \
+			-Wpointer-arith -Winit-self -Wfloat-equal \
+			-Werror=missing-declarations -Werror=return-type \
+			-Werror=format=2 -Wredundant-decls -Wmissing-noreturn \
+			-Wimplicit-fallthrough -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Wdate-time \
+			-fdiagnostics-color=auto")
+	endif()
 endif()
 
 ##### set output directory #####

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 add_executable(csim_benchmark EXCLUDE_FROM_ALL libcsim_benchmark.cpp)
 add_executable(cppsim_benchmark EXCLUDE_FROM_ALL libcppsim_benchmark.cpp)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 
 # In MSYS, Cygwin environment, pybind11_add_module does not work.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 # add warning flags
 if(NOT MSVC)

--- a/src/cppsim/CMakeLists.txt
+++ b/src/cppsim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB CPPSIM_SRC
     "*.cpp"

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -272,8 +272,8 @@ std::string QuantumCircuit::to_string() const {
     UINT max_block_size = 0;
 
     for (const auto gate : this->_gate_list) {
-        UINT whole_qubit_index_count = (UINT)(
-            gate->target_qubit_list.size() + gate->control_qubit_list.size());
+        UINT whole_qubit_index_count = (UINT)(gate->target_qubit_list.size() +
+                                              gate->control_qubit_list.size());
         if (whole_qubit_index_count == 0) continue;
         gate_size_count[whole_qubit_index_count - 1]++;
         max_block_size = std::max(max_block_size, whole_qubit_index_count);

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -272,8 +272,8 @@ std::string QuantumCircuit::to_string() const {
     UINT max_block_size = 0;
 
     for (const auto gate : this->_gate_list) {
-        UINT whole_qubit_index_count = (UINT)(gate->target_qubit_list.size() +
-                                              gate->control_qubit_list.size());
+        UINT whole_qubit_index_count = (UINT)(
+            gate->target_qubit_list.size() + gate->control_qubit_list.size());
         if (whole_qubit_index_count == 0) continue;
         gate_size_count[whole_qubit_index_count - 1]++;
         max_block_size = std::max(max_block_size, whole_qubit_index_count);

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -137,7 +137,7 @@ public:
      *
      * @param[in] circuit マージする量子回路
      */
-    virtual void merge_circuit(const QuantumCircuit* circuit) {
+    void merge_circuit(const QuantumCircuit* circuit) {
         for (auto gate : circuit->gate_list) {
             this->add_gate_copy(gate);
         }

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -460,8 +460,8 @@ QuantumGate_CPTP* AmplitudeDampingNoise(UINT target_index, double prob) {
     ComplexMatrix damping_matrix_0(2, 2), damping_matrix_1(2, 2);
     damping_matrix_0 << 1, 0, 0, sqrt(1 - prob);
     damping_matrix_1 << 0, sqrt(prob), 0, 0;
-    auto gate0 = DenseMatrix({target_index}, damping_matrix_0);
-    auto gate1 = DenseMatrix({target_index}, damping_matrix_1);
+    auto gate0 = DenseMatrix(target_index, damping_matrix_0);
+    auto gate1 = DenseMatrix(target_index, damping_matrix_1);
     auto new_gate = new QuantumGate_CPTP({gate0, gate1});
     delete gate0;
     delete gate1;

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -209,7 +209,7 @@ public:
         return;
     }
 
-    virtual bool is_noise() { return true; }
+    virtual bool is_noise() override { return true; }
 };
 
 /**

--- a/src/cppsim/gate_matrix.hpp
+++ b/src/cppsim/gate_matrix.hpp
@@ -149,5 +149,5 @@ public:
     friend DllExport std::ostream& operator<<(
         std::ostream& os, QuantumGateMatrix* gate);
 
-    virtual QuantumGateMatrix* get_inverse(void) const;
+    virtual QuantumGateMatrix* get_inverse(void) const override;
 };

--- a/src/cppsim/gate_named_one.cpp
+++ b/src/cppsim/gate_named_one.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "gate_factory.hpp"
 
 ClsOneQubitGate* ClsOneQubitGate::get_inverse(void) const {

--- a/src/cppsim/gate_named_one.hpp
+++ b/src/cppsim/gate_named_one.hpp
@@ -278,7 +278,7 @@ public:
         this->_matrix_element << 0, 0, 0, 1;
     }
 
-    virtual ClsOneQubitGate* get_inverse(void) const;
+    virtual ClsOneQubitGate* get_inverse(void) const override;
 };
 
 /**
@@ -383,7 +383,7 @@ public:
         this->_matrix_element << cos(_angle / 2) + 1.i * sin(_angle / 2), 0, 0,
             cos(_angle / 2) - 1.i * sin(_angle / 2);
     }
-    virtual ClsOneQubitRotationGate* get_inverse(void) const;
+    virtual ClsOneQubitRotationGate* get_inverse(void) const override;
 };
 
 using QuantumGate_OneQubit = ClsOneQubitGate;

--- a/src/cppsim/gate_noisy_evolution.cpp
+++ b/src/cppsim/gate_noisy_evolution.cpp
@@ -19,6 +19,7 @@
 #include "state.hpp"
 #include "type.hpp"
 #include "utility.hpp"
+
 double ClsNoisyEvolution::_find_collapse(QuantumStateBase* k1,
     QuantumStateBase* k2, QuantumStateBase* k3, QuantumStateBase* k4,
     QuantumStateBase* prev_state, QuantumStateBase* now_state,
@@ -272,10 +273,10 @@ void ClsNoisyEvolution::update_quantum_state(QuantumStateBase* state) {
             }
 
             // determine which collapse operator to be applied
-            auto jump_r = _random.uniform() * prob_sum;
-            auto ite = std::lower_bound(
+            const auto jump_r = _random.uniform() * prob_sum;
+            const auto ite = std::lower_bound(
                 cumulative_dist.begin(), cumulative_dist.end(), jump_r);
-            auto index = std::distance(cumulative_dist.begin(), ite);
+            const auto index = static_cast<size_t>(std::distance(cumulative_dist.begin(), ite));
 
             // apply the collapse operator and normalize the state
             // ルンゲクッタ法の誤差により、normが1にならない場合があります。

--- a/src/cppsim/gate_noisy_evolution.cpp
+++ b/src/cppsim/gate_noisy_evolution.cpp
@@ -276,7 +276,8 @@ void ClsNoisyEvolution::update_quantum_state(QuantumStateBase* state) {
             const auto jump_r = _random.uniform() * prob_sum;
             const auto ite = std::lower_bound(
                 cumulative_dist.begin(), cumulative_dist.end(), jump_r);
-            const auto index = static_cast<size_t>(std::distance(cumulative_dist.begin(), ite));
+            const auto index = static_cast<size_t>(
+                std::distance(cumulative_dist.begin(), ite));
 
             // apply the collapse operator and normalize the state
             // ルンゲクッタ法の誤差により、normが1にならない場合があります。

--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -97,7 +97,7 @@ public:
         this->_find_collapse_max_steps = n;
     }
 
-    virtual void update_quantum_state(QuantumStateBase* state);
+    virtual void update_quantum_state(QuantumStateBase* state) override;
 };
 
 /*
@@ -203,7 +203,7 @@ public:
      *
      * @param state 更新する量子状態
      */
-    virtual void update_quantum_state(QuantumStateBase* state);
+    virtual void update_quantum_state(QuantumStateBase* state) override;
 };
 
 // noisyEvolution_auto
@@ -341,7 +341,7 @@ public:
             it->set_seed(seed);
         }
     };
-    virtual void update_quantum_state(QuantumStateBase* state) {
+    virtual void update_quantum_state(QuantumStateBase* state) override {
         for (auto gate : gates) {
             gate->update_quantum_state(state);
         }

--- a/src/cppsim/matrix_decomposition.hpp
+++ b/src/cppsim/matrix_decomposition.hpp
@@ -159,13 +159,13 @@ KAK_data KAK_decomposition_internal(QuantumGateBase* target_gate) {
 
     a0 *= std::exp(1.0i * wxyz[0]);
     QuantumGateMatrix* a0_gate =
-        gate::DenseMatrix({target_gate->get_target_index_list()[0]}, a0);
+        gate::DenseMatrix(target_gate->get_target_index_list()[0], a0);
     QuantumGateMatrix* a1_gate =
-        gate::DenseMatrix({target_gate->get_target_index_list()[1]}, a1);
+        gate::DenseMatrix(target_gate->get_target_index_list()[1], a1);
     QuantumGateMatrix* b0_gate =
-        gate::DenseMatrix({target_gate->get_target_index_list()[0]}, b0);
+        gate::DenseMatrix(target_gate->get_target_index_list()[0], b0);
     QuantumGateMatrix* b1_gate =
-        gate::DenseMatrix({target_gate->get_target_index_list()[1]}, b1);
+        gate::DenseMatrix(target_gate->get_target_index_list()[1], b1);
 
     ans.single_qubit_operations_after[0] = a0_gate;
     ans.single_qubit_operations_after[1] = a1_gate;

--- a/src/cppsim/observable.hpp
+++ b/src/cppsim/observable.hpp
@@ -68,7 +68,7 @@ public:
      * @param[in] pauli_string
      * パウリ演算子と掛かるindexの組からなる文字列。(example: "X 1 Y 2 Z 5")
      */
-    void add_operator(CPPCTYPE coef, std::string pauli_string);
+    void add_operator(CPPCTYPE coef, std::string pauli_string) override;
 
     /**
      * \~japanese-en
@@ -98,7 +98,7 @@ public:
      *
      * @return 自身のディープコピー
      */
-    virtual HermitianQuantumOperator* copy() const {
+    virtual HermitianQuantumOperator* copy() const override {
         auto hermitian_quantum_operator =
             new HermitianQuantumOperator(this->get_qubit_count());
         for (auto pauli : this->get_terms()) {

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -79,7 +79,7 @@ PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list,
         } else {
             throw InvalidPauliIdentifierException(
                 "invalid Pauli string is given : " +
-                Pauli_operator_type_list[term_index]);
+                std::string{Pauli_operator_type_list[term_index]});
         }
 
         if (pauli_type != 0)

--- a/src/cppsim/qubit_info.hpp
+++ b/src/cppsim/qubit_info.hpp
@@ -18,6 +18,8 @@ class DllExport QubitInfo {
 protected:
     UINT _index; /**< \~japanese-en 量子ビットの添え字 */
 public:
+    virtual ~QubitInfo() {}
+
     /**
      * \~japanese-en 量子ビットの添え字を返す
      *

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -196,7 +196,7 @@ public:
     /**
      * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
      */
-    virtual void load(const QuantumStateBase* _state) {
+    virtual void load(const QuantumStateBase* _state) override {
         if (_state->qubit_count != this->qubit_count) {
             throw InvalidQubitCountException(
                 "Error: DensityMatrixCpu::load(const QuantumStateBase*): "
@@ -220,7 +220,7 @@ public:
     /**
      * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
      */
-    virtual void load(const std::vector<CPPCTYPE>& _state) {
+    virtual void load(const std::vector<CPPCTYPE>& _state) override {
         if (_state.size() != _dim && _state.size() != _dim * _dim) {
             throw InvalidStateVectorSizeException(
                 "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
@@ -266,7 +266,7 @@ public:
     /**
      * \~japanese-en <code>state</code>の量子状態を自身へコピーする。
      */
-    virtual void load(const CPPCTYPE* _state) {
+    virtual void load(const CPPCTYPE* _state) override {
         memcpy(
             this->data_cpp(), _state, (size_t)(sizeof(CPPCTYPE) * _dim * _dim));
     }
@@ -401,7 +401,7 @@ public:
         random.set_seed(random_seed);
         return this->sampling(sampling_count);
     }
-    virtual std::string to_string() const {
+    virtual std::string to_string() const override {
         std::stringstream os;
         ComplexMatrix eigen_state(this->dim, this->dim);
         auto data = this->data_cpp();

--- a/src/csim/CMakeLists.txt
+++ b/src/csim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB CSIM_SRC
     "*.cpp"

--- a/src/gpusim/CMakeLists.txt
+++ b/src/gpusim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 find_package(CUDA REQUIRED)
 if (MSVC)

--- a/src/vqcsim/CMakeLists.txt
+++ b/src/vqcsim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB VQCSIM_SRC
     "*.cpp"

--- a/src/vqcsim/parametric_circuit.hpp
+++ b/src/vqcsim/parametric_circuit.hpp
@@ -44,7 +44,7 @@ public:
      * @param[in] circuit マージする量子回路
      */
     virtual void merge_circuit(const ParametricQuantumCircuit* circuit);
-    virtual std::string to_string() const;
+    virtual std::string to_string() const override;
     friend DllExport std::ostream& operator<<(
         std::ostream& os, const ParametricQuantumCircuit&);
     friend DllExport std::ostream& operator<<(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 add_subdirectory(csim)
 add_subdirectory(cppsim)

--- a/test/cppsim/CMakeLists.txt
+++ b/test/cppsim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB CPPSIM_TEST_SRC "*.cpp")
 

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -746,6 +746,8 @@ TEST(CircuitTest, RandomCircuitOptimize3) {
     std::vector<UINT> qubit_list;
     for (int i = 0; i < n; ++i) qubit_list.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
         QuantumState state(n), org_state(n), test_state(n);
         state.set_Haar_random_state();
@@ -753,7 +755,7 @@ TEST(CircuitTest, RandomCircuitOptimize3) {
         QuantumCircuit circuit(n);
 
         for (UINT d = 0; d < depth; ++d) {
-            std::random_shuffle(qubit_list.begin(), qubit_list.end());
+            std::shuffle(qubit_list.begin(), qubit_list.end(), engine);
             std::vector<UINT> mylist;
             mylist.push_back(qubit_list[0]);
             mylist.push_back(qubit_list[1]);

--- a/test/cppsim/test_circuit_optimize_light.cpp
+++ b/test/cppsim/test_circuit_optimize_light.cpp
@@ -253,6 +253,8 @@ TEST(CircuitTest, RandomCircuitOptimizeLight3) {
     std::vector<UINT> qubit_list;
     for (int i = 0; i < n; ++i) qubit_list.push_back(i);
 
+        std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
         QuantumState state(n), org_state(n), test_state(n);
         state.set_Haar_random_state();
@@ -260,7 +262,7 @@ TEST(CircuitTest, RandomCircuitOptimizeLight3) {
         QuantumCircuit circuit(n);
 
         for (UINT d = 0; d < depth; ++d) {
-            std::random_shuffle(qubit_list.begin(), qubit_list.end());
+                    std::shuffle(qubit_list.begin(), qubit_list.end(), engine);
             std::vector<UINT> mylist;
             mylist.push_back(qubit_list[0]);
             mylist.push_back(qubit_list[1]);

--- a/test/cppsim/test_circuit_optimize_light.cpp
+++ b/test/cppsim/test_circuit_optimize_light.cpp
@@ -253,7 +253,7 @@ TEST(CircuitTest, RandomCircuitOptimizeLight3) {
     std::vector<UINT> qubit_list;
     for (int i = 0; i < n; ++i) qubit_list.push_back(i);
 
-        std::random_device seed_gen;
+    std::random_device seed_gen;
     std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < max_repeat; ++repeat) {
         QuantumState state(n), org_state(n), test_state(n);
@@ -262,7 +262,7 @@ TEST(CircuitTest, RandomCircuitOptimizeLight3) {
         QuantumCircuit circuit(n);
 
         for (UINT d = 0; d < depth; ++d) {
-                    std::shuffle(qubit_list.begin(), qubit_list.end(), engine);
+            std::shuffle(qubit_list.begin(), qubit_list.end(), engine);
             std::vector<UINT> mylist;
             mylist.push_back(qubit_list[0]);
             mylist.push_back(qubit_list[1]);

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1081,6 +1081,8 @@ TEST(GateTest, RandomControlMergeSmall) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (gate_count = 1; gate_count < n * 2; ++gate_count) {
         ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
         QuantumState state(n), test_state(n);
@@ -1092,7 +1094,7 @@ TEST(GateTest, RandomControlMergeSmall) {
         QuantumGateBase* merge_gate1 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-            std::random_shuffle(arr.begin(), arr.end());
+            std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
@@ -1130,6 +1132,8 @@ TEST(GateTest, RandomControlMergeLarge) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (gate_count = 1; gate_count < n * 2; ++gate_count) {
         ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
         QuantumState state(n), test_state(n);
@@ -1142,7 +1146,7 @@ TEST(GateTest, RandomControlMergeLarge) {
         QuantumGateBase* merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-            std::random_shuffle(arr.begin(), arr.end());
+            std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
@@ -1157,7 +1161,7 @@ TEST(GateTest, RandomControlMergeLarge) {
         }
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-            std::random_shuffle(arr.begin(), arr.end());
+            std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);

--- a/test/cppsim/test_gate_dm.cpp
+++ b/test/cppsim/test_gate_dm.cpp
@@ -649,7 +649,7 @@ TEST(DensityMatrixGateTest, RandomControlMergeSmall) {
         QuantumGateBase* merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-                    std::shuffle(arr.begin(), arr.end(), engine);
+            std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
@@ -688,7 +688,7 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
-        std::random_device seed_gen;
+    std::random_device seed_gen;
     std::mt19937 engine(seed_gen());
     for (gate_count = 1; gate_count < n * 2; ++gate_count) {
         ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
@@ -703,7 +703,7 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
         QuantumGateBase* merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-                    std::shuffle(arr.begin(), arr.end(), engine);
+            std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);

--- a/test/cppsim/test_gate_dm.cpp
+++ b/test/cppsim/test_gate_dm.cpp
@@ -635,6 +635,8 @@ TEST(DensityMatrixGateTest, RandomControlMergeSmall) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (gate_count = 1; gate_count < n * 2; ++gate_count) {
         ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
         DensityMatrix state(n);
@@ -647,7 +649,7 @@ TEST(DensityMatrixGateTest, RandomControlMergeSmall) {
         QuantumGateBase* merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-            std::random_shuffle(arr.begin(), arr.end());
+                    std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
@@ -686,6 +688,8 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+        std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (gate_count = 1; gate_count < n * 2; ++gate_count) {
         ComplexMatrix mat = ComplexMatrix::Identity(dim, dim);
         DensityMatrix state(n), state2(n);
@@ -699,7 +703,7 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
         QuantumGateBase* merge_gate2 = gate::Identity(0);
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-            std::random_shuffle(arr.begin(), arr.end());
+                    std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
@@ -714,7 +718,7 @@ TEST(DensityMatrixGateTest, RandomControlMergeLarge) {
         }
 
         for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-            std::random_shuffle(arr.begin(), arr.end());
+            std::shuffle(arr.begin(), arr.end(), engine);
             UINT target = arr[0];
             UINT control = arr[1];
             auto new_gate = gate::CNOT(control, target);
@@ -765,8 +769,10 @@ TEST(DensityMatrixGateTest, MultiTarget) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < 10; ++repeat) {
-        std::random_shuffle(arr.begin(), arr.end());
+        std::shuffle(arr.begin(), arr.end(), engine);
         std::vector<UINT> target_list;
         for (UINT i = 0; i < target_count; ++i) target_list.push_back(arr[i]);
         QuantumGateBase* gate = gate::RandomUnitary(target_list);
@@ -801,8 +807,10 @@ TEST(DensityMatrixGateTest, MultiControlSingleTarget) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < 10; ++repeat) {
-        std::random_shuffle(arr.begin(), arr.end());
+        std::shuffle(arr.begin(), arr.end(), engine);
         std::vector<UINT> target_list;
         target_list.push_back(arr[0]);
         auto gate = gate::RandomUnitary(target_list);
@@ -840,8 +848,10 @@ TEST(DensityMatrixGateTest, SingleControlMultiTarget) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < 10; ++repeat) {
-        std::random_shuffle(arr.begin(), arr.end());
+        std::shuffle(arr.begin(), arr.end(), engine);
         std::vector<UINT> target_list;
         for (UINT i = 0; i < target_count; ++i) target_list.push_back(arr[i]);
         UINT control = arr[target_count + 1];
@@ -880,8 +890,10 @@ TEST(DensityMatrixGateTest, MultiControlMultiTarget) {
     std::vector<UINT> arr;
     for (UINT i = 0; i < n; ++i) arr.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT repeat = 0; repeat < 10; ++repeat) {
-        std::random_shuffle(arr.begin(), arr.end());
+        std::shuffle(arr.begin(), arr.end(), engine);
         std::vector<UINT> target_list;
         for (UINT i = 0; i < target_count; ++i) target_list.push_back(arr[i]);
         auto gate = gate::RandomUnitary(target_list);

--- a/test/csim/CMakeLists.txt
+++ b/test/csim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB CSIM_TEST_SRC "*.cpp")
 

--- a/test/csim/test_stat.cpp
+++ b/test/csim/test_stat.cpp
@@ -336,7 +336,8 @@ TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+            std::shuffle(
+                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -396,7 +397,8 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopPartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+            std::shuffle(
+                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -581,7 +583,8 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudePartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+            std::shuffle(
+                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -651,7 +654,8 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopPartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+            std::shuffle(
+                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);

--- a/test/csim/test_stat.cpp
+++ b/test/csim/test_stat.cpp
@@ -304,6 +304,8 @@ TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
     const auto Y = make_Y();
     const auto Z = make_Z();
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     CTYPE* state = allocate_quantum_state(dim);
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -334,8 +336,7 @@ TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::random_shuffle(
-                pauli_partial_pair.begin(), pauli_partial_pair.end());
+            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -366,6 +367,8 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopPartialTest) {
     const auto Y = make_Y();
     const auto Z = make_Z();
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     CTYPE* state = allocate_quantum_state(dim);
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state, dim);
@@ -393,8 +396,7 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopPartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::random_shuffle(
-                pauli_partial_pair.begin(), pauli_partial_pair.end());
+            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -542,6 +544,8 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudePartialTest) {
     const auto Y = make_Y();
     const auto Z = make_Z();
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state_ket, dim);
         initialize_Haar_random_state(state_bra, dim);
@@ -577,8 +581,7 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudePartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::random_shuffle(
-                pauli_partial_pair.begin(), pauli_partial_pair.end());
+            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -613,6 +616,8 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopPartialTest) {
     const auto Y = make_Y();
     const auto Z = make_Z();
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         initialize_Haar_random_state(state_ket, dim);
         initialize_Haar_random_state(state_bra, dim);
@@ -646,8 +651,7 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopPartialTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::random_shuffle(
-                pauli_partial_pair.begin(), pauli_partial_pair.end());
+            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_index.push_back(val.first);
                 pauli_partial.push_back(val.second);

--- a/test/csim/test_update_control.cpp
+++ b/test/csim/test_update_control.cpp
@@ -110,9 +110,12 @@ void test_two_control_single_target(std::function<void(
 
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
+
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // two qubit control-10 single qubit gate
-        std::random_shuffle(index_list.begin(), index_list.end());
+        std::shuffle(index_list.begin(), index_list.end(), engine);
         target = index_list[0];
         controls[0] = index_list[1];
         controls[1] = index_list[2];
@@ -184,11 +187,13 @@ TEST(UpdateTest, SingleQubitControlTwoQubitDenseMatrixTest) {
 
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // single qubit 1-controlled qubit dense matrix gate
         U = get_eigen_matrix_random_single_qubit_unitary();
         U2 = get_eigen_matrix_random_single_qubit_unitary();
-        std::random_shuffle(index_list.begin(), index_list.end());
+        std::shuffle(index_list.begin(), index_list.end(), engine);
         targets[0] = index_list[0];
         targets[1] = index_list[1];
         control = index_list[2];
@@ -232,11 +237,14 @@ TEST(UpdateTest, TwoQubitControlTwoQubitDenseMatrixTest) {
 
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
+
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // two qubit control-11 two qubit gate
         U = get_eigen_matrix_random_single_qubit_unitary();
         U2 = get_eigen_matrix_random_single_qubit_unitary();
-        std::random_shuffle(index_list.begin(), index_list.end());
+        std::shuffle(index_list.begin(), index_list.end(), engine);
         targets[0] = index_list[0];
         targets[1] = index_list[1];
         controls[0] = index_list[2];

--- a/test/csim/test_update_dense.cpp
+++ b/test/csim/test_update_dense.cpp
@@ -81,13 +81,16 @@ void test_general_dense_matrix_gate(
 
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
+
     // general single
     {
         Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> Umerge;
         for (UINT rep = 0; rep < max_repeat; ++rep) {
             // two qubit dense matrix gate
             U1 = get_eigen_matrix_random_single_qubit_unitary();
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             Umerge = U1;
 
@@ -108,7 +111,7 @@ void test_general_dense_matrix_gate(
             U1 = get_eigen_matrix_random_single_qubit_unitary();
             U2 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             Umerge = kronecker_product(U2, U1);
@@ -125,14 +128,15 @@ void test_general_dense_matrix_gate(
     // general triple
     {
         Eigen::Matrix<std::complex<double>, 8, 8, Eigen::RowMajor> Umerge;
-
+        std::random_device seed_gen;
+        std::mt19937 engine(seed_gen());
         for (UINT rep = 0; rep < max_repeat; ++rep) {
             // two qubit dense matrix gate
             U1 = get_eigen_matrix_random_single_qubit_unitary();
             U2 = get_eigen_matrix_random_single_qubit_unitary();
             U3 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             targets[2] = index_list[2];

--- a/test/csim/test_update_dense_double.cpp
+++ b/test/csim/test_update_dense_double.cpp
@@ -34,12 +34,15 @@ void test_double_dense_matrix_gate(
 
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
+
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // two qubit dense matrix gate
         U = get_eigen_matrix_random_single_qubit_unitary();
         U2 = get_eigen_matrix_random_single_qubit_unitary();
 
-        std::random_shuffle(index_list.begin(), index_list.end());
+        std::shuffle(index_list.begin(), index_list.end(), engine);
 
         targets[0] = index_list[0];
         targets[1] = index_list[1];
@@ -62,12 +65,13 @@ void test_double_dense_matrix_gate(
             test_pairs.push_back(std::make_pair(i, j));
         }
     }
+
     for (auto pair : test_pairs) {
         // two qubit dense matrix gate
         U = get_eigen_matrix_random_single_qubit_unitary();
         U2 = get_eigen_matrix_random_single_qubit_unitary();
 
-        std::random_shuffle(index_list.begin(), index_list.end());
+        std::shuffle(index_list.begin(), index_list.end(), engine);
         targets[0] = pair.first;
         targets[1] = pair.second;
         Umerge = kronecker_product(U2, U);

--- a/test/csim/test_update_diagonal_multi.cpp
+++ b/test/csim/test_update_diagonal_multi.cpp
@@ -27,10 +27,12 @@ TEST(UpdateTest, MultiQubitDiagonalMatrixTest) {
     for (ITYPE i = 0; i < dim; ++i)
         test_state[i] = (std::complex<double>)state[i];
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT gate_size = 1; gate_size <= 1; ++gate_size) {
         ITYPE gate_dim = (1ULL) << gate_size;
         for (UINT r = 0; r < max_repeat; ++r) {
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             auto diag =
                 get_eigen_diagonal_matrix_random_multi_qubit_unitary(gate_size);
             Eigen::MatrixXcd matrix = Eigen::MatrixXcd::Zero(dim, dim);
@@ -70,10 +72,12 @@ TEST(UpdateTest, MultiQubitDiagonalMatrixTest2) {
     for (ITYPE i = 0; i < dim; ++i)
         test_state[i] = (std::complex<double>)state[i];
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT gate_size = 1; gate_size <= 1; ++gate_size) {
         ITYPE gate_dim = (1ULL) << gate_size;
         for (UINT r = 0; r < max_repeat; ++r) {
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             auto diag =
                 get_eigen_diagonal_matrix_random_multi_qubit_unitary(gate_size);
             Eigen::MatrixXcd matrix = Eigen::MatrixXcd::Zero(dim, dim);
@@ -120,11 +124,13 @@ TEST(UpdateTest, TwoQubitControlTwoQubitDiagonalMatrixTest) {
 
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // two qubit control-11 two qubit gate
         d = get_eigen_diagonal_matrix_random_multi_qubit_unitary(1);
         d2 = get_eigen_diagonal_matrix_random_multi_qubit_unitary(1);
-        std::random_shuffle(index_list.begin(), index_list.end());
+        std::shuffle(index_list.begin(), index_list.end(), engine);
         targets[0] = index_list[0];
         targets[1] = index_list[1];
         controls[0] = index_list[2];

--- a/test/csim/test_update_named.cpp
+++ b/test/csim/test_update_named.cpp
@@ -26,6 +26,8 @@ void test_single_qubit_named_gate(UINT n, std::string name,
     std::vector<UINT> indices;
     for (UINT i = 0; i < n; ++i) indices.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         for (UINT i = 0; i < n; ++i) {
             UINT target = indices[i];
@@ -35,7 +37,7 @@ void test_single_qubit_named_gate(UINT n, std::string name,
                 test_state;
             state_equal(state, test_state, dim, name);
         }
-        std::random_shuffle(indices.begin(), indices.end());
+        std::shuffle(indices.begin(), indices.end(), engine);
     }
     release_quantum_state(state);
 }
@@ -152,6 +154,8 @@ void test_projection_gate(std::function<void(UINT, CTYPE*, ITYPE)> func,
     std::vector<UINT> indices;
     for (UINT i = 0; i < n; ++i) indices.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         for (int i = 0; i < n; ++i) {
             target = indices[i];
@@ -174,7 +178,7 @@ void test_projection_gate(std::function<void(UINT, CTYPE*, ITYPE)> func,
             test_state.normalize();
             state_equal(state, test_state, dim, "Projection gate");
         }
-        std::random_shuffle(indices.begin(), indices.end());
+        std::shuffle(indices.begin(), indices.end(), engine);
     }
     release_quantum_state(state);
 }
@@ -253,6 +257,8 @@ void test_two_qubit_named_gate(UINT n, std::string name,
     std::vector<UINT> indices;
     for (UINT i = 0; i < n; ++i) indices.push_back(i);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         for (UINT i = 0; i + 1 < n; i += 2) {
             UINT target = indices[i];
@@ -262,7 +268,7 @@ void test_two_qubit_named_gate(UINT n, std::string name,
             test_state = mat * test_state;
             state_equal(state, test_state, dim, name);
         }
-        std::random_shuffle(indices.begin(), indices.end());
+        std::shuffle(indices.begin(), indices.end(), engine);
     }
     release_quantum_state(state);
 }

--- a/test/csim/test_update_pauli.cpp
+++ b/test/csim/test_update_pauli.cpp
@@ -108,7 +108,8 @@ TEST(UpdateTest, MultiQubitPauliTest) {
                 pauli_partial_pair.push_back(std::make_pair(i, pauli));
             }
         }
-        std::shuffle(pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+        std::shuffle(
+            pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
         for (auto val : pauli_partial_pair) {
             pauli_partial_index.push_back(val.first);
             pauli_partial.push_back(val.second);
@@ -170,7 +171,8 @@ TEST(UpdateTest, MultiQubitPauliRotationTest) {
                 pauli_partial_pair.push_back(std::make_pair(i, pauli));
             }
         }
-        std::shuffle(            pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+        std::shuffle(
+            pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
         for (auto val : pauli_partial_pair) {
             pauli_partial_index.push_back(val.first);
             pauli_partial.push_back(val.second);

--- a/test/csim/test_update_pauli.cpp
+++ b/test/csim/test_update_pauli.cpp
@@ -81,6 +81,8 @@ TEST(UpdateTest, MultiQubitPauliTest) {
     for (ITYPE i = 0; i < dim; ++i)
         test_state[i] = (std::complex<double>)state[i];
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         // multi pauli whole
         std::vector<UINT> pauli_whole, pauli_partial, pauli_partial_index;
@@ -106,8 +108,7 @@ TEST(UpdateTest, MultiQubitPauliTest) {
                 pauli_partial_pair.push_back(std::make_pair(i, pauli));
             }
         }
-        std::random_shuffle(
-            pauli_partial_pair.begin(), pauli_partial_pair.end());
+        std::shuffle(pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
         for (auto val : pauli_partial_pair) {
             pauli_partial_index.push_back(val.first);
             pauli_partial.push_back(val.second);
@@ -138,6 +139,8 @@ TEST(UpdateTest, MultiQubitPauliRotationTest) {
     Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
     std::complex<double> imag_unit(0, 1);
 
+    std::random_device seed_gen;
+    std::mt19937 engine(seed_gen());
     for (UINT rep = 0; rep < max_repeat; ++rep) {
         std::vector<UINT> pauli_whole, pauli_partial, pauli_partial_index;
         std::vector<std::pair<UINT, UINT>> pauli_partial_pair;
@@ -167,8 +170,7 @@ TEST(UpdateTest, MultiQubitPauliRotationTest) {
                 pauli_partial_pair.push_back(std::make_pair(i, pauli));
             }
         }
-        std::random_shuffle(
-            pauli_partial_pair.begin(), pauli_partial_pair.end());
+        std::shuffle(            pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
         for (auto val : pauli_partial_pair) {
             pauli_partial_index.push_back(val.first);
             pauli_partial.push_back(val.second);

--- a/test/gpusim/CMakeLists.txt
+++ b/test/gpusim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB GPUSIM_TEST_SRC "*.cpp")
 

--- a/test/gpusim/test_gate.cpp
+++ b/test/gpusim/test_gate.cpp
@@ -1089,7 +1089,7 @@ TEST(GateTest, RandomControlMergeSmall) {
             QuantumGateBase* merge_gate2 = gate::Identity(0);
 
             for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-                std::random_shuffle(arr.begin(), arr.end());
+                std::shuffle(arr.begin(), arr.end(), engine);
                 UINT target = arr[0];
                 UINT control = arr[1];
                 auto new_gate = gate::CNOT(control, target);
@@ -1133,7 +1133,7 @@ TEST(GateTest, RandomControlMergeLarge) {
             QuantumGateBase* merge_gate2 = gate::Identity(0);
 
             for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-                std::random_shuffle(arr.begin(), arr.end());
+                std::shuffle(arr.begin(), arr.end(), engine);
                 UINT target = arr[0];
                 UINT control = arr[1];
                 auto new_gate = gate::CNOT(control, target);
@@ -1145,7 +1145,7 @@ TEST(GateTest, RandomControlMergeLarge) {
             }
 
             for (UINT gate_index = 0; gate_index < gate_count; ++gate_index) {
-                std::random_shuffle(arr.begin(), arr.end());
+                std::shuffle(arr.begin(), arr.end(), engine);
                 UINT target = arr[0];
                 UINT control = arr[1];
                 auto new_gate = gate::CNOT(control, target);

--- a/test/gpusim/test_state.cpp
+++ b/test/gpusim/test_state.cpp
@@ -453,8 +453,7 @@ TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::random_shuffle(
-                    pauli_partial_pair.begin(), pauli_partial_pair.end());
+                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);
@@ -523,8 +522,7 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopPartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::random_shuffle(
-                    pauli_partial_pair.begin(), pauli_partial_pair.end());
+                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);
@@ -771,8 +769,7 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudePartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::random_shuffle(
-                    pauli_partial_pair.begin(), pauli_partial_pair.end());
+                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);
@@ -861,8 +858,7 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopPartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::random_shuffle(
-                    pauli_partial_pair.begin(), pauli_partial_pair.end());
+                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);

--- a/test/gpusim/test_state.cpp
+++ b/test/gpusim/test_state.cpp
@@ -453,7 +453,8 @@ TEST(StatOperationTest, MultiQubitExpectationValuePartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+                std::shuffle(pauli_partial_pair.begin(),
+                    pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);
@@ -522,7 +523,8 @@ TEST(StatOperationTest, MultiQubitExpectationValueZopPartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+                std::shuffle(pauli_partial_pair.begin(),
+                    pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);
@@ -769,7 +771,8 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudePartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+                std::shuffle(pauli_partial_pair.begin(),
+                    pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);
@@ -858,7 +861,8 @@ TEST(StatOperationTest, MultiQubitTransitionAmplitudeZopPartialTest) {
                         pauli_partial_pair.push_back(std::make_pair(i, pauli));
                     }
                 }
-                std::shuffle(                    pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+                std::shuffle(pauli_partial_pair.begin(),
+                    pauli_partial_pair.end(), engine);
                 for (auto val : pauli_partial_pair) {
                     pauli_index.push_back(val.first);
                     pauli_partial.push_back(val.second);

--- a/test/gpusim/test_update_control.cpp
+++ b/test/gpusim/test_update_control.cpp
@@ -73,62 +73,6 @@ TEST(UpdateTest, SingleQubitControlSingleQubitDenseMatrixTest) {
     test_single_control_single_target(func);
 }
 
-/*
-void test_two_control_single_target(std::function<void(const UINT*, const UINT*,
-UINT, UINT, const CPPCTYPE*, void*, ITYPE)> func) { const UINT n = 6; const
-ITYPE dim = 1ULL << n; const UINT max_repeat = 10;
-
-    std::vector<UINT> index_list;
-    for (UINT i = 0; i < n; ++i) index_list.push_back(i);
-
-    Eigen::MatrixXcd P0(2, 2), P1(2, 2);
-    P0 << 1, 0, 0, 0;
-    P1 << 0, 0, 0, 1;
-
-    Eigen::Matrix<std::complex<double>, 2, 2, Eigen::RowMajor> U;
-
-    UINT target;
-    UINT controls[2];
-
-    auto state = allocate_quantum_state_host(dim);
-    initialize_Haar_random_state_host(state, dim);
-    Eigen::VectorXcd test_state = copy_cpu_from_gpu(state, dim);
-
-    Eigen::MatrixXcd whole_I = Eigen::MatrixXcd::Identity(dim, dim);
-
-    for (UINT rep = 0; rep < max_repeat; ++rep) {
-        // two qubit control-10 single qubit gate
-        std::random_shuffle(index_list.begin(), index_list.end());
-        target = index_list[0];
-        controls[0] = index_list[1];
-        controls[1] = index_list[2];
-
-        U = get_eigen_matrix_random_single_qubit_unitary();
-        UINT mvalues[2] = { 1,0 };
-        func(controls, mvalues, 2, target, (CPPCTYPE*)U.data(), state, dim);
-        test_state = (
-            get_expanded_eigen_matrix_with_identity(controls[0], P0,
-n)*get_expanded_eigen_matrix_with_identity(controls[1], P0, n) +
-            get_expanded_eigen_matrix_with_identity(controls[0], P0,
-n)*get_expanded_eigen_matrix_with_identity(controls[1], P1, n) +
-            get_expanded_eigen_matrix_with_identity(controls[0], P1,
-n)*get_expanded_eigen_matrix_with_identity(controls[1], P0,
-n)*get_expanded_eigen_matrix_with_identity(target, U, n) +
-            get_expanded_eigen_matrix_with_identity(controls[0], P1,
-n)*get_expanded_eigen_matrix_with_identity(controls[1], P1, n) ) * test_state;
-        state_equal(state, test_state, dim, "two qubit control sinlge qubit
-dense gate");
-
-    }
-    release_quantum_state_host(state);
-}
-
-TEST(UpdateTest, TwoQubitControlSingleQubitDenseMatrixTest) {
-        // not implemented
-        //test_two_control_single_target(multi_qubit_control_single_qubit_dense_matrix_gate);
-}
-*/
-
 TEST(UpdateTest, SingleQubitControlTwoQubitDenseMatrixTest) {
     const UINT n = 6;
     const ITYPE dim = 1ULL << n;
@@ -160,7 +104,7 @@ TEST(UpdateTest, SingleQubitControlTwoQubitDenseMatrixTest) {
             // single qubit 1-controlled qubit dense matrix gate
             U = get_eigen_matrix_random_single_qubit_unitary();
             U2 = get_eigen_matrix_random_single_qubit_unitary();
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             control = index_list[2];
@@ -217,7 +161,7 @@ TEST(UpdateTest, TwoQubitControlTwoQubitDenseMatrixTest) {
             // two qubit control-11 two qubit gate
             U = get_eigen_matrix_random_single_qubit_unitary();
             U2 = get_eigen_matrix_random_single_qubit_unitary();
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             controls[0] = index_list[2];

--- a/test/gpusim/test_update_dense.cpp
+++ b/test/gpusim/test_update_dense.cpp
@@ -78,7 +78,7 @@ void test_double_dense_matrix_gate(
             U = get_eigen_matrix_random_single_qubit_unitary();
             U2 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
 
             targets[0] = index_list[0];
             targets[1] = index_list[1];
@@ -138,7 +138,7 @@ void test_three_dense_matrix_gate(std::function<void(
             U2 = get_eigen_matrix_random_single_qubit_unitary();
             U3 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             targets[2] = index_list[2];
@@ -198,7 +198,7 @@ void test_quad_dense_matrix_gate(
             U3 = get_eigen_matrix_random_single_qubit_unitary();
             U4 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             targets[2] = index_list[2];
@@ -262,7 +262,7 @@ void test_penta_dense_matrix_gate(
             U4 = get_eigen_matrix_random_single_qubit_unitary();
             U5 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             targets[2] = index_list[2];
@@ -331,7 +331,7 @@ void test_general_dense_matrix_gate(std::function<void(
             U5 = get_eigen_matrix_random_single_qubit_unitary();
             U6 = get_eigen_matrix_random_single_qubit_unitary();
 
-            std::random_shuffle(index_list.begin(), index_list.end());
+            std::shuffle(index_list.begin(), index_list.end(), engine);
             targets[0] = index_list[0];
             targets[1] = index_list[1];
             targets[2] = index_list[2];

--- a/test/gpusim/test_update_named.cpp
+++ b/test/gpusim/test_update_named.cpp
@@ -31,7 +31,7 @@ void test_single_qubit_named_gate(UINT n, std::string name,
                     test_state;
                 state_equal_gpu(state, test_state, dim, name, stream_ptr, idx);
             }
-            std::random_shuffle(indices.begin(), indices.end());
+            std::shuffle(indices.begin(), indices.end(), engine);
         }
         release_quantum_state_host(state, idx);
         release_cuda_stream_host(stream_ptr, 1, idx);
@@ -244,7 +244,7 @@ void test_two_qubit_named_gate(UINT n, std::string name,
                 test_state = mat * test_state;
                 state_equal_gpu(state, test_state, dim, name, stream_ptr, idx);
             }
-            std::random_shuffle(indices.begin(), indices.end());
+            std::shuffle(indices.begin(), indices.end(), engine);
         }
         release_quantum_state_host(state, idx);
         release_cuda_stream_host(stream_ptr, 1, idx);

--- a/test/gpusim/test_update_pauli.cpp
+++ b/test/gpusim/test_update_pauli.cpp
@@ -123,7 +123,8 @@ TEST(UpdateTest, MultiQubitPauliTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+            std::shuffle(
+                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_partial_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -192,7 +193,8 @@ TEST(UpdateTest, MultiQubitPauliRotationTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
+            std::shuffle(
+                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_partial_index.push_back(val.first);
                 pauli_partial.push_back(val.second);

--- a/test/gpusim/test_update_pauli.cpp
+++ b/test/gpusim/test_update_pauli.cpp
@@ -123,8 +123,7 @@ TEST(UpdateTest, MultiQubitPauliTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::random_shuffle(
-                pauli_partial_pair.begin(), pauli_partial_pair.end());
+            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_partial_index.push_back(val.first);
                 pauli_partial.push_back(val.second);
@@ -193,8 +192,7 @@ TEST(UpdateTest, MultiQubitPauliRotationTest) {
                     pauli_partial_pair.push_back(std::make_pair(i, pauli));
                 }
             }
-            std::random_shuffle(
-                pauli_partial_pair.begin(), pauli_partial_pair.end());
+            std::shuffle(                pauli_partial_pair.begin(), pauli_partial_pair.end(), engine);
             for (auto val : pauli_partial_pair) {
                 pauli_partial_index.push_back(val.first);
                 pauli_partial.push_back(val.second);

--- a/test/vqcsim/CMakeLists.txt
+++ b/test/vqcsim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 file(GLOB VQCSIM_TEST_SRC "*.cpp")
 


### PR DESCRIPTION
close #456 
- Supply appropriate warning options to clang
- Mark `override`
- Replace `std::random_shuffle` with `std::shuffle`
  - So many replacement, but simple; no need to check thoroughly