### PR TITLE
Remove clang format container

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -214,8 +214,7 @@ jobs:
 
       - name: format
         run: |
-          cd /qulacs
-          script/format.sh
+          ./script/format.sh
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -207,26 +207,10 @@ jobs:
   format:
     name: Format with clang-format
     runs-on: "ubuntu-20.04"
-    container:
-      image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
-      # This job is running on a docker container.
-      # We can't use actions/checkout because Node.js is not installed on the container.
-      # Therefore, we use `git clone` instead of actions/checkout.
-      - name: clone /qulacs (pull_request)
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          # We use $REPOSITORY to support PR from the forked repository of Qulacs/qulacs.
-          REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-        run: |
-          cd /
-          git clone -b "${GITHUB_HEAD_REF#refs/*/}" https://github.com/$REPOSITORY
+      - uses: actions/checkout@v3
 
-      - name: clone /qulacs (push)
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          cd /
-          git clone -b "${GITHUB_REF#refs/*/}" https://github.com/${GITHUB_REPOSITORY}
+      - run: sudo apt install clang-format=1:10.0-50~exp1
 
       - name: format
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -218,7 +218,6 @@ jobs:
 
       - name: Compare diff
         run: |
-          cd /qulacs
           diff=$(git diff)
           echo -n "$diff"
           # Without `-n`, `echo -n "$diff" | wc -l` is 1 even if `"$diff" is empty.`


### PR DESCRIPTION
We do not need clang-format container anymore by installing clang-format directly in a CI job.