### PR TITLE
Fix CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if(USE_TEST)
 	FetchContent_Declare(
 		googletest_fetch
 		GIT_REPOSITORY https://github.com/google/googletest
-		GIT_TAG release-1.8.1
+		GIT_TAG release-1.12.1
 	)
 	FetchContent_GetProperties(googletest_fetch)
 	if(NOT googletest_fetch_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ if (POLICY CMP0048)
 	cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)
 
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+# ref: https://github.com/qulacs/qulacs/issues/406
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+	cmake_policy(SET CMP0135 NEW)
+endif()
+
 project(qulacs)
 
 ##### Set default behavior #####
@@ -307,7 +313,7 @@ if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") OR (${CMAKE_CXX_COMPILER_ID} STREQ
 	# Add optimization flags
 	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${OPT_FLAGS}")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${OPT_FLAGS}")
-	
+
 	# Add coverage flags
 	if(COVERAGE)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")


### PR DESCRIPTION
- close #406 

Fixed the following CMake warning.

-  Fix CMake Deprecation Warning in GoogleTest source
	- Update GoogleTest to latest version
- Use CMP0135 policy's new behavior