### PR TITLE
Haar_random_state GPU bug

### DIFF
--- a/src/gpusim/memory_ops.cu
+++ b/src/gpusim/memory_ops.cu
@@ -2,7 +2,7 @@
 
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
-//#include <cuda.h>
+// #include <cuda.h>
 #include <assert.h>
 #include <cuComplex.h>
 #include <curand.h>
@@ -144,7 +144,7 @@ __host__ void initialize_Haar_random_state_with_seed_host(void* state,
     // CURAND_RNG_PSEUDO_MT19937 offset cannot be used and need sm_35 or higher.
 
     unsigned int block = dim <= 512 ? dim : 512;
-    unsigned int grid = min((int)(dim / block), 512);
+    unsigned int grid = dim / block;
 
     init_rnd<<<grid, block, 0, *cuda_stream>>>(rnd_state, seed);
     checkCudaErrors(cudaGetLastError(), __FILE__, __LINE__);


### PR DESCRIPTION
close #625  
I don't know why old dev insert `min(, 512)`, but this works with nqubits=25 in my environment.

```py
from qulacs import QuantumStateGpu

state = QuantumStateGpu(25)
state.set_Haar_random_state()
print(state.get_marginal_probability([1] * 25))

```