### PR TITLE
Fix typo in Python guide in the docs

### DIFF
--- a/doc/en/source/guide/2.0_python_advanced.ipynb
+++ b/doc/en/source/guide/2.0_python_advanced.ipynb
@@ -380,7 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Opetation on classic registers\n",
+    "### Operation on classic registers\n",
     "Quantum states have classical registers as integer arrays with variable length. The classical register is used to write the result of the Instrument operation or to describe a gate that executes conditions as the result of the classical register. The value of a classic register that has not yet been written is 0. The classical register is copied at the same time when the quantum state is copied by the `copy` and `load` functions."
    ]
   },


### PR DESCRIPTION
## Purpose
Fix the typo in `2.0_python_advanced.ipynb`

## Details
Changed `Opetation` to `Operation`.