### PR TITLE
add InoperatableQuantumStateTypeException

### DIFF
--- a/src/cppsim/exception.hpp
+++ b/src/cppsim/exception.hpp
@@ -24,14 +24,14 @@ public:
 /**
  * \~japanese-en StateVectorとDensityMatrixが混ざっていて処理不能な例外
  */
-class InOperatableQuantumStateTypeException : public std::logic_error {
+class InoperatableQuantumStateTypeException : public std::logic_error {
 public:
     /**
      * \~japanese-en コンストラクタ
      *
      * @param message エラーメッセージ
      */
-    InOperatableQuantumStateTypeException(const std::string& message)
+    InoperatableQuantumStateTypeException(const std::string& message)
         : std::logic_error(message) {}
 };
 

--- a/src/cppsim/exception.hpp
+++ b/src/cppsim/exception.hpp
@@ -22,6 +22,20 @@ public:
 };
 
 /**
+ * \~japanese-en StateVectorとDensityMatrixが混ざっていて処理不能な例外
+ */
+class InOperatableQuantumStateTypeException : public std::logic_error {
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param message エラーメッセージ
+     */
+    InOperatableQuantumStateTypeException(const std::string& message)
+        : std::logic_error(message) {}
+};
+
+/**
  * \~japanese-en QuantumStateCpuとQuantumStateGpuを同じ演算中で用いている例外
  */
 class QuantumStateProcessorException : public std::logic_error {

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -533,7 +533,7 @@ public:
                 "invalid qubit count");
         }
         if (!_state->is_state_vector()) {
-            throw InOperatableQuantumStateTypeException(
+            throw InoperatableQuantumStateTypeException(
                 "Error: QuantumStateCpu::load(const QuantumStateBase*): "
                 "cannot load DensityMatrix to StateVector");
         }
@@ -613,7 +613,7 @@ public:
      */
     virtual void add_state(const QuantumStateBase* state) override {
         if (!state->is_state_vector()) {
-            throw InOperatableQuantumStateTypeException(
+            throw InoperatableQuantumStateTypeException(
                 "Error: QuantumStateCpu::add_state(const QuantumStateBase*): "
                 "cannot add DensityMatrix to StateVector");
         }
@@ -630,7 +630,7 @@ public:
     virtual void add_state_with_coef(
         CPPCTYPE coef, const QuantumStateBase* state) override {
         if (!state->is_state_vector()) {
-            throw InOperatableQuantumStateTypeException(
+            throw InoperatableQuantumStateTypeException(
                 "Error: QuantumStateCpu::add_state_with_coef(const "
                 "QuantumStateBase*): "
                 "cannot add DensityMatrix to StateVector");
@@ -649,7 +649,7 @@ public:
     virtual void add_state_with_coef_single_thread(
         CPPCTYPE coef, const QuantumStateBase* state) override {
         if (!state->is_state_vector()) {
-            throw InOperatableQuantumStateTypeException(
+            throw InoperatableQuantumStateTypeException(
                 "Error: "
                 "QuantumStateCpu::add_state_with_coef_single_thread(const "
                 "QuantumStateBase*): "

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -532,6 +532,11 @@ public:
                 "Error: QuantumStateCpu::load(const QuantumStateBase*): "
                 "invalid qubit count");
         }
+        if (!_state->is_state_vector()) {
+            throw InOperatableQuantumStateTypeException(
+                "Error: QuantumStateCpu::load(const QuantumStateBase*): "
+                "cannot load DensityMatrix to StateVector");
+        }
 
         this->_classical_register = _state->classical_register;
         if (_state->get_device_name() == "gpu") {
@@ -607,6 +612,11 @@ public:
      * \~japanese-en 量子状態を足しこむ
      */
     virtual void add_state(const QuantumStateBase* state) override {
+        if (!state->is_state_vector()) {
+            throw InOperatableQuantumStateTypeException(
+                "Error: QuantumStateCpu::add_state(const QuantumStateBase*): "
+                "cannot add DensityMatrix to StateVector");
+        }
         if (state->get_device_name() == "gpu") {
             throw QuantumStateProcessorException(
                 "State vector on GPU cannot be added to that on CPU");
@@ -619,6 +629,12 @@ public:
      */
     virtual void add_state_with_coef(
         CPPCTYPE coef, const QuantumStateBase* state) override {
+        if (!state->is_state_vector()) {
+            throw InOperatableQuantumStateTypeException(
+                "Error: QuantumStateCpu::add_state_with_coef(const "
+                "QuantumStateBase*): "
+                "cannot add DensityMatrix to StateVector");
+        }
         if (state->get_device_name() == "gpu") {
             std::cerr << "State vector on GPU cannot be added to that on CPU"
                       << std::endl;
@@ -632,6 +648,13 @@ public:
      */
     virtual void add_state_with_coef_single_thread(
         CPPCTYPE coef, const QuantumStateBase* state) override {
+        if (!state->is_state_vector()) {
+            throw InOperatableQuantumStateTypeException(
+                "Error: "
+                "QuantumStateCpu::add_state_with_coef_single_thread(const "
+                "QuantumStateBase*): "
+                "cannot add DensityMatrix to StateVector");
+        }
         if (state->get_device_name() == "gpu") {
             std::cerr << "State vector on GPU cannot be added to that on CPU"
                       << std::endl;


### PR DESCRIPTION
close #515
QuantumStateCpu::load(QuantumStateBase*)やQuantumStateCpu::add(QuantumStateBase*)などでDensityMatrixを読み込んだときに例外を投げるようにしました。