### PR TITLE
pybind11-stubgen changed parameter

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -28,7 +28,7 @@ jobs:
           - compiler: "clang"
             c_compiler: "/usr/local/opt/ccache/libexec/clang"
             cxx_compiler: "/usr/local/opt/ccache/libexec/clang++"
-    runs-on: "macos-11"
+    runs-on: "macos-12"
     env:
       C_COMPILER: ${{ matrix.c_compiler }}
       CXX_COMPILER: ${{ matrix.cxx_compiler }}
@@ -44,7 +44,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           # Include compiler to distinguish cache for each compiler.
-          key: ${{ github.job }}-macos-11-${{ matrix.compiler }}
+          key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
           verbose: 2
 
       - name: Setup Python

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -23,8 +23,8 @@ jobs:
         compiler: ["gcc", "clang"]
         include:
           - compiler: "gcc"
-            c_compiler: "/usr/local/opt/ccache/libexec/gcc-10"
-            cxx_compiler: "/usr/local/opt/ccache/libexec/g++-10"
+            c_compiler: "/usr/local/opt/ccache/libexec/gcc-11"
+            cxx_compiler: "/usr/local/opt/ccache/libexec/g++-11"
           - compiler: "clang"
             c_compiler: "/usr/local/opt/ccache/libexec/clang"
             cxx_compiler: "/usr/local/opt/ccache/libexec/clang++"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -39,9 +39,9 @@ jobs:
           - os-arch: "win_amd64"
             os: "windows-2019"
           - os-arch: "macosx_x86_64"
-            os: "macos-11"
+            os: "macos-12"
           - os-arch: "macosx_arm64"
-            os: "macos-11"
+            os: "macos-12"
     runs-on: ${{ matrix.os }}
     env:
       CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ ci = [
     "flake8",
     "isort",
     "mypy",
-    "pybind11-stubgen",
+    "pybind11-stubgen == 0.16.2",
     "openfermion",
     "pytest"
 ]


### PR DESCRIPTION
- pybind11-stubgen parameters have changed in v 1.0, we will temporarily pin it to 0.16.2.
- Upgrade macos version of github ci from 11 to 12. because Xcode 14.0 can't install.
- macOS using gcc version is changed from 10 to 11. 