### PR TITLE
do not exclude on python3.8 3.9

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -45,11 +45,6 @@ jobs:
             python-version: "3.11"
           - cibw-python: "cp312"
             python-version: "3.12"
-        exclude:
-          - os-arch: "macosx_arm64"
-            cibw-python: "cp38"
-          - os-arch: "macosx_arm64"
-            cibw-python: "cp39"
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Python 3.8, 3.9 release of macos arm64 was removed in #631 because actions/setup-python did not support them.
Now they are supported so this PR restore it.