### PR TITLE
Adding swap insertion feature to circuit optimizer

### DIFF
--- a/README_MPI.md
+++ b/README_MPI.md
@@ -67,7 +67,7 @@
   - state.get_vector()
     - In the case state vector distributed in multi nodes, returns the elements that each rank has.
 
-  - Automatic FusedSWAP gate insertion of QuantumCircuitOptimizer  // not supported yet
+  - Automatic FusedSWAP gate insertion of QuantumCircuitOptimizer
     - optimize(circuit, block_size, swap_level=0)
       - swap_level = 0
         - No SWAP/FusedSWAP gate insertion
@@ -291,13 +291,13 @@ int main(int argc, char *argv[]) {
   - GeneralQuantumOperator (w/o get_transition_amplitude)
   - Observable (w/o get_transition_amplitude)
   - PauliOperator (w/o get_transition_amplitude)
+  - QuantumCircuitOptimizer
+      - optimize
+      - optimize_light
 
 ## Additional info
 
 - Might be supported in future (T.B.D.)
-  - QuantumCircuitOptimizer
-      - optimize
-      - optimize_light
   - ParametricQuantumCircuit
   - gate
       - Measurement

--- a/benchmark/bench_circuit.py
+++ b/benchmark/bench_circuit.py
@@ -25,8 +25,13 @@ def get_option():
         default=-1,
         help="Enable QuantumCircuitOptimizer: 99 is to use optmize_light(), 0-6 is to use optimize(). (default no-use)",
     )
-    # argparser.add_argument('-f', '--fused', type = int,
-    #        default = -1, help = 'Enable QuantumCircuitOptimizer: 0 is not to use, 1-2 is to use Fused-swap opt')
+    argparser.add_argument(
+        "-f",
+        "--fused",
+        type=int,
+        default=-1,
+        help="Enable QuantumCircuitOptimizer: 0 is not to use, 1-2 is to use Fused-swap opt",
+    )
     argparser.add_argument(
         "-v",
         "--verbose",
@@ -100,8 +105,7 @@ if __name__ == "__main__":
     circuit = get_circuit(
         args.circuit,
         nqubits=args.nqubits,
-        global_nqubits=num_global_qubits,
-        # global_nqubits = 0 if args.fused >= 0 else num_global_qubits,
+        global_nqubits=0 if args.fused >= 0 else num_global_qubits,
         depth=args.depth,
         verbose=(args.verbose and (mpirank == 0)),
         random_gen=rng,
@@ -110,24 +114,22 @@ if __name__ == "__main__":
     if args.check:
         circuit_ref = circuit.copy()
     if args.opt == 99:
-        # if args.fused == -1:
-        QCO().optimize_light(circuit)
-    # else:
-    #    QCO().optimize_light(circuit, args.fused)
+        if args.fused == -1:
+            QCO().optimize_light(circuit)
+        else:
+            QCO().optimize_light(circuit, args.fused)
     elif args.opt >= 0:
-        # if args.fused == -1:
-        QCO().optimize(circuit, args.opt)
-    # else:
-    #    QCO().optimize(circuit, args.opt, args.fused)
+        if args.fused == -1:
+            QCO().optimize(circuit, args.opt)
+        else:
+            QCO().optimize(circuit, args.opt, args.fused)
 
     if mpirank == 0:
         print(
             "# A quantum circuit was created. ",
             args.circuit,
             f"nqubits= {args.nqubits} depth= {args.depth}",
-            #        "optimize =", (args.opt, args.fused), elapsed())
-            "optimize=",
-            args.opt,
+            " optimize= {args.opt, args.fused}",
             elapsed(),
         )
         print(circuit)

--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -311,7 +311,7 @@ class GeneralQuantumOperator:
         """
         Get expectation value
         """
-    def get_matrix(self) -> scipy.sparse.csr_matrix[numpy.complex128]:
+    def get_matrix(self) -> scipy.sparse.csr_matrix:
         """
         Get the Hermitian matrix representation of the observable
         """

--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -457,19 +457,19 @@ class Observable(GeneralQuantumOperator):
         Get transition amplitude
         """
     def solve_ground_state_eigenvalue_by_arnoldi_method(
-        self, state: QuantumStateBase, iter_count: int, mu: complex = ...
+        self, state: QuantumStateBase, iter_count: int, mu: complex = 0.0
     ) -> complex:
         """
         Compute ground state eigenvalue by arnoldi method
         """
     def solve_ground_state_eigenvalue_by_lanczos_method(
-        self, state: QuantumStateBase, iter_count: int, mu: complex = ...
+        self, state: QuantumStateBase, iter_count: int, mu: complex = 0.0
     ) -> complex:
         """
         Compute ground state eigenvalue by lanczos method
         """
     def solve_ground_state_eigenvalue_by_power_method(
-        self, state: QuantumStateBase, iter_count: int, mu: complex = ...
+        self, state: QuantumStateBase, iter_count: int, mu: complex = 0.0
     ) -> complex:
         """
         Compute ground state eigenvalue by power method

--- a/pysrc/qulacs/circuit.pyi
+++ b/pysrc/qulacs/circuit.pyi
@@ -5,18 +5,22 @@ import qulacs_core
 __all__ = ["QuantumCircuitOptimizer", "from_json"]
 
 class QuantumCircuitOptimizer:
-    def __init__(self) -> None:
+    def __init__(self, mpi_size: int = 0) -> None:
         """
         Constructor
         """
     def merge_all(
         self, circuit: qulacs_core.QuantumCircuit
     ) -> qulacs_core.QuantumGateMatrix: ...
-    def optimize(self, circuit: qulacs_core.QuantumCircuit, block_size: int) -> None:
+    def optimize(
+        self, circuit: qulacs_core.QuantumCircuit, block_size: int, swap_level: int = 0
+    ) -> None:
         """
         Optimize quantum circuit
         """
-    def optimize_light(self, circuit: qulacs_core.QuantumCircuit) -> None:
+    def optimize_light(
+        self, circuit: qulacs_core.QuantumCircuit, swap_level: int = 0
+    ) -> None:
         """
         Optimize quantum circuit with light method
         """

--- a/pysrc/qulacs/gate.pyi
+++ b/pysrc/qulacs/gate.pyi
@@ -75,7 +75,7 @@ __all__ = [
 
 @typing.overload
 def Adaptive(
-    gate: qulacs_core.QuantumGateBase, condition: typing.Callable[[List[int]], bool]
+    gate: qulacs_core.QuantumGateBase, condition: typing.Callable[[list[int]], bool]
 ) -> qulacs_core.QuantumGateBase:
     """
     Create adaptive gate
@@ -84,7 +84,7 @@ def Adaptive(
 @typing.overload
 def Adaptive(
     gate: qulacs_core.QuantumGateBase,
-    condition: typing.Callable[[List[int], int], bool],
+    condition: typing.Callable[[list[int], int], bool],
     id: int,
 ) -> qulacs_core.QuantumGateBase:
     """
@@ -355,7 +355,7 @@ def Sdag(index: int) -> qulacs_core.ClsOneQubitGate:
     """
 
 def SparseMatrix(
-    index_list: list[int], matrix: scipy.sparse.csc_matrix[numpy.complex128]
+    index_list: list[int], matrix: scipy.sparse.csc_matrix
 ) -> qulacs_core.QuantumGateSparseMatrix:
     """
     Create sparse matrix gate

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -1525,12 +1525,13 @@ Matrix Representation
         "from json string", py::return_value_policy::take_ownership);
 
     py::class_<QuantumCircuitOptimizer>(mcircuit, "QuantumCircuitOptimizer")
-        .def(py::init<>(), "Constructor")
+        .def(py::init<UINT>(), "Constructor", py::arg("mpi_size") = 0)
         .def("optimize", &QuantumCircuitOptimizer::optimize,
             "Optimize quantum circuit", py::arg("circuit"),
-            py::arg("block_size"))
+            py::arg("block_size"), py::arg("swap_level") = 0)
         .def("optimize_light", &QuantumCircuitOptimizer::optimize_light,
-            "Optimize quantum circuit with light method", py::arg("circuit"))
+            "Optimize quantum circuit with light method", py::arg("circuit"),
+            py::arg("swap_level") = 0)
         .def("merge_all", &QuantumCircuitOptimizer::merge_all,
             py::return_value_policy::take_ownership, py::arg("circuit"));
 

--- a/python/tests/multi_cpu/test_circuit_optimizer.py
+++ b/python/tests/multi_cpu/test_circuit_optimizer.py
@@ -1,0 +1,91 @@
+from typing import Generator
+
+import numpy as np
+import pytest
+
+import qulacs
+from qulacs import QuantumCircuit, QuantumState
+from qulacs.circuit import QuantumCircuitOptimizer
+
+# `pytestmark` is a variable name determined by pytest.
+# If `pytestmark` is defined as skip mark, all tests in this file will be skipped.
+pytestmark = pytest.mark.skipif(
+    not qulacs.check_build_for_mpi(),
+    reason="To use multi-cpu, qulacs built for mpi is required.",
+)
+
+
+class TestQuantumCircuitOptimizer:
+    @pytest.fixture
+    def init_circuit(self, init_mpi) -> Generator[None, None, None]:
+        # from fixture in conftest.py
+        multicpu, mpicomm = init_mpi
+
+        self.n = 6
+        self.dim = 2**self.n
+        self.dim_all = self.dim
+        self.state = QuantumState(self.n)
+        self.state_multi = QuantumState(self.n, True)
+        self.circuit = QuantumCircuit(self.n)
+        if multicpu:
+            self.mpirank = mpicomm.Get_rank()  # type: ignore
+            self.mpisize = mpicomm.Get_size()  # type: ignore
+        else:
+            self.mpirank = 0
+            self.mpisize = 1
+        if self.state_multi.get_device_name() == "multi-cpu":
+            self.dim //= self.mpisize
+        np.random.seed(seed=0)
+
+        yield
+        del self.state
+        del self.state_multi
+        del self.circuit
+
+    @pytest.mark.parametrize("blocksize", [None, 0, 2])
+    @pytest.mark.parametrize("swap_level", [0, 1, 2])
+    @pytest.mark.usefixtures("init_circuit")
+    def test_circuit_optimizer(self, blocksize, swap_level) -> None:
+        # qulacs benchmark circuit with depth = 0
+        for i in range(self.n):
+            self.circuit.add_RX_gate(i, np.random.rand())
+            self.circuit.add_RZ_gate(i, np.random.rand())
+        for i in range(self.n):
+            self.circuit.add_CNOT_gate(i, (i + 1) % self.n)
+        for i in range(self.n):
+            self.circuit.add_RZ_gate(i, np.random.rand())
+            self.circuit.add_RX_gate(i, np.random.rand())
+
+        # reference
+        self.state.set_zero_state()
+        self.circuit.update_quantum_state(self.state)
+        vector = self.state.get_vector()
+
+        qco = QuantumCircuitOptimizer()
+        if blocksize is None:
+            qco.optimize_light(self.circuit, swap_level)
+        else:
+            qco.optimize(self.circuit, blocksize, swap_level)
+
+        self.state_multi.set_zero_state()
+        self.circuit.update_quantum_state(self.state_multi)
+        vector_multi = self.state_multi.get_vector()
+
+        part_vector = vector[self.dim * self.mpirank : self.dim * (self.mpirank + 1)]
+        assert ((vector_multi - part_vector) < 1e-10).all(), "check circuit optimizer"
+
+    @pytest.mark.usefixtures("init_circuit")
+    def test_circuit_optimizer_with_mpisize(self) -> None:
+        for i in range(self.n):
+            self.circuit.add_RX_gate(i, np.random.rand())
+            self.circuit.add_RZ_gate(i, np.random.rand())
+
+        qco = QuantumCircuitOptimizer(mpi_size=4)
+        qco.optimize(self.circuit, 0, 2)
+
+        is_fusedswap = [
+            self.circuit.get_gate(i).get_name() == "FusedSWAP"
+            for i in range(self.circuit.get_gate_count())
+        ]
+
+        assert any(is_fusedswap), "check circuit optimizer with mpi_size"

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -221,6 +221,25 @@ void QuantumCircuit::remove_gate(UINT index) {
     this->_gate_list.erase(this->_gate_list.begin() + index);
 }
 
+void QuantumCircuit::move_gate(UINT from_index, UINT to_index) {
+    if (from_index >= this->_gate_list.size() ||
+        to_index >= this->_gate_list.size()) {
+        throw GateIndexOutOfRangeException(
+            "Error: QuantumCircuit::move_gate(UINT, UINT) : "
+            "index must be smaller than gate_count");
+    }
+    if (from_index < to_index) {
+        std::rotate(this->_gate_list.begin() + from_index,
+            this->_gate_list.begin() + from_index + 1,
+            this->_gate_list.begin() + to_index + 1);
+    } else {
+        std::rotate(this->_gate_list.rbegin() +
+                        (this->_gate_list.size() - from_index - 1),
+            this->_gate_list.rbegin() + (this->_gate_list.size() - from_index),
+            this->_gate_list.rbegin() + (this->_gate_list.size() - to_index));
+    }
+}
+
 QuantumCircuit::~QuantumCircuit() {
     for (auto& gate : this->_gate_list) {
         delete gate;

--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -129,6 +129,15 @@ public:
      */
     virtual void remove_gate(UINT index);
     /**
+     * \~japanese-en 量子回路内のゲートを移動する。
+     *
+     * 回路内の量子ゲートを移動する。
+     * from_indexとto_indexの間のゲートはfrom_indexの方向にシフトする。
+     * @param[in] from_index 移動元のゲートの位置
+     * @param[in] to_index 移動先のゲートの位置
+     */
+    virtual void move_gate(UINT from_index, UINT to_index);
+    /**
      *  \~japanese-en 量子回路をマージする。
      *
      * 引数で与えた量子回路のゲートを後ろに追加していく。

--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -457,7 +457,7 @@ bool QuantumCircuitOptimizer::can_merge_with_swap_insertion(
 }
 
 bool QuantumCircuitOptimizer::needs_communication(
-    const UINT gate_index, QubitTable& qt) {
+    const UINT gate_index, const QubitTable& qt) {
     auto gate = circuit->gate_list[gate_index];
     auto logical_qubits = get_qubits_needing_communication(gate);
     return std::any_of(
@@ -468,8 +468,9 @@ bool QuantumCircuitOptimizer::needs_communication(
 }
 
 UINT QuantumCircuitOptimizer::move_gates_without_communication(
-    const UINT gate_idx, QubitTable& qt,
-    std::multimap<const QuantumGateBase*, const QuantumGateBase*>& dep_map,
+    const UINT gate_idx, const QubitTable& qt,
+    const std::multimap<const QuantumGateBase*, const QuantumGateBase*>&
+        dep_map,
     std::unordered_set<const QuantumGateBase*>& processed_gates) {
     const UINT num_gates = circuit->gate_list.size();
     UINT moved_gates = 0;
@@ -559,7 +560,7 @@ UINT QuantumCircuitOptimizer::move_matching_qubits_to_local_upper(
 }
 
 UINT QuantumCircuitOptimizer::rearrange_qubits(const UINT gate_idx,
-    std::unordered_set<UINT> next_local_qubit, QubitTable& qt) {
+    const std::unordered_set<UINT>& next_local_qubit, QubitTable& qt) {
     UINT num_inserted_gates = 0;
 
     std::unordered_set<UINT> cur_local_qubits(
@@ -614,7 +615,8 @@ UINT QuantumCircuitOptimizer::rearrange_qubits(const UINT gate_idx,
     // TODO: if fast qubit swapping between global qubits is implemented,
     //       global qubits should be rearranged to be contiguous.
     UINT total_swap_width = import_qubits.size();
-    int extra_local_qc = exportable_qubits.size() - import_qubits.size();
+    int extra_local_qc =
+        (int)exportable_qubits.size() - (int)import_qubits.size();
 
     for (UINT i = 0; i < swap_global_idx_list.size(); i++) {
         for (UINT j = i + 1; j < swap_global_idx_list.size();) {

--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -3,13 +3,34 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graphviz.hpp>
+#include <fstream>
 #include <iterator>
+#include <stdexcept>
 
 #include "circuit.hpp"
 #include "gate.hpp"
 #include "gate_factory.hpp"
 #include "gate_matrix.hpp"
 #include "gate_merge.hpp"
+#include "qubit_table.hpp"
+
+#define LOG \
+    if (log_enabled) std::cerr << "[CircOpt] "
+
+struct GateProp {
+    const QuantumGateBase* gate;
+    UINT index;
+};
+
+typedef boost::adjacency_list<boost::vecS,  // OutEdgeList
+    boost::vecS,                            // VertexList
+    boost::directedS,                       // Directed
+    GateProp                                // VertexProperties
+    >
+    DepGraph;
+typedef boost::graph_traits<DepGraph>::vertex_descriptor Vertex;
 
 UINT QuantumCircuitOptimizer::get_rightmost_commute_index(UINT gate_index) {
     UINT cursor = gate_index + 1;
@@ -90,8 +111,12 @@ bool QuantumCircuitOptimizer::is_neighboring(
 }
 
 void QuantumCircuitOptimizer::optimize(
-    QuantumCircuit* circuit_, UINT max_block_size) {
+    QuantumCircuit* circuit_, UINT max_block_size, UINT swap_level) {
     circuit = circuit_;
+    set_qubit_count();
+
+    insert_swap_gates(swap_level);
+
     bool merged_flag = true;
     while (merged_flag) {
         merged_flag = false;
@@ -106,6 +131,10 @@ void QuantumCircuitOptimizer::optimize(
                 // if merged block size is larger than max_block_size, we cannot
                 // merge them
                 if (this->get_merged_gate_size(ind1, ind2) > max_block_size)
+                    continue;
+
+                // we skip merging that would interfere swap insertion
+                if (!can_merge_with_swap_insertion(ind1, ind2, swap_level))
                     continue;
 
                 // if they are separated by not-commutive gate, we cannot merge
@@ -138,8 +167,13 @@ void QuantumCircuitOptimizer::optimize(
     }
 }
 
-void QuantumCircuitOptimizer::optimize_light(QuantumCircuit* circuit_) {
+void QuantumCircuitOptimizer::optimize_light(
+    QuantumCircuit* circuit_, UINT swap_level) {
     circuit = circuit_;
+    set_qubit_count();
+
+    insert_swap_gates(swap_level);
+
     UINT qubit_count = circuit->qubit_count;
     std::vector<std::pair<int, std::vector<UINT>>> current_step(
         qubit_count, std::make_pair(-1, std::vector<UINT>()));
@@ -165,11 +199,14 @@ void QuantumCircuitOptimizer::optimize_light(QuantumCircuit* circuit_) {
         if (hit != -1) parent_qubits = current_step[hit].second;
         if (std::includes(parent_qubits.begin(), parent_qubits.end(),
                 target_qubits.begin(), target_qubits.end())) {
-            auto merged_gate = gate::merge(circuit->gate_list[pos], gate);
-            circuit->remove_gate(ind1);
-            circuit->add_gate(merged_gate, pos + 1);
-            circuit->remove_gate(pos);
-            ind1--;
+            // we merge gates only when it does not interfere swap insertion
+            if (can_merge_with_swap_insertion(pos, ind1, swap_level)) {
+                auto merged_gate = gate::merge(circuit->gate_list[pos], gate);
+                circuit->remove_gate(ind1);
+                circuit->add_gate(merged_gate, pos + 1);
+                circuit->remove_gate(pos);
+                ind1--;
+            }
 
             // std::cout << "merge ";
             // for (auto val : target_qubits) std::cout << val << " ";
@@ -197,4 +234,681 @@ QuantumGateMatrix* QuantumCircuitOptimizer::merge_all(
         current_gate = next_gate;
     }
     return current_gate;
+}
+
+////////////////////////////////////////////////////////////
+// for swap insertion
+////////////////////////////////////////////////////////////
+
+static std::string to_string(std::unordered_set<UINT> s) {
+    std::vector<UINT> v(s.cbegin(), s.cend());
+    std::sort(v.begin(), v.end());
+
+    std::string str;
+    for (UINT i : v) {
+        str += std::to_string(i);
+        str += ",";
+    }
+    return str;
+}
+
+static std::multimap<const QuantumGateBase*, const QuantumGateBase*>
+build_parent_gate_map(DepGraph graph) {
+    std::multimap<const QuantumGateBase*, const QuantumGateBase*>
+        parent_gate_map;
+
+    for (auto e : boost::make_iterator_range(boost::edges(graph))) {
+        parent_gate_map.emplace(graph[boost::target(e, graph)].gate,
+            graph[boost::source(e, graph)].gate);
+    }
+    return parent_gate_map;
+}
+
+static void write_dot(std::ostream& out, DepGraph graph) {
+    class label_writer {
+    public:
+        label_writer(const DepGraph& graph) : graph_(graph) {}
+        void operator()(std::ostream& out, const Vertex& v) const {
+            auto& gate = graph_[v].gate;
+            auto& index = graph_[v].index;
+
+            out << "[label=\"";
+            out << index << ": " << gate->get_name() << "(t:{";
+            for (auto q_idx : gate->get_target_index_list()) {
+                out << q_idx << ",";
+            }
+            out << "}, c:{";
+            for (auto q_idx : gate->get_control_index_list()) {
+                out << q_idx << ",";
+            }
+            out << "})\"]";
+        }
+
+    private:
+        const DepGraph& graph_;
+    };
+
+    struct graph_writer {
+        void operator()(std::ostream& out) const {
+            out << "node [shape=rectangle]" << std::endl;
+        }
+    };
+
+    boost::write_graphviz(out, graph, label_writer(graph),
+        boost::default_writer(), graph_writer());
+}
+
+static bool is_non_communication_gate(const QuantumGateBase* gate) {
+    auto gate_name = gate->get_name();
+    return (gate->is_diagonal() || gate_name == "Projection-0" ||
+            gate_name == "Projection-1" || gate_name == "DiagonalMatrix");
+}
+
+static bool is_swap_gate(const QuantumGateBase* gate) {
+    auto gate_name = gate->get_name();
+    return (gate_name == "SWAP" || gate_name == "FusedSWAP");
+}
+
+static std::unordered_set<UINT> get_qubits_needing_communication(
+    const QuantumGateBase* gate) {
+    std::unordered_set<UINT> qubits;
+
+    if (!is_non_communication_gate(gate)) {
+        auto target_indexes = gate->get_target_index_list();
+        qubits.insert(target_indexes.cbegin(), target_indexes.cend());
+    }
+
+    return qubits;
+}
+
+static DepGraph build_dep_graph(QuantumCircuit* circuit) {
+    DepGraph graph;
+
+    const UINT num_gates = circuit->gate_list.size();
+    const UINT full_commute_prop =
+        (FLAG_X_COMMUTE | FLAG_Y_COMMUTE | FLAG_Z_COMMUTE);
+
+    std::vector<UINT> qubit_to_commute_prop(circuit->qubit_count, 0x0);
+    std::vector<std::vector<Vertex>> qubit_to_parent_vertexes(
+        circuit->qubit_count);
+    std::vector<std::vector<Vertex>> qubit_to_child_vertexes(
+        circuit->qubit_count);
+
+    for (UINT i = 0; i < num_gates; i++) {
+        auto g = circuit->gate_list[i];
+        auto v = add_vertex(graph);
+
+        graph[v].gate = g;
+        graph[v].index = i;
+
+        auto collect_parent_vertexes = [&](const UINT q,
+                                           const UINT commute_prop) {
+            std::unordered_set<Vertex> v_set;
+
+            // if Identity gate, there is no dependency
+            if (commute_prop == full_commute_prop) {
+                return v_set;
+            }
+
+            // depend target vertexes for current commute type
+            auto& parent_vertexes = qubit_to_parent_vertexes[q];
+            // depend source vertexes for current commute type
+            auto& child_vertexes = qubit_to_child_vertexes[q];
+
+            // both are the same commute_prop and not zero
+            if ((commute_prop & qubit_to_commute_prop[q]) != 0) {
+                child_vertexes.push_back(v);
+                v_set.insert(parent_vertexes.cbegin(), parent_vertexes.cend());
+            } else {
+                v_set.insert(child_vertexes.cbegin(), child_vertexes.cend());
+
+                // swap parent_vertexes and child_vertexes
+                // to set child_vertexes to parent_vertexes
+                std::swap(parent_vertexes, child_vertexes);
+                child_vertexes.clear();
+                child_vertexes.push_back(v);
+                // check if commute_prop has only one or no prop.
+                if (commute_prop == FLAG_X_COMMUTE ||
+                    commute_prop == FLAG_Y_COMMUTE ||
+                    commute_prop == FLAG_Z_COMMUTE || commute_prop == 0) {
+                    qubit_to_commute_prop[q] = commute_prop;
+                } else {
+                    throw std::runtime_error(
+                        "Error: QuantumCircuitOptimizer::build_dep_graph() "
+                        "unexpected commute_prop");
+                }
+            }
+
+            return v_set;
+        };
+
+        std::unordered_set<Vertex> parent_vertexes;
+
+        for (auto qubit_info : g->target_qubit_list) {
+            const UINT commute_prop =
+                qubit_info.get_merged_property(full_commute_prop);
+            auto deps =
+                collect_parent_vertexes(qubit_info.index(), commute_prop);
+            parent_vertexes.insert(deps.cbegin(), deps.cend());
+        }
+        for (auto qubit_info : g->control_qubit_list) {
+            const UINT commute_prop = FLAG_Z_COMMUTE;
+            auto deps =
+                collect_parent_vertexes(qubit_info.index(), commute_prop);
+            parent_vertexes.insert(deps.cbegin(), deps.cend());
+        }
+
+        for (auto w : parent_vertexes) {
+            boost::add_edge(w, v, graph);
+        }
+    }
+
+    return graph;
+}
+
+void QuantumCircuitOptimizer::set_qubit_count(void) {
+    // if local_qc is 1, state vector is not distributed
+    UINT log_nodes = std::log2(mpisize);
+    if (circuit->qubit_count >= log_nodes + 2) {
+        local_qc = circuit->qubit_count - log_nodes;
+        global_qc = log_nodes;
+    } else {
+        local_qc = circuit->qubit_count;
+        global_qc = 0;
+    }
+}
+
+bool QuantumCircuitOptimizer::can_merge_with_swap_insertion(
+    UINT gate_idx1, UINT gate_idx2, UINT swap_level) {
+    // if swap insertion is disabled, can merge
+    if (swap_level == 0) {
+        return true;
+    }
+
+    auto& gate1 = circuit->gate_list[gate_idx1];
+    auto& gate2 = circuit->gate_list[gate_idx2];
+
+    auto is_global_qubit = [&](auto idx) { return idx >= local_qc; };
+
+    auto is_swap_or_nocomm_gate_with_global_target = [&](QuantumGateBase* g) {
+        auto targets = g->get_target_index_list();
+        return (is_swap_gate(g) || is_non_communication_gate(g)) &&
+               std::any_of(targets.cbegin(), targets.cend(), is_global_qubit);
+    };
+
+    if (is_swap_or_nocomm_gate_with_global_target(gate1) ||
+        is_swap_or_nocomm_gate_with_global_target(gate2)) {
+        return false;
+    }
+
+    auto controls_gate1 = gate1->get_control_index_list();
+    auto controls_gate2 = gate2->get_control_index_list();
+    std::unordered_set<UINT> global_control_gate1;
+    std::unordered_set<UINT> global_control_gate2;
+
+    std::copy_if(controls_gate1.cbegin(), controls_gate1.cend(),
+        std::inserter(global_control_gate1, global_control_gate1.begin()),
+        is_global_qubit);
+    std::copy_if(controls_gate2.cbegin(), controls_gate2.cend(),
+        std::inserter(global_control_gate2, global_control_gate2.begin()),
+        is_global_qubit);
+
+    return global_control_gate1 == global_control_gate2;
+}
+
+bool QuantumCircuitOptimizer::needs_communication(
+    const UINT gate_index, QubitTable& qt) {
+    auto gate = circuit->gate_list[gate_index];
+    auto logical_qubits = get_qubits_needing_communication(gate);
+    return std::any_of(
+        logical_qubits.cbegin(), logical_qubits.cend(), [&](auto& l_q) {
+            // true if physical qubit is global qubit
+            return qt.l2p[l_q] >= local_qc;
+        });
+}
+
+UINT QuantumCircuitOptimizer::move_gates_without_communication(
+    const UINT gate_idx, QubitTable& qt,
+    std::multimap<const QuantumGateBase*, const QuantumGateBase*>& dep_map,
+    std::unordered_set<const QuantumGateBase*>& processed_gates) {
+    const UINT num_gates = circuit->gate_list.size();
+    UINT moved_gates = 0;
+    for (UINT i = gate_idx; i < num_gates; i++) {
+        // no comm & dependency is solved
+        if (!needs_communication(i, qt)) {
+            auto range = dep_map.equal_range(circuit->gate_list[i]);
+
+            bool is_dep_solved = true;
+            for (auto it = range.first; it != range.second; ++it) {
+                if (processed_gates.find(it->second) == processed_gates.end()) {
+                    is_dep_solved = false;
+                }
+            }
+
+            if (is_dep_solved) {
+                auto g = circuit->gate_list[i];
+                circuit->move_gate(i, gate_idx + moved_gates);
+                moved_gates++;
+
+                qt.rewrite_gate_qubit_indexes(g);
+                processed_gates.insert(g);
+            }
+        }
+    }
+    return moved_gates;
+}
+
+std::unordered_set<UINT> QuantumCircuitOptimizer::find_next_local_qubits(
+    const UINT start_gate_idx) {
+    // next local qubit set (logical index)
+    std::unordered_set<UINT> next_local_qubits;
+
+    for (UINT gate_idx = start_gate_idx; gate_idx < circuit->gate_list.size();
+         gate_idx++) {
+        auto gate = circuit->gate_list[gate_idx];
+        auto addition_qubits = get_qubits_needing_communication(gate);
+
+        for (auto q : next_local_qubits) {
+            addition_qubits.erase(q);
+        }
+
+        // if (# of qubits after adding the gate)<=(# of local qubits),
+        // add gate indexes
+        if (next_local_qubits.size() + addition_qubits.size() <= local_qc) {
+            next_local_qubits.insert(
+                addition_qubits.cbegin(), addition_qubits.cend());
+        } else {
+            break;
+        }
+    }
+
+    LOG << "next local qubits: " << to_string(next_local_qubits) << std::endl;
+
+    return next_local_qubits;
+}
+
+UINT QuantumCircuitOptimizer::move_matching_qubits_to_local_upper(
+    UINT lowest_idx, QubitTable& qt, std::function<bool(UINT)> is_matched,
+    UINT gate_insertion_pos) {
+    // bool is_matched(UINT logical_qubit)
+
+    UINT num_inserted_gates = 0;
+    int j = lowest_idx - 1;
+    for (int i = local_qc - 1; i >= (int)lowest_idx; --i) {
+        // if the qubit meets condition, skip it
+        if (is_matched(qt.p2l[i])) continue;
+
+        // if the qubit does not meet condition, find a matched qubit
+        for (; j >= 0; --j) {
+            if (is_matched(qt.p2l[j])) break;
+        }
+
+        // swap qubits if a matched qubit is found
+        if (j >= 0) {
+            num_inserted_gates += qt.add_swap_gate(
+                circuit, j, i, 1, gate_insertion_pos + num_inserted_gates);
+        } else {
+            throw std::runtime_error(
+                "Error: "
+                "QuantumCircuitOptimizer::move_matching_qubits_to_local_upper()"
+                " "
+                "no enougth matched qubits");
+        }
+    }
+    return num_inserted_gates;
+}
+
+UINT QuantumCircuitOptimizer::rearrange_qubits(const UINT gate_idx,
+    std::unordered_set<UINT> next_local_qubit, QubitTable& qt) {
+    UINT num_inserted_gates = 0;
+
+    std::unordered_set<UINT> cur_local_qubits(
+        qt.p2l.cbegin(), qt.p2l.cbegin() + local_qc);
+    std::unordered_set<UINT> import_qubits, exportable_qubits;
+
+    // e.g.
+    // qt.p2l = [0 4 3 1 2 7 6 5]
+    // global_qc = 4, local_qc = 4
+    //
+    //  local  | global
+    // -----------------
+    // 0 4 3 1 | 2 7 6 5
+    //
+    // cur_local_qubits = {0, 1, 3 ,4}
+    // next_local_qubits = {2, 4, 6}
+
+    // import_qubits = next_local_qubit - cur_local_qubits
+    // e.g. {2, 6} = {2, 4, 6} - {0, 1, 3 ,4}
+    for (UINT i : next_local_qubit) {
+        if (cur_local_qubits.count(i) == 0) {
+            import_qubits.insert(i);
+        }
+    }
+
+    // exportable_qubits = cur_local_qubits - next_local_qubit
+    // e.g. {0, 1, 3} = {0, 1, 3 ,4} - {2, 4, 6}
+    for (UINT i : cur_local_qubits) {
+        if (next_local_qubit.count(i) == 0) {
+            exportable_qubits.insert(i);
+        }
+    }
+
+    LOG << "import qubits: " << to_string(import_qubits) << std::endl;
+    LOG << "exportable qubits: " << to_string(exportable_qubits) << std::endl;
+
+    // make index and width for swap
+    // e.g. swap_global_idx_list = [2 6]
+    //      swap_width_list      = [1 1]
+    std::vector<UINT> swap_global_idx_list;
+    std::vector<UINT> swap_width_list;
+    for (UINT i = local_qc; i < circuit->qubit_count; i++) {
+        if (import_qubits.count(qt.p2l[i])) {
+            swap_global_idx_list.push_back(i);
+            swap_width_list.push_back(1);
+        }
+    }
+
+    // fuse swaps
+    // e.g. swap_global_idx_list = [2 6] -> [2]
+    //      swap_width_list      = [1 1] -> [3]
+    // TODO: if fast qubit swapping between global qubits is implemented,
+    //       global qubits should be rearranged to be contiguous.
+    UINT total_swap_width = import_qubits.size();
+    int extra_local_qc = exportable_qubits.size() - import_qubits.size();
+
+    for (UINT i = 0; i < swap_global_idx_list.size(); i++) {
+        for (UINT j = i + 1; j < swap_global_idx_list.size();) {
+            int gap = (int)(swap_global_idx_list[j]) -
+                      (swap_global_idx_list[i] + swap_width_list[i]);
+
+            if (gap <= extra_local_qc) {
+                swap_width_list[i] += swap_width_list[j] + gap;
+                extra_local_qc -= gap;
+                total_swap_width += gap;
+                swap_global_idx_list.erase(swap_global_idx_list.begin() + j);
+                swap_width_list.erase(swap_width_list.begin() + j);
+            } else {
+                j++;
+            }
+        }
+    }
+
+    LOG << "extra_local_qc = " << extra_local_qc << std::endl;
+
+    UINT lowest_swap_idx = local_qc - total_swap_width;
+
+    // gather target local qubits to the upper of local qubits
+    // e.g.
+    //            local  | global
+    //           -----------------
+    // before    0 4 3 1 | 2 7 6 5
+    //            X
+    // after     4 0 3 1 | 2 7 6 5  exportable_qubits={0,1,3}
+    //                              are placed at local upper
+
+    num_inserted_gates += move_matching_qubits_to_local_upper(
+        lowest_swap_idx, qt,
+        [&](UINT q) { return exportable_qubits.count(q) != 0; },
+        gate_idx + num_inserted_gates);
+
+    // add SWAP/FusedSWAP gates to exchange global qubits with local qubits
+    // e.g.
+    //            local  | global
+    //           -----------------
+    // before    4 0 3 1 | 2 7 6 5
+    //                             ) FusedSWAP(1, 4, 3)
+    // after     4 2 7 6 | 0 3 1 5   next_local_qubits={2,4,6} are placed local
+    //
+    UINT swap_local_idx = lowest_swap_idx;
+    for (UINT i = 0; i < swap_global_idx_list.size(); i++) {
+        UINT swap_global_idx = swap_global_idx_list[i];
+        UINT swap_width = swap_width_list[i];
+
+        num_inserted_gates += qt.add_swap_gate(circuit, swap_local_idx,
+            swap_global_idx, swap_width, gate_idx + num_inserted_gates);
+        swap_local_idx += swap_width;
+    }
+
+    LOG << "next: " << qt << std::endl;
+
+    return num_inserted_gates;
+}
+
+void QuantumCircuitOptimizer::revert_qubit_order(QubitTable& qt) {
+    // reference qubit order
+    std::vector<UINT> ref_order(circuit->qubit_count);
+    std::iota(ref_order.begin(), ref_order.end(), 0);
+
+    // find the lowest and highest global qubits which needs to be rearranged
+    // e.g.
+    //          local  | global
+    //         -----------------
+    // ref     0 1 2 3 | 4 5 6 7
+    // qt.p2l  0 3 5 1 | 4 6 7 2
+    //                     |   `- diff_global_idx_highest
+    //                     `--- diff_global_idx_lowest
+    UINT diff_global_idx_lowest = 0;   // dummy value
+    UINT diff_global_idx_highest = 0;  // dummy value
+    UINT diff_global_qubits_count = 0;
+
+    for (UINT i = local_qc; i < circuit->qubit_count; i++) {
+        if (qt.p2l[i] != ref_order[i]) {
+            if (diff_global_qubits_count == 0) {
+                diff_global_idx_lowest = i;
+            }
+            diff_global_idx_highest = i;
+            diff_global_qubits_count++;
+        }
+    }
+
+    if (diff_global_qubits_count > 0) {
+        // reorder global qubits
+
+        UINT swap_global_idx = diff_global_idx_lowest;
+        UINT swap_width = diff_global_idx_highest - diff_global_idx_lowest + 1;
+        UINT swap_local_idx = local_qc - swap_width;
+        // find the lowest and highest global qubits which needs to be
+        // rearranged e.g.
+        //          local  | global
+        //         -----------------
+        // ref     0 1 2 3 | 4 5 6 7
+        // qt.p2l  0 3 5 1 | 4 6 7 2
+        //           |         `- swap_global_idx   swap_width=3
+        //           `- swap_local_idx
+
+        // check if the global qubits that require reordering include qubits
+        // corresponding to the reference qubits or not. e.g.
+        //          local  | global
+        //         -----------------
+        // ref     0 1 2 3 | 4[5 6 7]  corr_ref_qubits = {5,6,7}
+        // qt.p2l  0 3 5 1 | 4[6 2 7]  global_qubits_to_reorder = {2,6,7}
+        //                             => corr_ref_count = 1
+        std::unordered_set<UINT> corr_ref_qubits(
+            ref_order.cbegin() + swap_global_idx,
+            ref_order.cbegin() + swap_global_idx + swap_width);
+        UINT corr_ref_count = std::count_if(qt.p2l.cbegin() + swap_global_idx,
+            qt.p2l.cbegin() + swap_global_idx + swap_width,
+            [&](UINT q) { return corr_ref_qubits.count(q); });
+
+        // check whether we can reorder qubits in a maximum of 2 FusedSWAPs or
+        // not
+        if (corr_ref_count == 0 ||
+            (UINT)(swap_width * 2 - corr_ref_count) <= local_qc) {
+            if (corr_ref_count > 0) {
+                // if global_qubits_to_reorder contains corr_ref_qubits,
+                // rearrange qubits at swap_local_idx ~ (local_qc-1) not to
+                // contain corr_ref_qubits e.g.
+                //          local  | global
+                //         -----------------
+                // ref     0 1 2 3 | 4 5 6 7  corr_ref_qubits = {5,6,7}
+                // qt.p2l  0[3 5 1]| 4 6 2 7  [3 5 1] has 5 in corr_ref_quits
+                //          \ /
+                //           X
+                //          / \               #
+                // qt.p2l  5[3 0 1]| 4 6 2 7  [3 0 1] has no index in
+                //                            corr_ref_quits
+                move_matching_qubits_to_local_upper(
+                    local_qc - swap_width, qt,
+                    [&](UINT q) { return corr_ref_qubits.count(q) == 0; },
+                    circuit->qubit_count /*end of circuit*/);
+
+                // and then fused-swap between local and global qubits
+                // e.g.
+                //          local  | global
+                //         -----------------
+                // ref     0 1 2 3 | 4 5 6 7
+                // qt.p2l  5[3 0 1]| 4[6 2 7]
+                //            \ \ \   / / /
+                //             ===========
+                //            / / /   \ \ \    #
+                // qt.p2l  5[6 2 7]| 4[3 0 1]
+                qt.add_swap_gate(
+                    circuit, swap_local_idx, swap_global_idx, swap_width);
+            }
+
+            // in local qubits, reorder the qubits to be swapped
+            // e.g.
+            //          local  | global
+            //         -----------------
+            // ref     0 1 2 3 | 4 5 6 7
+            // qt.p2l  5[6 2 7]| 4 3 0 1
+            //          \\/
+            //          /\\               #
+            // qt.p2l  2[5 6 7]| 4 3 0 1
+            for (UINT i = 0; i < swap_width; i++) {
+                qt.add_swap_gate(circuit, swap_local_idx + i,
+                    qt.l2p[ref_order[swap_global_idx + i]], 1);
+            }
+
+            // and then, fused-swap between local and global qubits
+            // e.g.
+            //          local  | global
+            //         -----------------
+            // ref     0 1 2 3 | 4 5 6 7
+            // qt.p2l  2[5 6 7]| 4[3 0 1]
+            //            \ \ \   / / /
+            //             ===========
+            //            / / /   \ \ \    #
+            // qt.p2l  2[3 0 1]| 4[5 6 7]
+            qt.add_swap_gate(
+                circuit, swap_local_idx, swap_global_idx, swap_width);
+        } else {
+            // naively reorder qubits one by one
+            for (UINT i = local_qc; i < circuit->qubit_count; i++) {
+                qt.add_swap_gate(circuit, i, qt.l2p[ref_order[i]], 1);
+            }
+        }
+    }
+
+    // reorder local qubits one by one
+    // e.g.
+    //          local  | global
+    //         -----------------
+    // ref     0 1 2 3 | 4 5 6 7
+    // qt.p2l  2 3 0 1 | 4 5 6 7
+    //          \ X /
+    //           X X
+    //          / X \             #
+    // qt.p2l  0 1 2 3 | 4 5 6 7
+    for (UINT i = 0; i < local_qc; i++) {
+        qt.add_swap_gate(circuit, i, qt.l2p[ref_order[i]], 1);
+    }
+}
+
+void QuantumCircuitOptimizer::insert_swap_gates(const UINT level) {
+    if (level == 0) {
+        return;
+    }
+
+    const bool gate_reordering_enabled = (level >= 2);
+
+    if (level > 2) {
+        throw std::invalid_argument(
+            "Error: "
+            "QuantumCircuit::QuantumCircuitOptimizer::insert_swap_gates(level) "
+            ": invalid level. "
+            "'0' means adding no SWAP/FusedSWAP, "
+            "'1' means adding SWAP/FusedSWAP, "
+            "'2' means adding SWAP/FusedSWAP with gate reordering");
+    }
+
+    if (global_qc == 0 && mpirank == 0) {
+        std::cerr
+            << "Warning: "
+               "QuantumCircuit::QuantumCircuitOptimizer::insert_swap_gates("
+               "level) "
+               ": insert_swap is no effect for non-distributed state vector"
+            << std::endl;
+    }
+
+    // warn if circuit has SWAP/FusedSWAP gates
+    bool has_swap = std::any_of(
+        circuit->gate_list.cbegin(), circuit->gate_list.cend(), is_swap_gate);
+    if (has_swap) {
+        std::cerr
+            << "Warning: "
+               "QuantumCircuit::QuantumCircuitOptimizer::insert_swap_gates("
+               "level) "
+               ": given circuit already has SWAP and/or FusedSWAP gates. "
+               "Inserting SWAP gates may increase the amount of communication."
+            << std::endl;
+    }
+
+    std::chrono::system_clock::time_point t_begin_depanalysis, t_begin_swapadd,
+        t_end;
+
+    // dependency analysis
+    t_begin_depanalysis = std::chrono::system_clock::now();
+    auto graph =
+        gate_reordering_enabled ? build_dep_graph(circuit) : DepGraph();
+    auto parent_gate_map = build_parent_gate_map(graph);
+
+    if (log_enabled) {
+        std::ofstream file("circuit_dep.dot");
+        write_dot(file, graph);
+    }
+
+    t_begin_swapadd = std::chrono::system_clock::now();
+    UINT num_gates = circuit->gate_list.size();
+    QubitTable qt(circuit->qubit_count);
+
+    std::unordered_set<const QuantumGateBase*> processed_gates;
+
+    // add SWAP/FusedSWAP gates
+    for (UINT gate_idx = 0; gate_idx < num_gates; gate_idx++) {
+        LOG << "processing gate #" << gate_idx << std::endl;
+        if (needs_communication(gate_idx, qt)) {
+            LOG << "cur: " << qt << std::endl;
+            if (gate_reordering_enabled) {
+                gate_idx += move_gates_without_communication(
+                    gate_idx, qt, parent_gate_map, processed_gates);
+            }
+            std::unordered_set<UINT> next_local_qubit =
+                find_next_local_qubits(gate_idx);
+            const UINT num_inserted_gates =
+                rearrange_qubits(gate_idx, next_local_qubit, qt);
+            gate_idx += num_inserted_gates;
+            num_gates += num_inserted_gates;
+        }
+        LOG << "rewrite_gate_qubit_indexes #" << gate_idx << std::endl;
+        qt.rewrite_gate_qubit_indexes(circuit->gate_list[gate_idx]);
+        processed_gates.insert(circuit->gate_list[gate_idx]);
+    }
+
+    // reorder qubits to the original order
+    revert_qubit_order(qt);
+
+    t_end = std::chrono::system_clock::now();
+    double t_depanalysis =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            t_begin_swapadd - t_begin_depanalysis)
+            .count() /
+        1000.0;
+    double t_swapadd = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           t_end - t_begin_swapadd)
+                           .count() /
+                       1000.0;
+
+    LOG << "time for dep_analysis [s] " << t_depanalysis << std::endl;
+    LOG << "time for swap_add [s] " << t_swapadd << std::endl;
 }

--- a/src/cppsim/circuit_optimizer.hpp
+++ b/src/cppsim/circuit_optimizer.hpp
@@ -1,11 +1,16 @@
 
 #pragma once
 
+#include <unordered_set>
+
+#include "csim/MPIutil.hpp"
+#include "exception.hpp"
 #include "type.hpp"
 
 class QuantumCircuit;
 class QuantumGateBase;
 class QuantumGateMatrix;
+class QubitTable;
 
 /**
  * \~japanese-en 量子回路の圧縮を行うクラス
@@ -15,17 +20,71 @@ class QuantumGateMatrix;
  */
 class DllExport QuantumCircuitOptimizer {
 private:
-    QuantumCircuit* circuit;
+    QuantumCircuit* circuit; /**< \~japanese-en 量子回路*/
+    UINT local_qc;    /**< \~japanese-en ローカル量子ビットの数*/
+    UINT global_qc;   /**< \~japanese-en グローバル量子ビットの数*/
+    UINT mpisize;     /**< \~japanese-en MPIプロセスの数*/
+    UINT mpirank;     /**< \~japanese-en MPIプロセスのランク*/
+    bool log_enabled; /**< \~japanese-en ログ出力が有効かどうか*/
     UINT get_rightmost_commute_index(UINT gate_index);
     UINT get_leftmost_commute_index(UINT gate_index);
     UINT get_merged_gate_size(UINT gate_index1, UINT gate_index2);
     bool is_neighboring(UINT gate_index1, UINT gate_index2);
 
+    ////////////////////////////////////////////////////////////
+    // for swap insertion
+    ////////////////////////////////////////////////////////////
+    void set_qubit_count(void);
+    bool can_merge_with_swap_insertion(
+        UINT gate_idx1, UINT gate_idx2, UINT swap_level);
+    bool needs_communication(const UINT gate_index, QubitTable& qt);
+    UINT move_gates_without_communication(const UINT gate_idx, QubitTable& qt,
+        std::multimap<const QuantumGateBase*, const QuantumGateBase*>& dep_map,
+        std::unordered_set<const QuantumGateBase*>& processed_gates);
+    std::unordered_set<UINT> find_next_local_qubits(const UINT start_gate_idx);
+    UINT move_matching_qubits_to_local_upper(UINT lowest_idx, QubitTable& qt,
+        std::function<bool(UINT)> fn, UINT gate_insertion_pos);
+    UINT rearrange_qubits(const UINT gate_idx,
+        std::unordered_set<UINT> next_local_qubits, QubitTable& qt);
+    void revert_qubit_order(QubitTable& qt);
+    void insert_swap_gates(const UINT level);
+
 public:
     /**
      * \~japanese-en コンストラクタ
      */
-    QuantumCircuitOptimizer(){};
+    QuantumCircuitOptimizer(UINT mpi_size = 0) {
+#ifdef _USE_MPI
+        MPIutil& mpiutil = MPIutil::get_inst();
+        if (mpi_size == 0) {
+            mpisize = mpiutil.get_size();
+        } else {
+            mpisize = mpi_size;
+        }
+        mpirank = mpiutil.get_rank();
+#else
+        if (mpi_size == 0) {
+            mpisize = 1;
+        } else {
+            mpisize = mpi_size;
+        }
+        mpirank = 0;
+#endif
+        if ((mpisize & (mpisize - 1))) {
+            throw MPISizeException(
+                "Error: "
+                "QuantumCircuitOptimizer::QuantumCircuitOptimizer(UINT): "
+                "mpi_size must be power of 2");
+        }
+
+        log_enabled = false;
+        if (const char* tmp = std::getenv("QULACS_OPTIMIZER_LOG")) {
+            const UINT tmp_val = strtol(tmp, nullptr, 0);
+            log_enabled = (tmp_val > 0);
+        }
+        // enable logging only on rank 0
+        log_enabled = log_enabled && mpirank == 0;
+    };
 
     /**
      * \~japanese-en デストラクタ
@@ -41,8 +100,11 @@ public:
      *
      * @param[in] circuit 量子回路のインスタンス
      * @param[in] max_block_size 合成後に許されるブロックの最大サイズ
+     * @param[in] swap_level SWAP挿入による最適化レベル。0: SWAP追加なし、1:
+     * SWAP追加、2: SWAP追加とゲート順序変更。
      */
-    void optimize(QuantumCircuit* circuit, UINT max_block_size = 2);
+    void optimize(
+        QuantumCircuit* circuit, UINT max_block_size = 2, UINT swap_level = 0);
 
     /**
      * \~japanese-en 与えられた量子回路のゲートを指定されたブロックまで纏める。
@@ -52,8 +114,10 @@ public:
      * 二つのゲートが合成可能であるとは、二つのゲートそれぞれについて隣接するゲートとの交換を繰り返し、二つのゲートが隣接した位置まで移動できることを指す。
      *
      * @param[in] circuit 量子回路のインスタンス
+     * @param[in] swap_level SWAP挿入による最適化レベル。0: SWAP追加なし、1:
+     * SWAP追加、2: SWAP追加とゲート順序変更。
      */
-    void optimize_light(QuantumCircuit* circuit);
+    void optimize_light(QuantumCircuit* circuit, UINT swap_level = 0);
 
     /**
      * \~japanese-en 量子回路を纏めて一つの巨大な量子ゲートにする

--- a/src/cppsim/circuit_optimizer.hpp
+++ b/src/cppsim/circuit_optimizer.hpp
@@ -37,15 +37,17 @@ private:
     void set_qubit_count(void);
     bool can_merge_with_swap_insertion(
         UINT gate_idx1, UINT gate_idx2, UINT swap_level);
-    bool needs_communication(const UINT gate_index, QubitTable& qt);
-    UINT move_gates_without_communication(const UINT gate_idx, QubitTable& qt,
-        std::multimap<const QuantumGateBase*, const QuantumGateBase*>& dep_map,
+    bool needs_communication(const UINT gate_index, const QubitTable& qt);
+    UINT move_gates_without_communication(const UINT gate_idx,
+        const QubitTable& qt,
+        const std::multimap<const QuantumGateBase*, const QuantumGateBase*>&
+            dep_map,
         std::unordered_set<const QuantumGateBase*>& processed_gates);
     std::unordered_set<UINT> find_next_local_qubits(const UINT start_gate_idx);
     UINT move_matching_qubits_to_local_upper(UINT lowest_idx, QubitTable& qt,
         std::function<bool(UINT)> fn, UINT gate_insertion_pos);
     UINT rearrange_qubits(const UINT gate_idx,
-        std::unordered_set<UINT> next_local_qubits, QubitTable& qt);
+        const std::unordered_set<UINT>& next_local_qubits, QubitTable& qt);
     void revert_qubit_order(QubitTable& qt);
     void insert_swap_gates(const UINT level);
 

--- a/src/cppsim/qubit_table.cpp
+++ b/src/cppsim/qubit_table.cpp
@@ -1,0 +1,72 @@
+#include "qubit_table.hpp"
+
+#include "circuit.hpp"
+#include "gate.hpp"
+#include "gate_factory.hpp"
+
+QubitTable::QubitTable(const UINT qubit_count)
+    : _qubit_count(qubit_count),
+      _p2l_table(qubit_count),
+      _l2p_table(qubit_count),
+      p2l(_p2l_table),
+      l2p(_l2p_table) {
+    std::iota(_p2l_table.begin(), _p2l_table.end(), 0);
+    std::iota(_l2p_table.begin(), _l2p_table.end(), 0);
+}
+
+QubitTable::QubitTable(const QubitTable& qt)
+    : _qubit_count(qt._qubit_count), p2l(_p2l_table), l2p(_l2p_table) {
+    std::copy(qt.p2l.begin(), qt.p2l.end(), back_inserter(_p2l_table));
+    std::copy(qt.l2p.begin(), qt.l2p.end(), back_inserter(_l2p_table));
+}
+
+UINT QubitTable::add_swap_gate(
+    QuantumCircuit* circuit, UINT idx0, UINT idx1, UINT width) {
+    return add_swap_gate(circuit, idx0, idx1, width, circuit->gate_list.size());
+}
+
+UINT QubitTable::add_swap_gate(
+    QuantumCircuit* circuit, UINT idx0, UINT idx1, UINT width, UINT gate_pos) {
+    //    LOG << "add_swap_gate(" << idx0 << "," << idx1 << "," << width << ")"
+    //    << std::endl;
+    if (idx0 == idx1) {
+        return 0;
+    }
+
+    const UINT i = (idx0 < idx1) ? idx0 : idx1;
+    const UINT j = (idx0 < idx1) ? idx1 : idx0;
+
+    if (j + width > _qubit_count) {
+        throw std::invalid_argument(
+            "QubitTable::add_swap_gate() out of qubit range");
+    }
+    if (i + width > j) {
+        throw std::invalid_argument(
+            "QubitTable::add_swap_gate() overlap range");
+    }
+
+    if (width == 1) {
+        circuit->add_gate(gate::SWAP(i, j), gate_pos);
+    } else {
+        circuit->add_gate(gate::FusedSWAP(i, j, width), gate_pos);
+    }
+
+    for (UINT w = 0; w < width; w++) {
+        std::swap(_p2l_table[i + w], _p2l_table[j + w]);
+        std::swap(_l2p_table[_p2l_table[i + w]], _l2p_table[_p2l_table[j + w]]);
+    }
+
+    return 1;
+}
+
+void QubitTable::rewrite_gate_qubit_indexes(QuantumGateBase* g) {
+    std::vector<UINT> target_index_list = g->get_target_index_list();
+    for_each(target_index_list.begin(), target_index_list.end(),
+        [&](UINT& x) { x = _l2p_table[x]; });
+    g->set_target_index_list(target_index_list);
+
+    std::vector<UINT> control_index_list = g->get_control_index_list();
+    for_each(control_index_list.begin(), control_index_list.end(),
+        [&](UINT& x) { x = _l2p_table[x]; });
+    g->set_control_index_list(control_index_list);
+}

--- a/src/cppsim/qubit_table.cpp
+++ b/src/cppsim/qubit_table.cpp
@@ -59,7 +59,7 @@ UINT QubitTable::add_swap_gate(
     return 1;
 }
 
-void QubitTable::rewrite_gate_qubit_indexes(QuantumGateBase* g) {
+void QubitTable::rewrite_gate_qubit_indexes(QuantumGateBase* g) const {
     std::vector<UINT> target_index_list = g->get_target_index_list();
     for_each(target_index_list.begin(), target_index_list.end(),
         [&](UINT& x) { x = _l2p_table[x]; });

--- a/src/cppsim/qubit_table.hpp
+++ b/src/cppsim/qubit_table.hpp
@@ -62,7 +62,7 @@ public:
      *
      * @param[in,out] g 書き換える量子ゲート
      */
-    void rewrite_gate_qubit_indexes(QuantumGateBase* g);
+    void rewrite_gate_qubit_indexes(QuantumGateBase* g) const;
 
     /**
      * \~japanese-en

--- a/src/cppsim/qubit_table.hpp
+++ b/src/cppsim/qubit_table.hpp
@@ -1,0 +1,93 @@
+
+#pragma once
+
+#include <unordered_set>
+
+#include "type.hpp"
+
+class QuantumCircuit;
+class QuantumGateBase;
+
+/**
+ * \~japanese-en 量子ビットの順序を管理するためのクラス
+ */
+class QubitTable {
+private:
+    UINT _qubit_count;
+    std::vector<UINT> _p2l_table;
+    std::vector<UINT> _l2p_table;
+    QubitTable& operator=(const QubitTable&) = delete;
+
+public:
+    const std::vector<UINT>&
+        p2l; /**< \~japanese-en 論理添え字への変換テーブル*/
+    const std::vector<UINT>&
+        l2p; /**< \~japanese-en 物理添え字への変換テーブル*/
+
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param[in] qubit_count 量子ビットの数
+     */
+    explicit QubitTable(UINT qubit_count);
+
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param[in] qt 量子ビットテーブル
+     */
+    QubitTable(const QubitTable& qt);
+
+    /**
+     * \~japanese-en 量子ビットテーブルを出力する
+     *
+     * @return 受け取ったストリーム
+     */
+    friend std::ostream& operator<<(std::ostream& os, const QubitTable& qt) {
+        os << "qc:" << qt._qubit_count;
+        os << ", p2l:[";
+        for (UINT i : qt._p2l_table) {
+            os << i << ",";
+        }
+        os << "], l2p[";
+        for (UINT i : qt._l2p_table) {
+            os << i << ",";
+        }
+        os << "]";
+        return os;
+    }
+
+    /**
+     * \~japanese-en 量子ゲートの量子ビットの添え字を書き換える
+     *
+     * @param[in,out] g 書き換える量子ゲート
+     */
+    void rewrite_gate_qubit_indexes(QuantumGateBase* g);
+
+    /**
+     * \~japanese-en
+     * 量子回路にSWAP/FusedSWAPゲートを追加し、量子ビットテーブルを更新する
+     *
+     * @param[in,out] circuit ゲートを追加する量子回路
+     * @param[in] idx0 交換する量子ビットの物理開始添え字
+     * @param[in] idx1 交換する量子ビットの物理開始添え字
+     * @param[in] width 交換する量子ビットの幅
+     * @return 追加した量子ゲート数
+     */
+    UINT add_swap_gate(
+        QuantumCircuit* circuit, UINT idx0, UINT idx1, UINT width);
+
+    /**
+     * \~japanese-en
+     * 量子回路にSWAP/FusedSWAPゲートを追加し、量子ビットテーブルを更新する
+     *
+     * @param[in,out] circuit ゲートを追加する量子回路
+     * @param[in] idx0 交換する量子ビットの物理開始添え字
+     * @param[in] idx1 交換する量子ビットの物理開始添え字
+     * @param[in] width 交換する量子ビットの幅
+     * @param[in] gate_pos ゲートを追加する位置
+     * @return 追加した量子ゲート数
+     */
+    UINT add_swap_gate(QuantumCircuit* circuit, UINT idx0, UINT idx1,
+        UINT width, UINT gate_pos);
+};


### PR DESCRIPTION
This PR adds a swap/fused-swap gate insertion feature to circuit optimizers for multi-cpu execution.

As described in README_MPI.md, you can use this feature by adding `swap_level` argument to optimize() or optimize_light() method.

Example code:
```python
from qulacs import QuantumCircuit
from qulacs.circuit import QuantumCircuitOptimizer

state = QuantumState(nqubits, True)
circuit = QuantumCircuit(nqubits)
# add some gates to the circuit here

qco = QuantumCircuitOptimizer()
qco.optimize(circuit, blocksize, swap_level=2)

circuit.update_quantum_state(state)
```

The value for `swap_level` means:
- 0: No SWAP/FusedSWAP gate insertion (default)
- 1: Insert SWAP/FusedSWAP gates to reduce communication without changing gate order
- 2: Insert SWAP/FusedSWAP gates to reduce communication with changing gate order

The number of processes is automatically obtained from MPI environment at runtime.
To optimize the circuit for a specific number of processors, add the `mpi_size` argument to the QuantumCircuitOptimizer constructor.
```python
qco = QuantumCircuitOptimizer(mpi_size=4)
qco.optimize(circuit, blocksize, swap_level=1) # the circuit is optimized for 4 processors
```

The CIs are passed except Ubuntu CI (GCC10 build with -fsanitizer=address enabled). This CI has also failed in other pull requests, so it is unlikely to be relevant for this pull request.