### PR TITLE
Match signed numbers

### DIFF
--- a/pysrc/qulacs/converter/qasm_converter.py
+++ b/pysrc/qulacs/converter/qasm_converter.py
@@ -13,7 +13,7 @@ logger = getLogger(__name__)
 logger.addHandler(NullHandler())
 
 FIXED_POINT_PATTERN = r"[+-]?\d+(?:\.\d*)?|\.\d+"
-FLOATING_POINT_PATTERN = r"[+-]?[eE][-+]?\d+"
+FLOATING_POINT_PATTERN = r"[eE][-+]?\d+"
 GENERAL_NUMBER_PATTERN = rf"(?:{FIXED_POINT_PATTERN})(?:{FLOATING_POINT_PATTERN})?" # noqa
 
 

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -991,6 +991,29 @@ class TestQASM(unittest.TestCase):
             assert np.allclose(transpiled_circuit.get_gate(x).get_matrix(),
                                gates[x].get_matrix())
 
+    def test_qasm_converter_with_signed_params(self):
+        from qulacs import QuantumCircuit
+        from qulacs.converter import (convert_QASM_to_qulacs_circuit,
+                                      convert_qulacs_circuit_to_QASM)
+        from qulacs.gate import (RX, RY, RZ, U1, U2, U3)
+        angle = -np.pi / 4.0
+        gates = [
+            U1(0, angle),
+            U2(0, angle, angle),
+            U3(0, angle, angle, angle),
+            RX(0, angle),
+            RY(0, angle),
+            RZ(0, angle),
+        ]
+        circuit = QuantumCircuit(5)
+        for x in gates:
+            circuit.add_gate(x)
+        QASM_strs = convert_qulacs_circuit_to_QASM(circuit)
+        transpiled_circuit = convert_QASM_to_qulacs_circuit(QASM_strs)
+        for x in range(transpiled_circuit.get_gate_count()):
+            assert np.allclose(transpiled_circuit.get_gate(x).get_matrix(),
+                               gates[x].get_matrix())
+
 
 class TestJSON(unittest.TestCase):
     def setUp(self):

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1029,7 +1029,7 @@ class TestQASM(unittest.TestCase):
             convert_qulacs_circuit_to_QASM
         )
 
-        # equals RX(0, np.pi / 4.0)
+        # equals RX(1, np.pi / 4.0)
         qasm = textwrap.dedent("""
             OPENQASM 2.0;
             include "qelib1.inc";

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1022,6 +1022,25 @@ class TestQASM(unittest.TestCase):
             assert np.allclose(transpiled_circuit.get_gate(x).get_matrix(),
                                gates[x].get_matrix())
 
+    def test_qasm_converter_from_qasm_str(self):
+        import textwrap
+        from qulacs.converter import (
+            convert_QASM_to_qulacs_circuit,
+            convert_qulacs_circuit_to_QASM
+        )
+
+        # equals RX(0, np.pi / 4.0)
+        qasm = textwrap.dedent("""
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[4];
+            rx(-0.7853981633974484) q[1];
+            """).strip()
+
+        circuit = convert_QASM_to_qulacs_circuit(qasm.splitlines())
+        recoverd = convert_qulacs_circuit_to_QASM(circuit)
+        assert qasm == "\n".join(recoverd)
+
 
 class TestJSON(unittest.TestCase):
     def setUp(self):

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -998,12 +998,20 @@ class TestQASM(unittest.TestCase):
         from qulacs.gate import (RX, RY, RZ, U1, U2, U3)
         angle = np.pi / 4.0
         gates = [
+            # backward rotation
             U1(0, angle),
             U2(0, angle, angle),
             U3(0, angle, angle, angle),
             RX(0, angle),
             RY(0, angle),
             RZ(0, angle),
+            # forward rotation
+            U1(0, -angle),
+            U2(0, -angle, -angle),
+            U3(0, -angle, -angle, -angle),
+            RX(0, -angle),
+            RY(0, -angle),
+            RZ(0, -angle),
         ]
         circuit = QuantumCircuit(5)
         for x in gates:

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1034,7 +1034,7 @@ class TestQASM(unittest.TestCase):
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[4];
-            rx(-0.7853981633974484) q[1];
+            rx(-0.785398163397448) q[1];
             """).strip()
 
         circuit = convert_QASM_to_qulacs_circuit(qasm.splitlines())

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -996,7 +996,7 @@ class TestQASM(unittest.TestCase):
         from qulacs.converter import (convert_QASM_to_qulacs_circuit,
                                       convert_qulacs_circuit_to_QASM)
         from qulacs.gate import (RX, RY, RZ, U1, U2, U3)
-        angle = -np.pi / 4.0
+        angle = np.pi / 4.0
         gates = [
             U1(0, angle),
             U2(0, angle, angle),


### PR DESCRIPTION
Modified the regular expression to correctly parse the input of a gate with reverse rotation. 

For DenseMatrix, the angle and qubit index are parsed. This regular expression correctly parses the sign. Also, `re.findall` (or `re.search`) finds too much detail, so I keep this regular expression.
https://github.com/qulacs/qulacs/blob/2ad2a3460ac91eb0e30f3dcb9a8d0118108142ce/pysrc/qulacs/converter/qasm_converter.py#L276-L277

