### PR TITLE
Fixed import

### DIFF
--- a/doc/en/source/apply/6.2_vqe.ipynb
+++ b/doc/en/source/apply/6.2_vqe.ipynb
@@ -35,14 +35,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "import qulacs\n",
     "from openfermion.transforms import get_fermion_operator, jordan_wigner\n",
-    "from openfermion.transforms import get_sparse_operator\n",
-    "from openfermion.hamiltonians import MolecularData\n",
+    "from openfermion.linalg import get_sparse_operator\n",
+    "from openfermion.chem import MolecularData\n",
     "from openfermionpyscf import run_pyscf\n",
     "from scipy.optimize import minimize\n",
     "from pyscf import fci\n",
@@ -261,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated import. `get_sparse_operator` is now moved to `openfermion.linalg` and `MolecularData` is now moved to `openfermion.chem`