### PR TITLE
Update stub files using pybind11-stubgen 0.15.0

### DIFF
--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -211,12 +211,12 @@ class GeneralQuantumOperator:
     @typing.overload
     def __sub__(self, arg0: PauliOperator) -> GeneralQuantumOperator: ...
     @typing.overload
-    def add_operator(self, coef: complex, pauli_string: str) -> None:
+    def add_operator(self, pauli_operator: PauliOperator) -> None:
         """
         Add Pauli operator
         """
     @typing.overload
-    def add_operator(self, pauli_operator: PauliOperator) -> None: ...
+    def add_operator(self, coef: complex, pauli_string: str) -> None: ...
     def add_operator_copy(self, pauli_operator: PauliOperator) -> None:
         """
         Add Pauli operator
@@ -227,17 +227,17 @@ class GeneralQuantumOperator:
         """
     @typing.overload
     def apply_to_state(
-        self, state_to_be_multiplied: QuantumStateBase, dst_state: QuantumStateBase
+        self,
+        work_state: QuantumStateBase,
+        state_to_be_multiplied: QuantumStateBase,
+        dst_state: QuantumStateBase,
     ) -> None:
         """
         Apply observable to `state_to_be_multiplied`. The result is stored into `dst_state`.
         """
     @typing.overload
     def apply_to_state(
-        self,
-        work_state: QuantumStateBase,
-        state_to_be_multiplied: QuantumStateBase,
-        dst_state: QuantumStateBase,
+        self, state_to_be_multiplied: QuantumStateBase, dst_state: QuantumStateBase
     ) -> None: ...
     def copy(self) -> GeneralQuantumOperator:
         """
@@ -326,12 +326,12 @@ class Observable(GeneralQuantumOperator):
         to string
         """
     @typing.overload
-    def add_operator(self, coef: complex, string: str) -> None:
+    def add_operator(self, pauli_operator: PauliOperator) -> None:
         """
         Add Pauli operator
         """
     @typing.overload
-    def add_operator(self, pauli_operator: PauliOperator) -> None: ...
+    def add_operator(self, coef: complex, string: str) -> None: ...
     def add_operator_copy(self, pauli_operator: PauliOperator) -> None:
         """
         Add Pauli operator
@@ -1089,9 +1089,9 @@ class DensityMatrix(QuantumStateBase):
         Load quantum state vector or density matrix
         """
     @typing.overload
-    def load(self, state: numpy.ndarray) -> None: ...
-    @typing.overload
     def load(self, state: typing.List[complex]) -> None: ...
+    @typing.overload
+    def load(self, state: numpy.ndarray) -> None: ...
     def multiply_coef(self, coef: complex) -> None:
         """
         Multiply coefficient to this state

--- a/pysrc/qulacs/gate/__init__.pyi
+++ b/pysrc/qulacs/gate/__init__.pyi
@@ -77,8 +77,7 @@ __all__ = [
 @typing.overload
 def Adaptive(
     gate: qulacs_core.QuantumGateBase,
-    condition: typing.Callable[[typing.List[int], int], bool],
-    id: int,
+    condition: typing.Callable[[typing.List[int]], bool],
 ) -> qulacs_core.QuantumGateBase:
     """
     Create adaptive gate
@@ -87,7 +86,8 @@ def Adaptive(
 @typing.overload
 def Adaptive(
     gate: qulacs_core.QuantumGateBase,
-    condition: typing.Callable[[typing.List[int]], bool],
+    condition: typing.Callable[[typing.List[int], int], bool],
+    id: int,
 ) -> qulacs_core.QuantumGateBase:
     pass
 

--- a/pysrc/qulacs/state/__init__.pyi
+++ b/pysrc/qulacs/state/__init__.pyi
@@ -59,7 +59,7 @@ def make_superposition(
 
 @typing.overload
 def partial_trace(
-    state: qulacs_core.DensityMatrix, target_traceout: typing.List[int]
+    state: qulacs_core.QuantumState, target_traceout: typing.List[int]
 ) -> qulacs_core.DensityMatrix:
     """
     Take partial trace
@@ -67,34 +67,34 @@ def partial_trace(
 
 @typing.overload
 def partial_trace(
-    state: qulacs_core.QuantumState, target_traceout: typing.List[int]
+    state: qulacs_core.DensityMatrix, target_traceout: typing.List[int]
 ) -> qulacs_core.DensityMatrix:
     pass
 
 @typing.overload
 def permutate_qubit(
-    state: qulacs_core.DensityMatrix, qubit_order: typing.List[int]
-) -> qulacs_core.DensityMatrix:
+    state: qulacs_core.QuantumState, qubit_order: typing.List[int]
+) -> qulacs_core.QuantumState:
     """
     Permutate qubits from state
     """
 
 @typing.overload
 def permutate_qubit(
-    state: qulacs_core.QuantumState, qubit_order: typing.List[int]
-) -> qulacs_core.QuantumState:
+    state: qulacs_core.DensityMatrix, qubit_order: typing.List[int]
+) -> qulacs_core.DensityMatrix:
     pass
 
 @typing.overload
 def tensor_product(
-    state_left: qulacs_core.DensityMatrix, state_right: qulacs_core.DensityMatrix
-) -> qulacs_core.DensityMatrix:
+    state_left: qulacs_core.QuantumState, state_right: qulacs_core.QuantumState
+) -> qulacs_core.QuantumState:
     """
     Get tensor product of states
     """
 
 @typing.overload
 def tensor_product(
-    state_left: qulacs_core.QuantumState, state_right: qulacs_core.QuantumState
-) -> qulacs_core.QuantumState:
+    state_left: qulacs_core.DensityMatrix, state_right: qulacs_core.DensityMatrix
+) -> qulacs_core.DensityMatrix:
     pass


### PR DESCRIPTION
## Overview

The latest CI on the main branch was failing at the [stubs check step](https://github.com/qulacs/qulacs/actions/runs/5117794417/jobs/9201202855). 
The reason for this failure is due to the release of the [pybind11-stubgen 0.15.0 version on May 27.](https://pypi.org/project/pybind11-stubgen/0.15.0/)

In this PR, the stub file was updated using pybind11-stubgen 0.15.0.