### PR TITLE
Fix typo in overview in the docs

### DIFF
--- a/doc/en/source/apply/0_overview.ipynb
+++ b/doc/en/source/apply/0_overview.ipynb
@@ -43,7 +43,7 @@
      "nbsphinx-toctree": {}
    },
    "source": [
-    "- [1.1 Quantum Circuit Learing](5.2_qcl.ipynb)\n",
+    "- [1.1 Quantum Circuit Learning](5.2_qcl.ipynb)\n",
     "- [1.2 Variational Quantum Eigensolver](6.2_vqe.ipynb)\n",
     "- [1.3 Subspace-Search Variational Quantum Eigensolver](6.3_ssvqe.ipynb)"
    ]


### PR DESCRIPTION
## Purpose
Fix the typo in 0_overview.ipynb

## Details
Changed `Learing` to `Learning`.