### PR TITLE
Fix sphinx-autoapi version to build Python API document properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ doc = [
     "myst-parser",
     "sphinx-copybutton",
     "ipykernel",
-    "sphinx-autoapi==3.*"
+    "sphinx-autoapi==3.0.0"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Fix sphinx-autoapi on 3.0.0.
Specifying it to "==3.*" leads to install 3.1.1 and fail to build the API document.