### PR TITLE
upgrade doc dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,15 +62,15 @@ ci = [
 ]
 
 doc = [
-    "sphinx == 4.5.0",
-    "sphinx-rtd-theme == 1.0.*",
-    "breathe == 4.33.*",
-    "exhale == 0.3.*",
-    "nbsphinx == 0.8.*",
-    "myst-parser == 0.18.*",
-    "sphinx-copybutton == 0.5.*",
-    "ipykernel == 6.17.*",
-    "sphinx-autoapi == 2.0.*"
+    "sphinx",
+    "sphinx-rtd-theme",
+    "breathe",
+    "exhale",
+    "nbsphinx",
+    "myst-parser",
+    "sphinx-copybutton",
+    "ipykernel",
+    "sphinx-autoapi"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,15 +62,15 @@ ci = [
 ]
 
 doc = [
-    "sphinx",
+    "sphinx==7.*",
     "sphinx-rtd-theme",
     "breathe",
-    "exhale",
+    "exhale@git+https://github.com/svenevs/exhale.git@fix/packaging-requirements", # workaround until https://github.com/svenevs/exhale/pull/205 is merged
     "nbsphinx",
     "myst-parser",
     "sphinx-copybutton",
     "ipykernel",
-    "sphinx-autoapi"
+    "sphinx-autoapi==3.*"
 ]
 
 [tool.setuptools]

--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -457,19 +457,19 @@ class Observable(GeneralQuantumOperator):
         Get transition amplitude
         """
     def solve_ground_state_eigenvalue_by_arnoldi_method(
-        self, state: QuantumStateBase, iter_count: int, mu: complex = ...
+        self, state: QuantumStateBase, iter_count: int, mu: complex = 0.0
     ) -> complex:
         """
         Compute ground state eigenvalue by arnoldi method
         """
     def solve_ground_state_eigenvalue_by_lanczos_method(
-        self, state: QuantumStateBase, iter_count: int, mu: complex = ...
+        self, state: QuantumStateBase, iter_count: int, mu: complex = 0.0
     ) -> complex:
         """
         Compute ground state eigenvalue by lanczos method
         """
     def solve_ground_state_eigenvalue_by_power_method(
-        self, state: QuantumStateBase, iter_count: int, mu: complex = ...
+        self, state: QuantumStateBase, iter_count: int, mu: complex = 0.0
     ) -> complex:
         """
         Compute ground state eigenvalue by power method


### PR DESCRIPTION
close #600
We have to upgrade sphinx-api (ref: https://stackoverflow.com/questions/77257145/sphinx-autoapi-error-module-object-has-no-attribute-doc-with-various-sphi ).
I tried to explicitly new versions of sphinx, sphinx-api and others on `pyproject.toml`, but sphinx dep version of breathe, exhale and myst-parser is very complex so I remove version restrictions and let pip automatically resolve conflict.