### PR TITLE
Update stub before documentation build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,9 @@ build:
   apt_packages:
     - cmake
     - libboost-dev
+  jobs:
+    pre_build:
+      - ./script/update_stubs.sh
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,11 @@ ci = [
 ]
 
 doc = [
+    "mypy",
+    "pybind11-stubgen",
     "sphinx==7.*",
     "sphinx-rtd-theme",
     "breathe",
-    #"exhale@git+https://github.com/svenevs/exhale.git@fix/packaging-requirements", # workaround until https://github.com/svenevs/exhale/pull/205 is merged
     "exhale",
     "nbsphinx",
     "myst-parser",

--- a/script/update_stubs.sh
+++ b/script/update_stubs.sh
@@ -6,7 +6,3 @@ stubgen -p qulacs_core -o typings
 pybind11-stubgen qulacs_core --root-suffix '' --numpy-array-remove-parameters -o './typings'
 cp -R typings/qulacs_core/* pysrc/qulacs/
 find pysrc/ -name __init__.pyi | sed -e 's/__init__.pyi/py.typed/' | xargs touch
-
-# FIXME: format
-python -m black pysrc
-python -m isort pysrc


### PR DESCRIPTION
Python API Reference in the document is empty.
It seems to need stubs to build the API reference, so run `./script/update_stub.sh` before building the document.
Just check .readthedocs.yaml; this PR includes diff pulled from #631 

## Cause
I investigated build logs in readthedocs, and found that [the build for #616](https://qulacs-rtd--616.org.readthedocs.build/en/616/pyRef/qulacs/index.html) was OK and [the one for #620](https://qulacs-rtd--620.org.readthedocs.build/en/620/pyRef/qulacs/index.html) was not.
I looked into the build log for #616, I found the stub files are used to generate API reference.
And the change introduced in #620 was excluding stubs from git source, so the stubs are not available during the documentation build.
