### PR TITLE
Ubuntu 22.04 LTS installation instructions

### DIFF
--- a/doc/en/source/intro/1_install.md
+++ b/doc/en/source/intro/1_install.md
@@ -54,6 +54,9 @@ Install with default options (Multi-thread without GPU):
 pip install .
 ```
 
+Your build may fail with python's `cmake` package installed. Adding `--no-build-isolation` option will help.
+
+
 If AVX2 instructions are not supported, SIMD optimization is automatically disabled.
 
 

--- a/doc/en/source/intro/1_install.md
+++ b/doc/en/source/intro/1_install.md
@@ -73,15 +73,6 @@ The number of threads used in Qulacs installed with default options can be contr
 While `OMP_NUM_THREADS` affects the parallelization of other libraries, `QULACS_NUM_THREADS` controls only the parallelization of QULACS.
 Or, if you want to force only Qulacs to use a single thread, You can install single-thread Qulacs with the above command.
 
-On versions of Ubuntu including 22.04 LTS, this installation process might fail due to Python and operating system incompatibilities.
-Assuming your Python 3 interpreter is `python3` command, you can build a wheel compatible with the local system as follows, (for GPU):
-
-```
-USE_GPU=Yes python3 -m build
-```
-
-(You might need to install `build` with `pip`, beforehand.) Install the wheel file produced by this command, with `pip install`.
-
 For development purpose, optional dependencies can be installed as follows.
 ```
 # Install development tools

--- a/doc/en/source/intro/1_install.md
+++ b/doc/en/source/intro/1_install.md
@@ -73,6 +73,15 @@ The number of threads used in Qulacs installed with default options can be contr
 While `OMP_NUM_THREADS` affects the parallelization of other libraries, `QULACS_NUM_THREADS` controls only the parallelization of QULACS.
 Or, if you want to force only Qulacs to use a single thread, You can install single-thread Qulacs with the above command.
 
+On versions of Ubuntu including 22.04 LTS, this installation process might fail due to Python and operating system incompatibilities.
+Assuming your Python 3 interpreter is `python3` command, you can build a wheel compatible with the local system as follows, (for GPU):
+
+```
+USE_GPU=Yes python3 -m build
+```
+
+(You might need to install `build` with `pip`, beforehand.) Install the wheel file produced by this command, with `pip install`.
+
 For development purpose, optional dependencies can be installed as follows.
 ```
 # Install development tools


### PR DESCRIPTION
Hi, I'm Dan Strano from over at https://github.com/unitaryfund/qrack. I build and install your library regularly, and it took me several hours today to figure out how to install on my Ubuntu 22.04 LTS (and 20.04 LTS) systems. However, it's very simple to communicate a workaround (on close-to-stock LTS). If you like this documentation change, I think it broadens your installation support significantly.

(Thanks for the open-source simulator library!) :v: 