### PR TITLE
Upgrade macOS in Wheel CI

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -25,7 +25,7 @@ jobs:
           - compiler: "clang"
             c_compiler: "/usr/local/opt/ccache/libexec/clang"
             cxx_compiler: "/usr/local/opt/ccache/libexec/clang++"
-    runs-on: "macos-12"
+    runs-on: "macos-13"
     env:
       C_COMPILER: ${{ matrix.c_compiler }}
       CXX_COMPILER: ${{ matrix.cxx_compiler }}

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -48,7 +48,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install Boost for macOS
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install boost
         run: sudo apt install libboost-dev

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.3

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -61,7 +61,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install Python dependencies
         run: python -m pip install cibuildwheel twine

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -45,6 +45,11 @@ jobs:
             python-version: "3.11"
           - cibw-python: "cp312"
             python-version: "3.12"
+        exclude:
+          - os-arch: "macosx_arm64"
+            cibw-python: "cp38"
+          - os-arch: "macosx_arm64"
+            cibw-python: "cp39"
 
     runs-on: ${{ matrix.os }}
     env:
@@ -108,7 +113,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheels
 
       - name: Upload wheel to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheels/*.whl
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -15,7 +15,6 @@ on:
     types: [submitted, edited]
   workflow_dispatch:
 
-
 jobs:
   wheel-build:
     name: Python wheel build
@@ -23,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-arch: ["manylinux_x86_64", "win_amd64", "macosx_x86_64", "macosx_arm64"]
+        os-arch:
+          ["manylinux_x86_64", "win_amd64", "macosx_x86_64", "macosx_arm64"]
         cibw-python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
         # Documentation for `include`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
@@ -32,9 +32,9 @@ jobs:
           - os-arch: "win_amd64"
             os: "windows-2019"
           - os-arch: "macosx_x86_64"
-            os: "macos-12"
+            os: "macos-13"
           - os-arch: "macosx_arm64"
-            os: "macos-12"
+            os: "macos-14"
           - cibw-python: "cp38"
             python-version: "3.8"
           - cibw-python: "cp39"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Upload wheel to GitHub
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
           path: ./wheels/*.whl
 
       - name: Upload wheel data if the Git tag is set


### PR DESCRIPTION
Upgrade macOS version from 12 in Wheel CI.
Since Python 3.8 and 3.9 is not available in macOS 14(arm runner), they are excluded.
And `architecture` option in setup-python is removed. Some options like arm64 does not exist, and [the architecture is selected properly by default.](https://github.com/actions/setup-python/blob/82c7e631bb3cdc910f68e0081d67478d79c6982d/src/setup-python.ts#L98)