### PR TITLE
Update 6.2_vqe.ipynb

### DIFF
--- a/doc/en/source/apply/6.2_vqe.ipynb
+++ b/doc/en/source/apply/6.2_vqe.ipynb
@@ -41,8 +41,8 @@
    "source": [
     "import qulacs\n",
     "from openfermion.transforms import get_fermion_operator, jordan_wigner\n",
-    "from openfermion.transforms import get_sparse_operator\n",
-    "from openfermion.hamiltonians import MolecularData\n",
+    "from openfermion.linalg import get_sparse_operator\n",
+    "from openfermion.chem import MolecularData\n",
     "from openfermionpyscf import run_pyscf\n",
     "from scipy.optimize import minimize\n",
     "from pyscf import fci\n",


### PR DESCRIPTION
`get_sparse_operator` is shifted to `openfermion.linalg`

Class `MolecularData` is shifted to `openfermion.chem`