### PR TITLE
Update action to remove deprecated components

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.11
         with:
+          cuda: "11.4.2"
           method: "network"
           sub-packages: '["nvcc"]'
           non-cuda-sub-packages: '["libcublas", "libcurand"]'

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -151,6 +151,7 @@ jobs:
         with:
           method: "network"
           sub-packages: '["nvcc"]'
+          non-cuda-sub-packages: '["libcublas", "libcurand"]'
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -147,7 +147,7 @@ jobs:
         run: sudo apt install libboost-dev
 
       - name: Install CUDA toolkit
-        uses: Jimver/cuda-toolkit@v0.2.5
+        uses: Jimver/cuda-toolkit@v0.2.11
         id: cuda-toolkit
 
       - name: Install qulacs for Ubuntu

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -148,7 +148,9 @@ jobs:
 
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.11
-        id: cuda-toolkit
+        with:
+          method: "network"
+          sub-packages: '["nvcc"]'
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -151,8 +151,6 @@ jobs:
         with:
           cuda: "11.4.2"
           method: "network"
-          sub-packages: '["nvcc"]'
-          non-cuda-sub-packages: '["libcublas", "libcurand"]'
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -43,7 +43,7 @@ jobs:
           architecture: x64
 
       - name: Install boost
-        uses: MarkusJx/install-boost@v2.0.0
+        uses: MarkusJx/install-boost@v2.4.3
         id: install-boost
         with:
           boost_version: 1.77.0


### PR DESCRIPTION
close #489 

Update the following actions to suppress warning for deprecated Node version or `set-output`.
- Jimver/cuda-toolkit
- MarkusJx/install-boost