### PR TITLE
Always enable sphinx_rtd_theme

### DIFF
--- a/doc/en/source/conf.py
+++ b/doc/en/source/conf.py
@@ -1,5 +1,5 @@
 import os
-
+import sphinx_rtd_theme
 import qulacs
 
 project = "Qulacs"

--- a/doc/en/source/conf.py
+++ b/doc/en/source/conf.py
@@ -96,14 +96,9 @@ autoapi_options = [
 
 #
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 html_theme_options = {

--- a/doc/ja/source/conf.py
+++ b/doc/ja/source/conf.py
@@ -1,6 +1,5 @@
-import sphinx_rtd_theme
 import os
-
+import sphinx_rtd_theme
 import qulacs
 
 project = "Qulacs"

--- a/doc/ja/source/conf.py
+++ b/doc/ja/source/conf.py
@@ -1,3 +1,4 @@
+import sphinx_rtd_theme
 import os
 
 import qulacs
@@ -97,14 +98,8 @@ autoapi_options = [
 
 #
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 html_theme_options = {


### PR DESCRIPTION
Previously, the environment variable READTHEDOCS was used to switch.
However, changes may have been made on Read The Docs side, and theme no longer applies.
Make sure sphinx_rtd_theme is set.