### PR TITLE
Provide Codecov token

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   gcc10-build-with-address-sanitizer:
     name: GCC10 build with -fsanitizer=address enabled


### PR DESCRIPTION
close #636 
The Codecov token is obtained from the [Settings](https://app.codecov.io/gh/qulacs/qulacs/settings) page for contiributers.