### PR TITLE
add explanation for get_inverse func

### DIFF
--- a/doc/en/source/intro/4.1_python_tutorial.ipynb
+++ b/doc/en/source/intro/4.1_python_tutorial.ipynb
@@ -829,6 +829,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Obtain a inverse gate from a quantum gate\n",
+    "\n",
+    "The hermitian conjugate `U†` of the generated quantum gate `U` can be obtained using a `get_inverse` function. The hermitian conjugate `U†` represents the inverse operation of the generated quantum gate `U`. If the hermitian conjugate function is not implemented, an exception is thrown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "original:\n",
+      " [[1.+0.j 0.+0.j]\n",
+      " [0.+0.j 0.+1.j]]\n",
+      "inversed:\n",
+      " [[ 1.+0.j  0.+0.j]\n",
+      " [ 0.+0.j -0.-1.j]]\n",
+      "Exception occured as expected: this gate don't have get_inverse function\n"
+     ]
+    }
+   ],
+   "source": [
+    "from qulacs.gate import S, DepolarizingNoise\n",
+    "\n",
+    "s_gate = S(2)\n",
+    "s_dagger_gate = s_gate.get_inverse()\n",
+    "print(\"original:\\n\", s_gate.get_matrix())\n",
+    "print(\"inversed:\\n\", s_dagger_gate.get_matrix())\n",
+    "\n",
+    "noise_gate = DepolarizingNoise(0, 0.05)\n",
+    "try:\n",
+    "        noise_gate.get_inverse()\n",
+    "        assert 0, \"No exception occured. should not reach here.\"\n",
+    "except Exception as err:\n",
+    "        print(f\"Exception occured as expected: {err}\")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -946,11 +990,63 @@
     "circuit.update_quantum_state(state)\n",
     "print(state)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Obtain a inverse circuit from a quantum circuit\n",
+    "\n",
+    "An inverse circuit of the quantum circuit can be obtained using a `get_inverse` function, as with the quantum gate.\n",
+    "If the quantum circuit contains quantum gates such that hermitian transpose is not implemented, an exception is thrown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " *** Quantum State ***\n",
+      " * Qubit Count : 3\n",
+      " * Dimension   : 8\n",
+      " * State vector : \n",
+      "(1,0)\n",
+      "(0,0)\n",
+      "(0,0)\n",
+      "(0,0)\n",
+      "(0,0)\n",
+      "(0,0)\n",
+      "(0,0)\n",
+      "(0,0)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from qulacs import QuantumCircuit\n",
+    "\n",
+    "n=3\n",
+    "circuit = QuantumCircuit(n)\n",
+    "circuit.add_H_gate(1)\n",
+    "circuit.add_RX_gate(2,0.1)\n",
+    "\n",
+    "inverse_circuit = circuit.get_inverse()\n",
+    "\n",
+    "from qulacs import QuantumState\n",
+    "state = QuantumState(n)\n",
+    "circuit.update_quantum_state(state)\n",
+    "inverse_circuit.update_quantum_state(state)\n",
+    "print(state)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.9.10 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -964,11 +1060,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4 (main, May  9 2022, 18:28:02) [GCC 9.4.0]"
+   "version": "3.9.10"
   },
   "vscode": {
    "interpreter": {
-    "hash": "84aa2c67dae1159a9469e7ac93262a46ff5158e6dcd4abab35ce17cbce36ce1e"
+    "hash": "949777d72b0d2535278d3dc13498b2535136f6dfe0678499012e853ee9abcab1"
    }
   }
  },

--- a/doc/ja/source/intro/4.1_python_tutorial.md
+++ b/doc/ja/source/intro/4.1_python_tutorial.md
@@ -444,6 +444,36 @@ print(matrix)
  [1.+0.j 0.+0.j]]
 ```
 
+## 量子ゲートの逆操作の取得
+
+生成した量子ゲート `U` のエルミート共役 `U†` は `get_inverse` 関数で取得できます。エルミート共役 `U†` は量子ゲート `U` の逆操作を表現します。エルミート共役を取得する機能が実装されていない場合は例外が送出されます。
+
+```python
+from qulacs.gate import S, DepolarizingNoise
+
+s_gate = S(2)
+s_dagger_gate = s_gate.get_inverse()
+print("original:\n", s_gate.get_matrix())
+print("inversed:\n", s_dagger_gate.get_matrix())
+
+noise_gate = DepolarizingNoise(0, 0.05)
+try:
+        noise_gate.get_inverse()
+        assert 0, "No exception occured. should not reach here."
+except Exception as err:
+        print(f"Exception occured as expected: {err}")
+```
+
+```
+original:
+ [[1.+0.j 0.+0.j]
+ [0.+0.j 0.+1.j]]
+inversed:
+ [[ 1.+0.j  0.+0.j]
+ [ 0.+0.j -0.-1.j]]
+Exception occured as expected: this gate don't have get_inverse function
+```
+
 ## 量子回路
 
 ### 量子回路の生成と構成
@@ -506,4 +536,41 @@ print(state)
         (0,0)
 (0,0.0353406)
         (0,0)
+```
+
+## 量子回路の逆操作の取得
+
+量子回路も量子ゲートと同様にして逆操作を取得することができます。
+量子回路の中にエルミート共役を取得する機能が実装されていない量子ゲートが含まれている場合は例外が送出されます。
+
+```python
+from qulacs import QuantumCircuit
+
+n=3
+circuit = QuantumCircuit(n)
+circuit.add_H_gate(1)
+circuit.add_RX_gate(2,0.1)
+
+inverse_circuit = circuit.get_inverse()
+
+from qulacs import QuantumState
+state = QuantumState(n)
+circuit.update_quantum_state(state)
+inverse_circuit.update_quantum_state(state)
+print(state)
+```
+
+```
+ *** Quantum State ***
+ * Qubit Count : 3
+ * Dimension   : 8
+ * State vector : 
+(1,0)
+(0,0)
+(0,0)
+(0,0)
+(0,0)
+(0,0)
+(0,0)
+(0,0)
 ```


### PR DESCRIPTION
close #506 

This PR adds an explanation to a newly implemented function:  `get_inverse`.
This function is implemented on the quantum gates and quantum circuit class and returns an inversed instance of the original instance.