### PR TITLE
614 update deprecated actions

### DIFF
--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -22,6 +22,3 @@ RUN apt-get update \
     doxygen \
     pandoc \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
-RUN pip install -U pip \
-    && pip install black flake8 openfermion mypy pybind11-stubgen

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -32,7 +32,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       CACHE_NAME: "ccache-qulacs-build-v2"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
@@ -45,7 +45,7 @@ jobs:
           verbose: 2
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
       COVERAGE: "Yes"
       USE_TEST: "Yes"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
@@ -40,7 +40,7 @@ jobs:
           verbose: 2
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -91,7 +91,7 @@ jobs:
       QULACS_OPT_FLAGS: "-mtune=haswell -march=haswell -mfpmath=both"
       USE_TEST: "Yes"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
@@ -126,7 +126,7 @@ jobs:
       USE_TEST: "Yes"
       USE_GPU: "Yes"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
@@ -138,7 +138,7 @@ jobs:
           verbose: 2
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.7.5"
           architecture: x64
@@ -172,7 +172,7 @@ jobs:
       QULACS_OPT_FLAGS: "-march=armv8.2-a+sve"
       QEMU_LD_PREFIX: "/usr/aarch64-linux-gnu"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup qemu
         run: |
@@ -210,7 +210,7 @@ jobs:
     name: Format with clang-format
     runs-on: "ubuntu-20.04"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: sudo apt install clang-format=1:10.0-50~exp1
 
@@ -233,10 +233,10 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -262,13 +262,13 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
     name: GCC8 build
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     runs-on: "ubuntu-20.04"
     env:
       CXX_COMPILER: "/usr/lib/ccache/g++"
@@ -230,7 +230,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -246,14 +246,14 @@ jobs:
 
       - name: Check format
         run: |
-          black . --check --diff
-          isort . --check --diff
+          python -m black . --check --diff
+          python -m isort . --check --diff
 
   mpicc-build:
     name: MPICC build
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     runs-on: "ubuntu-20.04"
     env:
       CXX_COMPILER: "mpic++"

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,14 +1,6 @@
 name: Windows CI
 
 on:
-  push:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
-    branches:
-      - "dev"
   pull_request_review:
     types: [submitted, edited]
   workflow_dispatch:
@@ -17,7 +9,7 @@ jobs:
   gcc8-build:
     name: GCC8 build
     # For jobs triggered by pull_request_review, build task should run only if is in `approved` state.
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.review.state == 'approved' }}
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -28,7 +28,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
@@ -37,7 +37,7 @@ jobs:
       # mozilla/sccache is one candidate for this situation.
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -48,13 +48,13 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       TWINE_USERNAME: "__token__"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -105,13 +105,13 @@ jobs:
       COVERAGE: "ON"
       TWINE_USERNAME: "__token__"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,6 @@ on:
       - "main"
     tags:
       - "v*"
-  pull_request:
   pull_request_review:
     types: [submitted, edited]
   workflow_dispatch:

--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -786,11 +786,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            R_X(\\theta) = \exp(i\\frac{\\theta}{2} X) =
-                \\begin{pmatrix}
-                \cos(\\frac{\\theta}{2})  & i\sin(\\frac{\\theta}{2}) \\\\
-                i\sin(\\frac{\\theta}{2}) & \cos(\\frac{\\theta}{2})
-                \end{pmatrix}
+            R_X(\\\\theta) = \\exp(i\\\\frac{\\\\theta}{2} X) =
+                \\\\begin{pmatrix}
+                \\cos(\\\\frac{\\\\theta}{2})  & i\\sin(\\\\frac{\\\\theta}{2}) \\\\\\\\
+                i\\sin(\\\\frac{\\\\theta}{2}) & \\cos(\\\\frac{\\\\theta}{2})
+                \\end{pmatrix}
         """
 
     def add_RY_gate(self, index: int, angle: float) -> None:
@@ -802,11 +802,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            R_Y(\\theta) = \exp(i\\frac{\\theta}{2} Y) =
-                \\begin{pmatrix}
-                \cos(\\frac{\\theta}{2})  & \sin(\\frac{\\theta}{2}) \\\\
-                -\sin(\\frac{\\theta}{2}) & \cos(\\frac{\\theta}{2})
-                \end{pmatrix}
+            R_Y(\\\\theta) = \\exp(i\\\\frac{\\\\theta}{2} Y) =
+                \\\\begin{pmatrix}
+                \\cos(\\\\frac{\\\\theta}{2})  & \\sin(\\\\frac{\\\\theta}{2}) \\\\\\\\
+                -\\sin(\\\\frac{\\\\theta}{2}) & \\cos(\\\\frac{\\\\theta}{2})
+                \\end{pmatrix}
         """
 
     def add_RZ_gate(self, index: int, angle: float) -> None:
@@ -818,11 +818,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            R_Z(\\theta) = \exp(i\\frac{\\theta}{2} Z) =
-                \\begin{pmatrix}
-                e^{i\\frac{\\theta}{2}} & 0 \\\\
-                0 & e^{-i\\frac{\\theta}{2}}
-                \end{pmatrix}
+            R_Z(\\\\theta) = \\exp(i\\\\frac{\\\\theta}{2} Z) =
+                \\\\begin{pmatrix}
+                e^{i\\\\frac{\\\\theta}{2}} & 0 \\\\\\\\
+                0 & e^{-i\\\\frac{\\\\theta}{2}}
+                \\end{pmatrix}
         """
 
     def add_RotInvX_gate(self, index: int, angle: float) -> None:
@@ -834,11 +834,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            R_X(\\theta) = \exp(i\\frac{\\theta}{2} X) =
-                \\begin{pmatrix}
-                \cos(\\frac{\\theta}{2})  & i\sin(\\frac{\\theta}{2}) \\\\
-                i\sin(\\frac{\\theta}{2}) & \cos(\\frac{\\theta}{2})
-                \end{pmatrix}
+            R_X(\\\\theta) = \\exp(i\\\\frac{\\\\theta}{2} X) =
+                \\\\begin{pmatrix}
+                \\cos(\\\\frac{\\\\theta}{2})  & i\\sin(\\\\frac{\\\\theta}{2}) \\\\\\\\
+                i\\sin(\\\\frac{\\\\theta}{2}) & \\cos(\\\\frac{\\\\theta}{2})
+                \\end{pmatrix}
         """
 
     def add_RotInvY_gate(self, index: int, angle: float) -> None:
@@ -850,11 +850,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            R_Y(\\theta) = \exp(i\\frac{\\theta}{2} Y) =
-                \\begin{pmatrix}
-                \cos(\\frac{\\theta}{2})  & \sin(\\frac{\\theta}{2}) \\\\
-                -\sin(\\frac{\\theta}{2}) & \cos(\\frac{\\theta}{2})
-                \end{pmatrix}
+            R_Y(\\\\theta) = \\exp(i\\\\frac{\\\\theta}{2} Y) =
+                \\\\begin{pmatrix}
+                \\cos(\\\\frac{\\\\theta}{2})  & \\sin(\\\\frac{\\\\theta}{2}) \\\\\\\\
+                -\\sin(\\\\frac{\\\\theta}{2}) & \\cos(\\\\frac{\\\\theta}{2})
+                \\end{pmatrix}
         """
 
     def add_RotInvZ_gate(self, index: int, angle: float) -> None:
@@ -866,11 +866,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            R_Z(\\theta) = \exp(i\\frac{\\theta}{2} Z) =
-                \\begin{pmatrix}
-                e^{i\\frac{\\theta}{2}} & 0 \\\\
-                0 & e^{-i\\frac{\\theta}{2}}
-                \end{pmatrix}
+            R_Z(\\\\theta) = \\exp(i\\\\frac{\\\\theta}{2} Z) =
+                \\\\begin{pmatrix}
+                e^{i\\\\frac{\\\\theta}{2}} & 0 \\\\\\\\
+                0 & e^{-i\\\\frac{\\\\theta}{2}}
+                \\end{pmatrix}
         """
 
     def add_RotX_gate(self, index: int, angle: float) -> None:
@@ -882,11 +882,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            RotX(\\theta) = \exp(-i\\frac{\\theta}{2} X) =
-                \\begin{pmatrix}
-                \cos(\\frac{\\theta}{2})  & -i\sin(\\frac{\\theta}{2}) \\\\
-                -i\sin(\\frac{\\theta}{2}) & \cos(\\frac{\\theta}{2})
-                \end{pmatrix}
+            RotX(\\\\theta) = \\exp(-i\\\\frac{\\\\theta}{2} X) =
+                \\\\begin{pmatrix}
+                \\cos(\\\\frac{\\\\theta}{2})  & -i\\sin(\\\\frac{\\\\theta}{2}) \\\\\\\\
+                -i\\sin(\\\\frac{\\\\theta}{2}) & \\cos(\\\\frac{\\\\theta}{2})
+                \\end{pmatrix}
         """
 
     def add_RotY_gate(self, index: int, angle: float) -> None:
@@ -898,11 +898,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            RotY(\\theta) = \exp(-i\\frac{\\theta}{2} Y) =
-                \\begin{pmatrix}
-                \cos(\\frac{\\theta}{2})  & -\sin(\\frac{\\theta}{2}) \\\\
-                \sin(\\frac{\\theta}{2}) & \cos(\\frac{\\theta}{2})
-                \end{pmatrix}
+            RotY(\\\\theta) = \\exp(-i\\\\frac{\\\\theta}{2} Y) =
+                \\\\begin{pmatrix}
+                \\cos(\\\\frac{\\\\theta}{2})  & -\\sin(\\\\frac{\\\\theta}{2}) \\\\\\\\
+                \\sin(\\\\frac{\\\\theta}{2}) & \\cos(\\\\frac{\\\\theta}{2})
+                \\end{pmatrix}
         """
 
     def add_RotZ_gate(self, index: int, angle: float) -> None:
@@ -914,11 +914,11 @@ class QuantumCircuit:
         Matrix Representation
         
         .. math::
-            RotZ(\\theta) = \exp(-i\\frac{\\theta}{2} Z) =
-                \\begin{pmatrix}
-                e^{-i\\frac{\\theta}{2}} & 0 \\\\
-                0 & e^{i\\frac{\\theta}{2}}
-                \end{pmatrix}
+            RotZ(\\\\theta) = \\exp(-i\\\\frac{\\\\theta}{2} Z) =
+                \\\\begin{pmatrix}
+                e^{-i\\\\frac{\\\\theta}{2}} & 0 \\\\\\\\
+                0 & e^{i\\\\frac{\\\\theta}{2}}
+                \\end{pmatrix}
         """
 
     def add_SWAP_gate(self, target1: int, target2: int) -> None:


### PR DESCRIPTION
close #614 

- actions のバージョンアップ
- 開発環境と CI でのフォーマッタのバージョン不一致を解消
  - Python のバージョンを揃える
    - Python のバージョンが違うと black の挙動が異なる場合がある
- 使われていない CI のトリガーを削除

一つ問題点として、black が docstring の `\` を（最近になって？）勝手にエスケープするようになっています。
もともと `\` がエスケープされていたりいなかったりするのに API ドキュメントは期待通りレンダリングされているので、これでもいけるだろうと決めつけてコミットしています。