### PR TITLE
Use hendrikmuhs/ccache-action to improve cache hit rate

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -26,8 +26,8 @@ jobs:
             c_compiler: "/usr/local/opt/ccache/libexec/gcc-10"
             cxx_compiler: "/usr/local/opt/ccache/libexec/g++-10"
           - compiler: "clang"
-            c_compiler: "clang"
-            cxx_compiler: "clang++"
+            c_compiler: "/usr/local/opt/ccache/libexec/clang"
+            cxx_compiler: "/usr/local/opt/ccache/libexec/clang++"
     runs-on: "macos-11"
     env:
       C_COMPILER: ${{ matrix.c_compiler }}
@@ -43,7 +43,8 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ github.job }}-${{ matrix.os }}
+          # Include compiler to distinguish cache for each compiler.
+          key: ${{ github.job }}-${{ matrix.os }}-{{ matrix.compiler }}
           verbose: 2
 
       - name: Setup Python

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -40,28 +40,23 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}
+          verbose: 2
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Install ccache
-        if: ${{ matrix.compiler == 'gcc' }}
-        run: brew install ccache
-
       - name: Install Boost for macOS
         run: |
           brew upgrade
           brew install boost
           brew link boost
-
-      - name: Setup cache
-        if: ${{ matrix.compiler == 'gcc' }}
-        uses: actions/cache@v3
-        with:
-          path: /Users/runner/Library/Caches/ccache
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}
 
       - name: Install qulacs for macOS
         run: USE_TEST=Yes ./script/build_gcc.sh
@@ -79,7 +74,3 @@ jobs:
           cd ./build
           make test -j
           make pythontest -j
-
-      - name: Show cache stats
-        if: ${{ matrix.compiler == 'gcc' }}
-        run: ccache -s -v

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -34,20 +34,17 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}
+          verbose: 2
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
-      - name: Install ccache
-        run: sudo apt install ccache
-
-      - name: Setup cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}
 
       - name: Install boost
         run: sudo apt install libboost-dev
@@ -86,9 +83,6 @@ jobs:
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3
 
-      - name: Show cache stats
-        run: ccache -s
-
   gcc10-build-with-address-sanitizer:
     name: GCC10 build with -fsanitizer=address enabled
     runs-on: "ubuntu-20.04"
@@ -104,14 +98,11 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
-      - name: Install ccache
-        run: sudo apt install ccache
-
-      - name: Setup cache
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}
+          key: ${{ github.job }}-${{ matrix.os }}
+          verbose: 2
 
       - name: Install boost
         run: sudo apt install libboost-dev
@@ -124,9 +115,6 @@ jobs:
         run: |
           cd ./build
           make test
-
-      - name: Show cache stats
-        run: ccache -s
 
   nvcc-gcc8-GPUbuild:
     name: nvcc + gcc8 build
@@ -144,20 +132,17 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}
+          verbose: 2
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.7.5"
           architecture: x64
-
-      - name: Install ccache
-        run: sudo apt install ccache
-
-      - name: Setup cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}
 
       - name: Install boost
         run: sudo apt install libboost-dev

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
+      # TODO: In Windows, ccache is not used because its behavior is not stable.
+      # mozilla/sccache is one candidate for this situation.
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
close #355 

The cache hit rate on Ubuntu and macOS is fairly low, always near 0%.
To improve the rate of gcc compilation on CI, use hendrikmuhs/ccache-action.
I cannot figure out the reason, but the cache rate is improved.

[This CI run for Ubuntu test](https://github.com/qulacs/qulacs/actions/runs/4131392558/jobs/7138980211) marks 94% cache hit rate for the build with slightly small changes.
To see the rate, open "Post Setup ccache" step.
And [this CI run for macOS test](https://github.com/qulacs/qulacs/actions/runs/4131392559/jobs/7138980102) marks 96% for the same commit.