### PR TITLE
remove useless single-pauli of observable

### DIFF
--- a/src/vqcsim/causalcone_simulator.hpp
+++ b/src/vqcsim/causalcone_simulator.hpp
@@ -173,6 +173,7 @@ public:
                 }
                 auto& paulioperator = pauli_operators[i];
                 for (UINT j = 0; j < (UINT)term_index_list.size(); j++) {
+                    if ((UINT)uf.root(term_index_list[j]) != root) continue;
                     paulioperator.add_single_Pauli(
                         qubit_encode[term_index_list[j]], pauli_id_list[j]);
                 }


### PR DESCRIPTION
ref: #659 #661 
I found the problem on CausalConeSimulator. on `src/vqcsim/causalcone_simulator.hpp:176`.
All pauli operators on the term has been added, but with qubits which are not in the connected component, `qubit_encode[term_index_list[j]]` is `-1`, which is treated as a large number on `UINT`. Then `PauliOperator::add_single_Pauli` expand `dynamic_bitset` to very large size. This takes so much time and memory.