### PR TITLE
fix build warning

### DIFF
--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -1122,11 +1122,11 @@ PYBIND11_MODULE(qulacs_core, m) {
             "Get qubit count")
 
         .def("update_quantum_state",
-            (void(QuantumCircuit::*)(QuantumStateBase*)) &
+            (void (QuantumCircuit::*)(QuantumStateBase*)) &
                 QuantumCircuit::update_quantum_state,
             "Update quantum state", py::arg("state"))
         .def("update_quantum_state",
-            (void(QuantumCircuit::*)(QuantumStateBase*, UINT, UINT)) &
+            (void (QuantumCircuit::*)(QuantumStateBase*, UINT, UINT)) &
                 QuantumCircuit::update_quantum_state,
             py::arg("state"), py::arg("start"), py::arg("end"))
         .def("calculate_depth", &QuantumCircuit::calculate_depth,

--- a/src/cppsim/gate.hpp
+++ b/src/cppsim/gate.hpp
@@ -269,7 +269,7 @@ public:
      *
      * @return ptree
      */
-    virtual boost::property_tree::ptree to_ptree() const;
+    [[noreturn]] virtual boost::property_tree::ptree to_ptree() const;
 
     virtual bool is_noise() { return false; }
     virtual void set_seed(int) { return; };
@@ -305,5 +305,5 @@ public:
         }
     }
 
-    virtual QuantumGateBase* get_inverse(void) const;
+    [[noreturn]] virtual QuantumGateBase* get_inverse(void) const;
 };

--- a/src/cppsim/gate_named_one.hpp
+++ b/src/cppsim/gate_named_one.hpp
@@ -278,7 +278,7 @@ public:
         this->_matrix_element << 0, 0, 0, 1;
     }
 
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.add("name", _name + "Gate");
         pt.add("target_qubit", _target_qubit_list[0].index());
@@ -390,7 +390,7 @@ public:
             cos(_angle / 2) - 1.i * sin(_angle / 2);
     }
 
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.add("name", _name + "Gate");
         pt.add("target_qubit", _target_qubit_list[0].index());

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -101,7 +101,7 @@ public:
      *
      * @return ptree
      */
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.add("name", "PauliGate");
         pt.add_child("pauli", _pauli->to_ptree());
@@ -207,7 +207,7 @@ public:
      *
      * @return ptree
      */
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.add("name", "PauliRotationGate");
         pt.add("angle", _angle);

--- a/src/cppsim/gate_named_two.hpp
+++ b/src/cppsim/gate_named_two.hpp
@@ -86,7 +86,7 @@ public:
      *
      * @return ptree
      */
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.add("name", _name + "Gate");
         std::vector<UINT> target_qubit_list_uint;
@@ -207,7 +207,7 @@ public:
      *
      * @return ptree
      */
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.add("name", _name + "Gate");
         pt.add("control_qubit", _control_qubit_list[0].index());

--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -102,7 +102,7 @@ public:
     /**
      * \~japanese-en ptreeに変換する
      */
-    virtual boost::property_tree::ptree to_ptree() const;
+    virtual boost::property_tree::ptree to_ptree() const override;
 };
 
 /*
@@ -213,7 +213,7 @@ public:
     /**
      * \~japanese-en ptreeに変換する
      */
-    virtual boost::property_tree::ptree to_ptree() const;
+    virtual boost::property_tree::ptree to_ptree() const override;
 };
 
 // noisyEvolution_auto

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -687,7 +687,7 @@ public:
         random.set_seed(random_seed);
         return this->sampling(sampling_count);
     }
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.put("name", "QuantumState");
         pt.put("qubit_count", _qubit_count);

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -416,7 +416,7 @@ public:
         os << " * Density matrix : \n" << eigen_state << std::endl;
         return os.str();
     }
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         boost::property_tree::ptree pt;
         pt.put("name", "DensityMatrix");
         pt.put("qubit_count", _qubit_count);

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -384,7 +384,7 @@ public:
         return os.str();
     }
 
-    virtual boost::property_tree::ptree to_ptree() const {
+    virtual boost::property_tree::ptree to_ptree() const override {
         throw NotImplementedException(
             "to_ptree for QuantumStateGpu is not implemented "
             "yet");

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <cctype>

--- a/src/csim/update_ops_matrix_dense_double.cpp
+++ b/src/csim/update_ops_matrix_dense_double.cpp
@@ -779,7 +779,6 @@ void double_qubit_dense_matrix_gate_simd_middle(UINT target_qubit_index1,
     const ITYPE loop_dim = dim / 4;
     ITYPE state_index;
 
-    // TODO: fix compile warning.
     double* ptr_vec = (double*)vec;
     char* ptr_mat_char = (char*)mat;  // workaround for compile warning
                                       // "dereferencing type-punned pointer"

--- a/src/csim/update_ops_matrix_dense_double.cpp
+++ b/src/csim/update_ops_matrix_dense_double.cpp
@@ -781,7 +781,9 @@ void double_qubit_dense_matrix_gate_simd_middle(UINT target_qubit_index1,
 
     // TODO: fix compile warning.
     double* ptr_vec = (double*)vec;
-    const double* ptr_mat = (const double*)mat;
+    char* ptr_mat_char = (char*)mat;  // workaround for compile warning
+                                      // "dereferencing type-punned pointer"
+    double* ptr_mat = (double*)ptr_mat_char;
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif

--- a/src/csim/update_ops_matrix_dense_double.cpp
+++ b/src/csim/update_ops_matrix_dense_double.cpp
@@ -737,26 +737,30 @@ void double_qubit_dense_matrix_gate_simd_low(UINT target_qubit_index1,
     }
 }
 
-__inline void _element_swap(CTYPE* vec, UINT i1, UINT i2) {
-    CTYPE temp = vec[i1];
-    vec[i1] = vec[i2];
-    vec[i2] = temp;
+__inline void _complex_element_swap(double* vec, UINT i1, UINT i2) {
+    double temp;
+    temp = vec[i1 << 1];
+    vec[i1 << 1] = vec[i2 << 1];
+    vec[i2 << 1] = temp;
+    temp = vec[i1 << 1 | 1];
+    vec[i1 << 1 | 1] = vec[i2 << 1 | 1];
+    vec[i2 << 1 | 1] = temp;
 }
 
 void double_qubit_dense_matrix_gate_simd_middle(UINT target_qubit_index1,
     UINT target_qubit_index2, const CTYPE _mat[16], CTYPE* vec, ITYPE dim) {
-    CTYPE mat[16];
+    double mat[32];
     memcpy(mat, _mat, sizeof(CTYPE) * 16);
     if (target_qubit_index2 < target_qubit_index1) {
         UINT temp = target_qubit_index1;
         target_qubit_index1 = target_qubit_index2;
         target_qubit_index2 = temp;
-        _element_swap(mat, 1, 2);
-        _element_swap(mat, 4, 8);
-        _element_swap(mat, 7, 11);
-        _element_swap(mat, 13, 14);
-        _element_swap(mat, 5, 10);
-        _element_swap(mat, 6, 9);
+        _complex_element_swap(mat, 1, 2);
+        _complex_element_swap(mat, 4, 8);
+        _complex_element_swap(mat, 7, 11);
+        _complex_element_swap(mat, 13, 14);
+        _complex_element_swap(mat, 5, 10);
+        _complex_element_swap(mat, 6, 9);
     }
     assert(target_qubit_index1 < 2);
     assert(target_qubit_index2 >= 2);
@@ -780,9 +784,7 @@ void double_qubit_dense_matrix_gate_simd_middle(UINT target_qubit_index1,
     ITYPE state_index;
 
     double* ptr_vec = (double*)vec;
-    char* ptr_mat_char = (char*)mat;  // workaround for compile warning
-                                      // "dereferencing type-punned pointer"
-    double* ptr_mat = (double*)ptr_mat_char;
+    double* ptr_mat = (double*)mat;
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif

--- a/src/vqcsim/parametric_circuit.hpp
+++ b/src/vqcsim/parametric_circuit.hpp
@@ -67,7 +67,7 @@ public:
      *
      * @return ptree
      */
-    virtual boost::property_tree::ptree to_ptree() const;
+    virtual boost::property_tree::ptree to_ptree() const override;
 };
 
 namespace circuit {


### PR DESCRIPTION
close #494
コンパイル時のWarningのうち、Qulacsのソースによるものを修正しました。

boostが原因のものはいくつか残っています(特にclangでビルドするとたくさん)。