### PR TITLE
Fix correct key for author's email address

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dynamic = ["version"]
 name = "qulacs"
 description = "Quantum circuit simulator for research"
 authors = [
-    { name = "QunaSys", Email = "qulacs@qunasys.com" }
+    { name = "QunaSys", email = "qulacs@qunasys.com" }
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
- Close #496 

authorsのemailアドレスのキーを `Email` から `email` に修正しました。