### PR TITLE
Add missing test cases in circuit test

### DIFF
--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -135,7 +135,9 @@ TEST(CircuitTest, CircuitBasic) {
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
+    circuit.add_RY_gate(target, angle);
     circuit.add_RotInvY_gate(target, angle);
+    circuit.add_RotY_gate(target, angle);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target,
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Y, n) *
@@ -144,6 +146,8 @@ TEST(CircuitTest, CircuitBasic) {
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
     circuit.add_RZ_gate(target, angle);
+    circuit.add_RotInvZ_gate(target, angle);
+    circuit.add_RotZ_gate(target, angle);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target,
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Z, n) *
@@ -229,16 +233,20 @@ TEST(CircuitTest, CircuitRev) {
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_RX_gate(target, angle * 2);
-    circuit.add_RotInvX_gate(target, angle + 0.5);
-    circuit.add_RotX_gate(target, angle * 2 + 0.5);
+    circuit.add_RX_gate(target, angle);
+    circuit.add_RotInvX_gate(target, angle);
+    circuit.add_RotX_gate(target, angle);
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
+    circuit.add_RY_gate(target, angle);
+    circuit.add_RotInvY_gate(target, angle);
     circuit.add_RotInvY_gate(target, angle);
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
+    circuit.add_RZ_gate(target, angle);
+    circuit.add_RotInvZ_gate(target, angle);
     circuit.add_RotZ_gate(target, -angle);
 
     target = random.int32() % n;
@@ -274,6 +282,10 @@ TEST(CircuitTest, CircuitRev) {
         ASSERT_NEAR(abs(state_eigen[i] - state.data_cpp()[i]), 0, eps);
 
     delete revcircuit;
+}
+
+TEST(CircuitTest, IBMQGates) {
+
 }
 
 TEST(CircuitTest, CircuitOptimize) {

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -125,10 +125,9 @@ TEST(CircuitTest, CircuitBasic) {
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_RX_gate(target, angle * 2);
-    circuit.add_RotInvX_gate(target, angle + 0.5);
-    circuit.add_RotX_gate(target, angle * 2 + 0.5);
-    // RX +RotInvX - RotX = angle
+    circuit.add_RX_gate(target, angle);
+    circuit.add_RotInvX_gate(target, angle);
+    circuit.add_RotX_gate(target, angle);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target,
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * X, n) *

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -198,6 +198,15 @@ TEST(CircuitTest, CircuitBasic) {
     PauliOperator pauli = PauliOperator("I 0 X 1 Y 2 Z 3");
     circuit.add_multi_Pauli_gate(pauli);
 
+    ComplexMatrix mat_x(2, 2);
+    target = random.int32() % n;
+    mat_x << 0, 1, 1, 0;
+    circuit.add_dense_matrix_gate(target, mat_x);
+
+    state_eigen = get_expanded_eigen_matrix_with_identity(
+                      target, get_eigen_matrix_single_Pauli(1), n) *
+                  state_eigen;
+
     circuit.update_quantum_state(&state);
     for (ITYPE i = 0; i < dim; ++i)
         ASSERT_NEAR(abs(state_eigen[i] - state.data_cpp()[i]), 0, eps);

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -176,11 +176,13 @@ TEST(CircuitTest, CircuitBasic) {
 
     target = random.int32() % n;
     circuit.add_U1_gate(target, M_PI);
-    state_eigen = get_expanded_eigen_matrix_with_identity(target, Z, n) * state_eigen;
+    state_eigen =
+        get_expanded_eigen_matrix_with_identity(target, Z, n) * state_eigen;
 
     target = random.int32() % n;
     circuit.add_U2_gate(target, 0, M_PI);
-    state_eigen = get_expanded_eigen_matrix_with_identity(target, H, n) * state_eigen;
+    state_eigen =
+        get_expanded_eigen_matrix_with_identity(target, H, n) * state_eigen;
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -317,10 +317,6 @@ TEST(CircuitTest, CircuitRev) {
     delete revcircuit;
 }
 
-TEST(CircuitTest, IBMQGates) {
-
-}
-
 TEST(CircuitTest, CircuitOptimize) {
     const UINT n = 4;
     const UINT dim = 1ULL << n;

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -190,6 +190,14 @@ TEST(CircuitTest, CircuitBasic) {
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Y, n) *
         state_eigen;
 
+    std::vector<UINT> target_index_list{0, 1, 2, 3};
+    std::vector<UINT> pauli_id_list{0, 1, 2, 3};
+    circuit.add_multi_Pauli_gate(target_index_list, pauli_id_list);
+
+    // add same gate == cancel above pauli gate
+    PauliOperator pauli = PauliOperator("I 0 X 1 Y 2 Z 3");
+    circuit.add_multi_Pauli_gate(pauli);
+
     circuit.update_quantum_state(&state);
     for (ITYPE i = 0; i < dim; ++i)
         ASSERT_NEAR(abs(state_eigen[i] - state.data_cpp()[i]), 0, eps);

--- a/test/cppsim/test_circuit.cpp
+++ b/test/cppsim/test_circuit.cpp
@@ -174,6 +174,22 @@ TEST(CircuitTest, CircuitBasic) {
     state_eigen =
         get_eigen_matrix_full_qubit_SWAP(target, target_sub, n) * state_eigen;
 
+    target = random.int32() % n;
+    circuit.add_U1_gate(target, M_PI);
+    state_eigen = get_expanded_eigen_matrix_with_identity(target, Z, n) * state_eigen;
+
+    target = random.int32() % n;
+    circuit.add_U2_gate(target, 0, M_PI);
+    state_eigen = get_expanded_eigen_matrix_with_identity(target, H, n) * state_eigen;
+
+    target = random.int32() % n;
+    angle = random.uniform() * 3.14159;
+    circuit.add_U3_gate(target, -angle, 0, 0);
+    state_eigen =
+        get_expanded_eigen_matrix_with_identity(target,
+            cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Y, n) *
+        state_eigen;
+
     circuit.update_quantum_state(&state);
     for (ITYPE i = 0; i < dim; ++i)
         ASSERT_NEAR(abs(state_eigen[i] - state.data_cpp()[i]), 0, eps);

--- a/test/cppsim/test_circuit_multicpu.cpp
+++ b/test/cppsim/test_circuit_multicpu.cpp
@@ -133,10 +133,9 @@ TEST(CircuitTest_multicpu, CircuitBasic) {
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_RX_gate(target, angle * 2);
-    circuit.add_RotInvX_gate(target, angle + 0.5);
-    circuit.add_RotX_gate(target, angle * 2 + 0.5);
-    // RX +RotInvX - RotX = angle
+    circuit.add_RX_gate(target, angle);
+    circuit.add_RotInvX_gate(target, angle);
+    circuit.add_RotX_gate(target, angle);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target,
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * X, n) *
@@ -144,7 +143,9 @@ TEST(CircuitTest_multicpu, CircuitBasic) {
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
+    circuit.add_RY_gate(target, angle);
     circuit.add_RotInvY_gate(target, angle);
+    circuit.add_RotY_gate(target, angle);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target,
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Y, n) *
@@ -153,6 +154,8 @@ TEST(CircuitTest_multicpu, CircuitBasic) {
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
     circuit.add_RZ_gate(target, angle);
+    circuit.add_RotInvZ_gate(target, angle);
+    circuit.add_RotZ_gate(target, angle);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target,
             cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Z, n) *
@@ -178,6 +181,41 @@ TEST(CircuitTest_multicpu, CircuitBasic) {
     circuit.add_SWAP_gate(target, target_sub);
     state_eigen =
         get_eigen_matrix_full_qubit_SWAP(target, target_sub, n) * state_eigen;
+
+   target = random.int32() % n;
+    circuit.add_U1_gate(target, M_PI);
+    state_eigen =
+        get_expanded_eigen_matrix_with_identity(target, Z, n) * state_eigen;
+
+    target = random.int32() % n;
+    circuit.add_U2_gate(target, 0, M_PI);
+    state_eigen =
+        get_expanded_eigen_matrix_with_identity(target, H, n) * state_eigen;
+
+    target = random.int32() % n;
+    angle = random.uniform() * 3.14159;
+    circuit.add_U3_gate(target, -angle, 0, 0);
+    state_eigen =
+        get_expanded_eigen_matrix_with_identity(target,
+            cos(angle / 2) * Identity + imag_unit * sin(angle / 2) * Y, n) *
+        state_eigen;
+
+    std::vector<UINT> target_index_list{0, 1, 2, 3};
+    std::vector<UINT> pauli_id_list{0, 1, 2, 3};
+    circuit.add_multi_Pauli_gate(target_index_list, pauli_id_list);
+
+    // add same gate == cancel above pauli gate
+    PauliOperator pauli = PauliOperator("I 0 X 1 Y 2 Z 3");
+    circuit.add_multi_Pauli_gate(pauli);
+
+    ComplexMatrix mat_x(2, 2);
+    target = random.int32() % n;
+    mat_x << 0, 1, 1, 0;
+    circuit.add_dense_matrix_gate(target, mat_x);
+
+    state_eigen = get_expanded_eigen_matrix_with_identity(
+                      target, get_eigen_matrix_single_Pauli(1), n) *
+                  state_eigen;
 
     circuit.update_quantum_state(&state);
 
@@ -252,16 +290,20 @@ TEST(CircuitTest_multicpu, CircuitRev) {
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_RX_gate(target, angle * 2);
-    circuit.add_RotInvX_gate(target, angle + 0.5);
-    circuit.add_RotX_gate(target, angle * 2 + 0.5);
+    circuit.add_RX_gate(target, angle);
+    circuit.add_RotInvX_gate(target, angle);
+    circuit.add_RotX_gate(target, angle);
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
+    circuit.add_RY_gate(target, angle);
+    circuit.add_RotInvY_gate(target, angle);
     circuit.add_RotInvY_gate(target, angle);
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
+    circuit.add_RZ_gate(target, angle);
+    circuit.add_RotInvZ_gate(target, angle);
     circuit.add_RotZ_gate(target, -angle);
 
     target = random.int32() % n;

--- a/test/cppsim/test_circuit_multicpu.cpp
+++ b/test/cppsim/test_circuit_multicpu.cpp
@@ -182,7 +182,7 @@ TEST(CircuitTest_multicpu, CircuitBasic) {
     state_eigen =
         get_eigen_matrix_full_qubit_SWAP(target, target_sub, n) * state_eigen;
 
-   target = random.int32() % n;
+    target = random.int32() % n;
     circuit.add_U1_gate(target, M_PI);
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, Z, n) * state_eigen;


### PR DESCRIPTION
## Overview

Add test for `add_*_gate` method to add gate in QunatumCircuit.
Because there are tests where gate has the correct matrix, I now check if the add operations to the circuit can be used correctly.