### PR TITLE
Fix `CausalConeSimulator` by replacing `QuantumGateBase::set_target_qubit_index`

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -44,16 +44,16 @@ jobs:
           key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
           verbose: 2
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Install Boost for macOS
         run: |
           brew update
           brew install boost
           brew link boost
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install qulacs for macOS
         run: USE_TEST=Yes ./script/build_gcc.sh

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -44,11 +44,10 @@ jobs:
           key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
           verbose: 2
 
-      # remove 2to3 link to deal with https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
+      # override python link to deal with https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
       - name: Install Boost for macOS
         run: |
-          unlink /usr/local/bin/2to3
-          unlink /usr/local/bin/2to3-3.12
+          brew link --overwrite python@3.12
           brew update
           brew install boost
           brew link boost

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -44,12 +44,12 @@ jobs:
           key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
           verbose: 2
 
-      # override python link to deal with https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
+      # ignore python link issue https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
+      # ref: https://github.com/actions/runner-images/issues/8500
       - name: Install Boost for macOS
         run: |
-          brew unlink python@3.12
           brew update
-          brew install boost
+          brew install boost || true
           brew link boost
 
       - name: Setup Python

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -47,7 +47,7 @@ jobs:
       # override python link to deal with https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
       - name: Install Boost for macOS
         run: |
-          brew link --overwrite python@3.12
+          brew unlink python@3.12
           brew update
           brew install boost
           brew link boost

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Install Boost for macOS
         run: |
           unlink /usr/local/bin/2to3
+          unlink /usr/local/bin/2to3-3.12
           brew update
           brew install boost
           brew link boost

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -44,8 +44,10 @@ jobs:
           key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
           verbose: 2
 
+      # remove 2to3 link to deal with https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
       - name: Install Boost for macOS
         run: |
+          unlink /usr/local/bin/2to3
           brew update
           brew install boost
           brew link boost

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -44,18 +44,16 @@ jobs:
           key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
           verbose: 2
 
-      # ignore python link issue https://github.com/qulacs/qulacs/actions/runs/11227598146/job/31210081471
-      # ref: https://github.com/actions/runner-images/issues/8500
-      - name: Install Boost for macOS
-        run: |
-          brew update
-          brew install boost || true
-          brew link boost
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install Boost for macOS
+        run: |
+          brew update
+          brew install boost
+          brew link boost
 
       - name: Install qulacs for macOS
         run: USE_TEST=Yes ./script/build_gcc.sh

--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -908,7 +908,6 @@ void QuantumCircuitOptimizer::insert_swap_gates(const UINT level) {
         if (g != g_replaced) {
             circuit->remove_gate(gate_idx);
             circuit->add_gate(g_replaced, gate_idx);
-            delete g;
         }
     }
 

--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -475,7 +475,7 @@ UINT QuantumCircuitOptimizer::move_gates_without_communication(
     UINT moved_gates = 0;
     for (UINT i = gate_idx; i < num_gates; i++) {
         // no comm & dependency is solved
-        if (!needs_communication(i, qt)) {
+        if (!needs_communication(i, qt, replacer)) {
             auto range = dep_map.equal_range(circuit->gate_list[i]);
 
             bool is_dep_solved = true;

--- a/src/cppsim/circuit_optimizer.hpp
+++ b/src/cppsim/circuit_optimizer.hpp
@@ -43,6 +43,12 @@ private:
         }
 
         void set_replaced_gate(QuantumGateBase* from, QuantumGateBase* to) {
+            if (replace.count(from)) {
+                throw std::runtime_error(
+                    "QuantumCircuitOptimizer::GateReplacer::set_replaced_gate: "
+                    "The gate passed as `from` is already replaced to other "
+                    "gate.");
+            }
             replace[from] = to;
         }
     };

--- a/src/cppsim/circuit_optimizer.hpp
+++ b/src/cppsim/circuit_optimizer.hpp
@@ -34,16 +34,32 @@ private:
     ////////////////////////////////////////////////////////////
     // for swap insertion
     ////////////////////////////////////////////////////////////
+    struct GateReplacer {
+        std::map<QuantumGateBase*, QuantumGateBase*> replace;
+
+        QuantumGateBase* get_replaced_gate(QuantumGateBase* gate) {
+            if (!replace.count(gate)) return gate;
+            return replace[gate] = get_replaced_gate(replace[gate]);
+        }
+
+        QuantumGateBase* set_replaced_gate(
+            QuantumGateBase* from, QuantumGateBase* to) {
+            replace[from] = to;
+        }
+    };
     void set_qubit_count(void);
     bool can_merge_with_swap_insertion(
         UINT gate_idx1, UINT gate_idx2, UINT swap_level);
-    bool needs_communication(const UINT gate_index, const QubitTable& qt);
+    bool needs_communication(
+        const UINT gate_index, const QubitTable& qt, GateReplacer& replacer);
     UINT move_gates_without_communication(const UINT gate_idx,
         const QubitTable& qt,
         const std::multimap<const QuantumGateBase*, const QuantumGateBase*>&
             dep_map,
-        std::unordered_set<const QuantumGateBase*>& processed_gates);
-    std::unordered_set<UINT> find_next_local_qubits(const UINT start_gate_idx);
+        std::unordered_set<const QuantumGateBase*>& processed_gates,
+        GateReplacer& replacer);
+    std::unordered_set<UINT> find_next_local_qubits(
+        const UINT start_gate_idx, GateReplacer& replacer);
     UINT move_matching_qubits_to_local_upper(UINT lowest_idx, QubitTable& qt,
         std::function<bool(UINT)> fn, UINT gate_insertion_pos);
     UINT rearrange_qubits(const UINT gate_idx,

--- a/src/cppsim/circuit_optimizer.hpp
+++ b/src/cppsim/circuit_optimizer.hpp
@@ -42,8 +42,7 @@ private:
             return replace[gate] = get_replaced_gate(replace[gate]);
         }
 
-        QuantumGateBase* set_replaced_gate(
-            QuantumGateBase* from, QuantumGateBase* to) {
+        void set_replaced_gate(QuantumGateBase* from, QuantumGateBase* to) {
             replace[from] = to;
         }
     };

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -125,7 +125,9 @@ public:
         }
         PauliOperator* pauli = new PauliOperator(
             target_index_list, _pauli->get_pauli_id_list(), _pauli->get_coef());
-        return new ClsPauliGate(pauli);
+        auto ret = new ClsPauliGate(pauli);
+        delete pauli;
+        return ret;
     }
 
     virtual QuantumGateBase* get_inverse() const override { return copy(); }
@@ -254,7 +256,9 @@ public:
         }
         PauliOperator* pauli = new PauliOperator(
             target_index_list, _pauli->get_pauli_id_list(), _pauli->get_coef());
-        return new ClsPauliRotationGate(_angle, pauli);
+        auto ret = new ClsPauliRotationGate(_angle, pauli);
+        delete pauli;
+        return ret;
     }
 
     virtual ClsPauliRotationGate* get_inverse(void) const override {

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -107,6 +107,28 @@ public:
         pt.add_child("pauli", _pauli->to_ptree());
         return pt;
     }
+
+    virtual QuantumGateBase* create_gate_whose_qubit_indices_are_replaced(
+        const std::vector<UINT>& target_index_list,
+        const std::vector<UINT>& control_index_list) const override {
+        if (_target_qubit_list.size() != target_index_list.size()) {
+            throw InvalidQubitCountException(
+                "Error: "
+                "QuantumGateBase::create_gate_whose_qubit_indices_is_"
+                "replaced\n qubit count of target_index_list does not match.");
+        }
+        if (_control_qubit_list.size() != control_index_list.size()) {
+            throw InvalidQubitCountException(
+                "Error: "
+                "QuantumGateBase::create_gate_whose_qubit_indices_is_"
+                "replaced\n qubit count of control_index_list does not match.");
+        }
+        PauliOperator* pauli = new PauliOperator(
+            target_index_list, _pauli->get_pauli_id_list(), _pauli->get_coef());
+        return new ClsPauliGate(pauli);
+    }
+
+    virtual QuantumGateBase* get_inverse() const override { return copy(); }
 };
 
 /**
@@ -213,6 +235,26 @@ public:
         pt.add("angle", _angle);
         pt.add_child("pauli", _pauli->to_ptree());
         return pt;
+    }
+
+    virtual QuantumGateBase* create_gate_whose_qubit_indices_are_replaced(
+        const std::vector<UINT>& target_index_list,
+        const std::vector<UINT>& control_index_list) const override {
+        if (_target_qubit_list.size() != target_index_list.size()) {
+            throw InvalidQubitCountException(
+                "Error: "
+                "QuantumGateBase::create_gate_whose_qubit_indices_is_"
+                "replaced\n qubit count of target_index_list does not match.");
+        }
+        if (_control_qubit_list.size() != control_index_list.size()) {
+            throw InvalidQubitCountException(
+                "Error: "
+                "QuantumGateBase::create_gate_whose_qubit_indices_is_"
+                "replaced\n qubit count of control_index_list does not match.");
+        }
+        PauliOperator* pauli = new PauliOperator(
+            target_index_list, _pauli->get_pauli_id_list(), _pauli->get_coef());
+        return new ClsPauliRotationGate(_angle, pauli);
     }
 
     virtual ClsPauliRotationGate* get_inverse(void) const override {

--- a/src/cppsim/gate_noisy_evolution.cpp
+++ b/src/cppsim/gate_noisy_evolution.cpp
@@ -507,7 +507,12 @@ ClsNoisyEvolution_fast::ClsNoisyEvolution_fast(Observable* hamiltonian,
     //(iHという名前だが、実際には-iH)
 
     QuantumGateMatrix* iH = gate::add(gate_list);
-    this->set_target_index_list(iH->get_target_index_list());
+    auto target_index_list = iH->get_target_index_list();
+    _target_qubit_list.clear();
+    _target_qubit_list.reserve(target_index_list.size());
+    for (UINT idx : target_index_list) {
+        _target_qubit_list.emplace_back(idx);
+    }
     // 注意　このtarget_index_listはPや対角行列　に対してのlistである。
     // このlistに入っていないが、c_opsには入っている　というパターンもありうる。
     // ここで、　対角化を求める

--- a/src/cppsim/qubit_table.cpp
+++ b/src/cppsim/qubit_table.cpp
@@ -59,14 +59,14 @@ UINT QubitTable::add_swap_gate(
     return 1;
 }
 
-void QubitTable::rewrite_gate_qubit_indexes(QuantumGateBase* g) const {
+QuantumGateBase* QubitTable::rewrite_gate_qubit_indexes(
+    QuantumGateBase* g) const {
     std::vector<UINT> target_index_list = g->get_target_index_list();
     for_each(target_index_list.begin(), target_index_list.end(),
         [&](UINT& x) { x = _l2p_table[x]; });
-    g->set_target_index_list(target_index_list);
-
     std::vector<UINT> control_index_list = g->get_control_index_list();
     for_each(control_index_list.begin(), control_index_list.end(),
         [&](UINT& x) { x = _l2p_table[x]; });
-    g->set_control_index_list(control_index_list);
+    return g->create_gate_whose_qubit_indices_are_replaced(
+        target_index_list, control_index_list);
 }

--- a/src/cppsim/qubit_table.hpp
+++ b/src/cppsim/qubit_table.hpp
@@ -60,9 +60,10 @@ public:
     /**
      * \~japanese-en 量子ゲートの量子ビットの添え字を書き換える
      *
-     * @param[in,out] g 書き換える量子ゲート
+     * @param[in] g 書き換える量子ゲート
+     * @return 書き換え後のゲート
      */
-    void rewrite_gate_qubit_indexes(QuantumGateBase* g) const;
+    QuantumGateBase* rewrite_gate_qubit_indexes(QuantumGateBase* g) const;
 
     /**
      * \~japanese-en

--- a/src/csim/update_ops_named_FusedSWAP.cpp
+++ b/src/csim/update_ops_named_FusedSWAP.cpp
@@ -76,7 +76,9 @@ void FusedSWAP_gate_global(UINT target_qubit_index_0, UINT target_qubit_index_1,
 #else
     assert(target_qubit_index_0 > nqubits);
     assert(target_qubit_index_1 > nqubits);
-    assert(std::abs(target_qubit_index_0 - target_qubit_index_1) >= block_size);
+    assert(std::abs(static_cast<std::int32_t>(target_qubit_index_0) -
+                    static_cast<std::int32_t>(target_qubit_index_1)) >=
+           block_size);
 
     MPIutil& m = MPIutil::get_inst();
     const int rank = m.get_rank();

--- a/src/vqcsim/causalcone_simulator.hpp
+++ b/src/vqcsim/causalcone_simulator.hpp
@@ -4,7 +4,6 @@
 #include <cppsim/observable.hpp>
 #include <cppsim/state.hpp>
 #include <cppsim/type.hpp>
-#include <iostream>
 #include <utility>
 #include <vector>
 #include <vqcsim/parametric_circuit.hpp>

--- a/src/vqcsim/causalcone_simulator.hpp
+++ b/src/vqcsim/causalcone_simulator.hpp
@@ -165,7 +165,6 @@ public:
                 }
                 auto& paulioperator = pauli_operators[i];
                 for (UINT j = 0; j < (UINT)term_index_list.size(); j++) {
-                    if ((UINT)uf.root(term_index_list[j]) != root) continue;
                     paulioperator.add_single_Pauli(
                         qubit_encode[term_index_list[j]], pauli_id_list[j]);
                 }

--- a/src/vqcsim/causalcone_simulator.hpp
+++ b/src/vqcsim/causalcone_simulator.hpp
@@ -91,6 +91,14 @@ public:
                         break;
                     }
                 }
+                if (!use_gate[i]) {
+                    for (auto control_index : control_index_list) {
+                        if (use_qubit[control_index]) {
+                            use_gate[i] = true;
+                            break;
+                        }
+                    }
+                }
                 if (use_gate[i]) {
                     for (auto target_index : target_index_list) {
                         use_qubit[target_index] = true;

--- a/src/vqcsim/causalcone_simulator.hpp
+++ b/src/vqcsim/causalcone_simulator.hpp
@@ -60,7 +60,7 @@ public:
         delete init_circuit;
         delete init_observable;
         for (auto& circuit1 : circuit_list) {
-            for (auto& circuit2 : circuit1) {
+            for (auto* circuit2 : circuit1) {
                 delete circuit2;
             }
         }
@@ -74,7 +74,7 @@ public:
             const UINT gate_count = init_circuit->gate_list.size();
             const UINT qubit_count = init_circuit->qubit_count;
             const UINT observable_count = observable_index_list.size();
-            UnionFind uf(qubit_count + observable_count);
+            UnionFind uf(qubit_count);
             std::vector<bool> use_qubit(qubit_count);
             std::vector<bool> use_gate(gate_count);
             for (UINT i = 0; i < observable_count; i++) {
@@ -90,14 +90,6 @@ public:
                     if (use_qubit[target_index]) {
                         use_gate[i] = true;
                         break;
-                    }
-                }
-                if (!use_gate[i]) {
-                    for (auto control_index : control_index_list) {
-                        if (use_qubit[control_index]) {
-                            use_gate[i] = true;
-                            break;
-                        }
                     }
                 }
                 if (use_gate[i]) {
@@ -158,7 +150,7 @@ public:
                 for (UINT j = 0; j < gate_count; j++) {
                     if (!use_gate[j]) continue;
 
-                    auto gate = init_circuit->gate_list[j]->copy();
+                    auto gate = init_circuit->gate_list[j];
                     auto target_index_list = gate->get_target_index_list();
                     auto control_index_list = gate->get_control_index_list();
                     if ((UINT)uf.root(target_index_list[0]) != root) continue;
@@ -167,12 +159,14 @@ public:
                     for (auto& control_idx : control_index_list)
                         control_idx = qubit_encode[control_idx];
 
-                    gate->set_target_index_list(target_index_list);
-                    gate->set_control_index_list(control_index_list);
-                    circuit->add_gate(gate);
+                    auto gate_replaced =
+                        gate->create_gate_whose_qubit_indices_are_replaced(
+                            target_index_list, control_index_list);
+                    circuit->add_gate(gate_replaced);
                 }
                 auto& paulioperator = pauli_operators[i];
                 for (UINT j = 0; j < (UINT)term_index_list.size(); j++) {
+                    if ((UINT)uf.root(term_index_list[j]) != root) continue;
                     paulioperator.add_single_Pauli(
                         qubit_encode[term_index_list[j]], pauli_id_list[j]);
                 }

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -233,7 +233,11 @@ public:
                 target_index_list[index], commutation_relation));
         }
     };
-    virtual ~ClsParametricPauliRotationGate() { delete _pauli; }
+    virtual ~ClsParametricPauliRotationGate() {
+        std::cerr << "PPauliRotation deleted: " << std::hex << (void*)this
+                  << std::endl;
+        delete _pauli;
+    }
     virtual void update_quantum_state(QuantumStateBase* state) override {
         auto target_index_list = _pauli->get_index_list();
         auto pauli_id_list = _pauli->get_pauli_id_list();
@@ -300,7 +304,9 @@ public:
         }
         PauliOperator* pauli = new PauliOperator(
             target_index_list, _pauli->get_pauli_id_list(), _pauli->get_coef());
-        return new ClsParametricPauliRotationGate(_angle, pauli);
+        auto ret = new ClsParametricPauliRotationGate(_angle, pauli);
+        delete pauli;
+        return ret;
     }
 
     virtual ClsParametricPauliRotationGate* get_inverse() const override {

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -282,6 +282,27 @@ public:
         pt.put_child("pauli", _pauli->to_ptree());
         return pt;
     }
+
+    virtual QuantumGateBase* create_gate_whose_qubit_indices_are_replaced(
+        const std::vector<UINT>& target_index_list,
+        const std::vector<UINT>& control_index_list) const override {
+        if (_target_qubit_list.size() != target_index_list.size()) {
+            throw InvalidQubitCountException(
+                "Error: "
+                "QuantumGateBase::create_gate_whose_qubit_indices_is_"
+                "replaced\n qubit count of target_index_list does not match.");
+        }
+        if (_control_qubit_list.size() != control_index_list.size()) {
+            throw InvalidQubitCountException(
+                "Error: "
+                "QuantumGateBase::create_gate_whose_qubit_indices_is_"
+                "replaced\n qubit count of control_index_list does not match.");
+        }
+        PauliOperator* pauli = new PauliOperator(
+            target_index_list, _pauli->get_pauli_id_list(), _pauli->get_coef());
+        return new ClsParametricPauliRotationGate(_angle, pauli);
+    }
+
     virtual ClsParametricPauliRotationGate* get_inverse() const override {
         return new ClsParametricPauliRotationGate(-_angle, _pauli);
     };

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -233,11 +233,7 @@ public:
                 target_index_list[index], commutation_relation));
         }
     };
-    virtual ~ClsParametricPauliRotationGate() {
-        std::cerr << "PPauliRotation deleted: " << std::hex << (void*)this
-                  << std::endl;
-        delete _pauli;
-    }
+    virtual ~ClsParametricPauliRotationGate() { delete _pauli; }
     virtual void update_quantum_state(QuantumStateBase* state) override {
         auto target_index_list = _pauli->get_index_list();
         auto pauli_id_list = _pauli->get_pauli_id_list();


### PR DESCRIPTION
close #659 

`QuantumGateBase::set_target_qubit_index` was wrong because it didn't replace target indices of `PauliOperator` on `ClsPauliGate` etc.
I think this function is evil. Replacing target qubit index later makes trouble easily.
So this time I created a new function to make copied gate with targets replaced.

In addition, I found some wrong parts in `CausalConeSimulator` and fix them.