### PR TITLE
Multi qubit measurement cptp

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install qulacs for Windows
         run: |
           $env:USE_TEST = "Yes"
-          ./script/build_msvc_2019.bat
+          ./script/build_msvc_2022.bat
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -764,6 +764,12 @@ PYBIND11_MODULE(qulacs_core, m) {
         m, "ClsReversibleBooleanGate");
     py::class_<ClsNoisyEvolution_fast, QuantumGateBase>(
         m, "ClsNoisyEvolution_fast");
+    py::class_<QuantumGate_LinearCombination, QuantumGateBase>(
+        m, "QuantumGate_LinearCombination")
+        .def("get_coef_list", &QuantumGate_LinearCombination::get_coef_list,
+            "get coef_list")
+        .def("get_gate_list", &QuantumGate_LinearCombination::get_gate_list,
+            "get gate_list");
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,
@@ -985,6 +991,10 @@ PYBIND11_MODULE(qulacs_core, m) {
     mgate.def("StateReflection", &gate::StateReflection,
         py::return_value_policy::take_ownership, "Create state reflection gate",
         py::arg("state"));
+    mgate.def("LinearCombination", &gate::LinearCombination,
+        py::return_value_policy::take_ownership,
+        "Create linear combination gate", py::arg("coefs"),
+        py::arg("gate_list"));
 
     mgate.def("BitFlipNoise",
         py::overload_cast<UINT, double>(&gate::BitFlipNoise),
@@ -1045,6 +1055,20 @@ PYBIND11_MODULE(qulacs_core, m) {
         py::overload_cast<UINT, UINT, UINT>(&gate::Measurement),
         py::return_value_policy::take_ownership, "Create measurement gate",
         py::arg("index"), py::arg("register"), py::arg("seed"));
+    mgate.def("MultiQubitPauliMeasurement",
+        py::overload_cast<const std::vector<UINT>&, const std::vector<UINT>&,
+            UINT>(&gate::MultiQubitPauliMeasurement),
+        py::return_value_policy::take_ownership,
+        "Create multi qubit pauli measurement gate",
+        py::arg("target_index_list"), py::arg("pauli_id_list"),
+        py::arg("classical_register_address"));
+    mgate.def("MultiQubitPauliMeasurement",
+        py::overload_cast<const std::vector<UINT>&, const std::vector<UINT>&,
+            UINT, UINT>(&gate::MultiQubitPauliMeasurement),
+        py::return_value_policy::take_ownership,
+        "Create multi qubit pauli measurement gate",
+        py::arg("target_index_list"), py::arg("pauli_id_list"),
+        py::arg("classical_register_address"), py::arg("seed"));
 
     mgate.def("merge",
         py::overload_cast<const QuantumGateBase*, const QuantumGateBase*>(

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -769,7 +769,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("get_coef_list", &QuantumGate_LinearCombination::get_coef_list,
             "get coef_list")
         .def("get_gate_list", &QuantumGate_LinearCombination::get_gate_list,
-            py::keep_alive<0, 1>, "get gate_list");
+            py::keep_alive<0, 1>(), "get gate_list");
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -769,7 +769,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("get_coef_list", &QuantumGate_LinearCombination::get_coef_list,
             "get coef_list")
         .def("get_gate_list", &QuantumGate_LinearCombination::get_gate_list,
-            "get gate_list");
+            py::keep_alive<0, 1>, "get gate_list");
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -768,8 +768,17 @@ PYBIND11_MODULE(qulacs_core, m) {
         m, "QuantumGate_LinearCombination")
         .def("get_coef_list", &QuantumGate_LinearCombination::get_coef_list,
             "get coef_list")
-        .def("get_gate_list", &QuantumGate_LinearCombination::get_gate_list,
-            py::keep_alive<0, 1>(), "get gate_list");
+        .def(
+            "get_gate_list",
+            [](QuantumGate_Probabilistic& gate_linear) {
+                py::list ret;
+                for (auto* g : gate_linear.get_gate_list()) {
+                    ret.append(py::cast(
+                        g->copy(), py::return_value_policy::take_ownership));
+                }
+                return ret;
+            },
+            "get gate_list");
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,

--- a/script/build_msvc_2022.bat
+++ b/script/build_msvc_2022.bat
@@ -1,0 +1,10 @@
+if not defined USE_TEST (
+    set USE_TEST=No
+)
+mkdir visualstudio
+cd visualstudio
+cmake -G "Visual Studio 17 2022" -A "x64" -D USE_GPU:STR=No -D USE_TEST=%USE_TEST% ..
+cd ..
+cmake --build ./visualstudio --target ALL_BUILD --config Release
+cmake --build ./visualstudio --target python --config Release
+

--- a/script/build_msvc_2022_with_gpu.bat
+++ b/script/build_msvc_2022_with_gpu.bat
@@ -1,0 +1,10 @@
+if not defined USE_TEST (
+    set USE_TEST=No
+)
+mkdir visualstudio
+cd visualstudio
+cmake -G "Visual Studio 17 2022" -D USE_GPU:STR=Yes -D USE_TEST=%USE_TEST% ..
+cd ..
+cmake --build ./visualstudio --target ALL_BUILD --config Release
+cmake --build ./visualstudio --target python --config Release
+

--- a/script/generate_msvc_project_2022.bat
+++ b/script/generate_msvc_project_2022.bat
@@ -1,0 +1,7 @@
+if not defined USE_TEST (
+    set USE_TEST=No
+)
+mkdir visualstudio
+cd visualstudio
+cmake -G "Visual Studio 17 2022" -D USE_GPU:STR=No -D USE_TEST=%USE_TEST% ..
+cd ..

--- a/script/generate_msvc_project_2022_with_gpu.bat
+++ b/script/generate_msvc_project_2022_with_gpu.bat
@@ -1,0 +1,7 @@
+if not defined USE_TEST (
+    set USE_TEST=No
+)
+mkdir visualstudio
+cd visualstudio
+cmake -G "Visual Studio 17 2022" -D USE_GPU:STR=Yes -D USE_TEST=%USE_TEST% ..
+cd ..

--- a/src/cppsim/exception.hpp
+++ b/src/cppsim/exception.hpp
@@ -177,6 +177,20 @@ public:
 };
 
 /**
+ * \~japanese-en 係数リストが不適切という例外
+ */
+class InvalidCoefListException : public std::logic_error {
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param message エラーメッセージ
+     */
+    InvalidCoefListException(const std::string& message)
+        : std::logic_error(message) {}
+};
+
+/**
  * \~japanese-en 確率分布が不適切という例外
  */
 class InvalidProbabilityDistributionException : public std::logic_error {

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -531,6 +531,39 @@ QuantumGate_Instrument* Measurement(
     return new_gate;
 }
 
+QuantumGate_Instrument* MultiQubitPauliMeasurement(
+    const std::vector<UINT>& target_index_list,
+    const std::vector<UINT>& pauli_id_list, UINT classical_register_address) {
+    auto i_gate = Identity(0);
+    auto pauli_gate = Pauli(target_index_list, pauli_id_list);
+    auto gate0 = LinearCombination({.5, .5}, {i_gate, pauli_gate});
+    auto gate1 = LinearCombination({.5, -.5}, {i_gate, pauli_gate});
+    auto new_gate =
+        new QuantumGate_Instrument({gate0, gate1}, classical_register_address);
+    delete i_gate;
+    delete pauli_gate;
+    delete gate0;
+    delete gate1;
+    return new_gate;
+}
+QuantumGate_Instrument* MultiQubitPauliMeasurement(
+    const std::vector<UINT>& target_index_list,
+    const std::vector<UINT>& pauli_id_list, UINT classical_register_address,
+    UINT seed) {
+    auto i_gate = Identity(0);
+    auto pauli_gate = Pauli(target_index_list, pauli_id_list);
+    auto gate0 = LinearCombination({.5, .5}, {i_gate, pauli_gate});
+    auto gate1 = LinearCombination({.5, -.5}, {i_gate, pauli_gate});
+    auto new_gate =
+        new QuantumGate_Instrument({gate0, gate1}, classical_register_address);
+    new_gate->set_seed(seed);
+    delete i_gate;
+    delete pauli_gate;
+    delete gate0;
+    delete gate1;
+    return new_gate;
+}
+
 ClsNoisyEvolution* NoisyEvolution(Observable* hamiltonian,
     std::vector<GeneralQuantumOperator*> c_ops, double time, double dt) {
     return new ClsNoisyEvolution(hamiltonian, c_ops, time, dt);

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -394,6 +394,11 @@ ClsReversibleBooleanGate* ReversibleBoolean(
 ClsStateReflectionGate* StateReflection(const QuantumState* reflection_state) {
     return new ClsStateReflectionGate(reflection_state);
 }
+QuantumGate_LinearCombination* LinearCombination(
+    const std::vector<CPPCTYPE>& coefs,
+    const std::vector<QuantumGateBase*>& gate_list) {
+    return new QuantumGate_LinearCombination(coefs, gate_list);
+}
 
 QuantumGate_Probabilistic* BitFlipNoise(UINT target_index, double prob) {
     return BitFlipNoise(target_index, prob, std::random_device{}());

--- a/src/cppsim/gate_factory.hpp
+++ b/src/cppsim/gate_factory.hpp
@@ -432,9 +432,7 @@ DllExport ClsStateReflectionGate* StateReflection(
  */
 DllExport QuantumGate_LinearCombination* LinearCombination(
     const std::vector<CPPCTYPE>& coefs,
-    const std::vector<QuantumGateBase*>& gate_list) {
-    return new QuantumGate_LinearCombination(coefs, gate_list);
-}
+    const std::vector<QuantumGateBase*>& gate_list);
 
 /**
  * bit-flipノイズを発生させるゲート

--- a/src/cppsim/gate_factory.hpp
+++ b/src/cppsim/gate_factory.hpp
@@ -424,6 +424,19 @@ DllExport ClsStateReflectionGate* StateReflection(
     const QuantumState* reflection_state);
 
 /**
+ * 量子ゲートの線型結合を作成する．
+ *
+ * @param[in] coeffs 係数のリスト
+ * @param[in] gate_list ゲートのリスト
+ * @return 作成されたゲートのインスタンス
+ */
+DllExport QuantumGate_LinearCombination* LinearCombination(
+    const std::vector<CPPCTYPE>& coefs,
+    const std::vector<QuantumGateBase*>& gate_list) {
+    return new QuantumGate_LinearCombination(coefs, gate_list);
+}
+
+/**
  * bit-flipノイズを発生させるゲート
  *
  * @param[in] target_index ターゲットとなる量子ビットの添え字
@@ -570,6 +583,28 @@ DllExport QuantumGate_Instrument* Measurement(
  */
 DllExport QuantumGate_Instrument* Measurement(
     UINT target_index, UINT classical_register_address, UINT seed);
+/**
+ * 測定を行う
+ *
+ * @param[in] pauli 測定を行うパウリ演算子
+ * @param[in] classical_register_address 測定値を格納する古典レジスタの場所
+ * @return 作成されたゲートのインスタンス
+ */
+DllExport QuantumGate_Instrument* MultiQubitPauliMeasurement(
+    const std::vector<UINT>& target_index_list,
+    const std::vector<UINT>& pauli_id_list, UINT classical_register_address);
+/**
+ * 測定を行う
+ *
+ * @param[in] pauli 測定を行うパウリ演算子
+ * @param[in] classical_register_address 測定値を格納する古典レジスタの場所
+ * @param[in] seed 乱数のシード値
+ * @return 作成されたゲートのインスタンス
+ */
+DllExport QuantumGate_Instrument* MultiQubitPauliMeasurement(
+    const std::vector<UINT>& target_index_list,
+    const std::vector<UINT>& pauli_id_list, UINT classical_register_address,
+    UINT seed);
 
 /**
  * Noisy Evolution

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -14,6 +14,143 @@
  */
 
 /**
+ * \~japanese-en いくつかのゲートの線型結合
+ */
+class QuantumGate_LinearCombination : public QuantumGateBase {
+protected:
+    std::vector<CPPCTYPE> _coefs;
+    std::vector<QuantumGateBase*> _gate_list;
+
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param coefs ゲートにかけられる係数
+     * @param gate_list ゲートのリスト
+     */
+    explicit QuantumGate_LinearCombination(const std::vector<CPPCTYPE>& coefs,
+        const std::vector<QuantumGateBase*>& gate_list)
+        : _coefs(coefs) {
+        if (coefs.size() != gate_list.size()) {
+            throw InvalidCoefListException(
+                "Error: "
+                "QuantumGate_LinearCombination::LinearCombination(vector<"
+                "CPPCTYPE>, vector<QuantumGateBase*>): gate_list.size() must "
+                "be "
+                "equal to coefs.size().");
+        }
+        _gate_list.reserve(gate_list.size());
+        std::transform(gate_list.begin(), gate_list.end(),
+            std::back_inserter(_gate_list),
+            [&](const QuantumGateBase* gate) { return gate->copy(); });
+
+        this->_name = "LinearCombination";
+
+        if (_gate_list.size() > 0) {
+            this->_target_qubit_list = _gate_list[0]->target_qubit_list;
+            this->_control_qubit_list = _gate_list[0]->control_qubit_list;
+        }
+
+        for (UINT i = 1; i < _gate_list.size(); i++) {
+            std::vector<TargetQubitInfo> new_target_list;
+            std::vector<ControlQubitInfo> new_control_list;
+            gate::get_new_qubit_list(
+                this, _gate_list[i], new_target_list, new_control_list);
+            this->_target_qubit_list = move(new_target_list);
+            this->_control_qubit_list = move(new_control_list);
+        }
+        std::sort(this->_target_qubit_list.begin(),
+            this->_target_qubit_list.end(),
+            [](const TargetQubitInfo& a, const TargetQubitInfo& b) {
+                return a.index() < b.index();
+            });
+        std::sort(this->_control_qubit_list.begin(),
+            this->_control_qubit_list.end(),
+            [](const ControlQubitInfo& a, const ControlQubitInfo& b) {
+                return a.index() < b.index();
+            });
+    }
+
+    virtual ~QuantumGate_LinearCombination() {
+        for (unsigned int i = 0; i < _gate_list.size(); ++i) {
+            delete _gate_list[i];
+        }
+    }
+
+    /**
+     * \~japanese-en 量子状態を更新する
+     *
+     * @param state 更新する量子状態
+     */
+    virtual void update_quantum_state(QuantumStateBase* state) override {
+        if (state->is_state_vector()) {
+            auto* updated_state = state->copy();
+            auto* tmp_state = state->copy();
+            updated_state->set_zero_norm_state();
+            for (UINT idx = 0; idx < _gate_list.size(); ++idx) {
+                tmp_state->load(state);
+                _gate_list[idx]->update_quantum_state(tmp_state);
+                updated_state->add_state_with_coef(_coefs[idx], tmp_state);
+            }
+            state->load(updated_state);
+            delete updated_state;
+            delete tmp_state;
+        } else {
+            throw NotImplementedException(
+                "QuantumGate_LinearCombination::update_quantum_state for "
+                "density matrix is not supported.");
+        }
+    };
+    /**
+     * \~japanese-en 自身のディープコピーを生成する
+     *
+     * @return 自身のディープコピー
+     */
+    virtual QuantumGate_LinearCombination* copy() const override {
+        return new QuantumGate_LinearCombination(_coefs, _gate_list);
+    };
+
+    /**
+     * \~japanese-en 自身のゲート行列をセットする
+     *
+     * @param matrix 行列をセットする変数の参照
+     */
+    virtual void set_matrix(ComplexMatrix& matrix) const override {
+        std::cerr << "* Warning : Gate-matrix of linear combination gate is "
+                     "currently not "
+                     "supported. Identity matrix is returned."
+                  << std::endl;
+        matrix = Eigen::MatrixXcd::Ones(1, 1);
+    }
+
+    /**
+     * \~japanese-en ptreeに変換する
+     *
+     * @return ptree
+     */
+    virtual boost::property_tree::ptree to_ptree() const override {
+        boost::property_tree::ptree pt;
+        pt.put("name", "LinearCombinationGate");
+        boost::property_tree::ptree coefs_pt;
+        for (CPPCTYPE c : _coefs) {
+            boost::property_tree::ptree child;
+            child.put("", c);
+            coefs_pt.push_back(std::make_pair("", child));
+        }
+        pt.put_child("coefs", coefs_pt);
+        boost::property_tree::ptree gate_list_pt;
+        for (const QuantumGateBase* gate : _gate_list) {
+            gate_list_pt.push_back(std::make_pair("", gate->to_ptree()));
+        }
+        pt.put_child("gate_list", gate_list_pt);
+        return pt;
+    }
+
+    virtual std::vector<CPPCTYPE> get_coef_list() { return _coefs; };
+    virtual std::vector<QuantumGateBase*> get_gate_list() { return _gate_list; }
+};
+
+/**
  * \~japanese-en 確率的なユニタリ操作
  */
 class QuantumGate_Probabilistic : public QuantumGateBase {

--- a/src/cppsim/gate_linear_combination.hpp
+++ b/src/cppsim/gate_linear_combination.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "gate.hpp"
+#include "state.hpp"
+#include "utility.hpp"
+
+/**
+ * \~japanese-en いくつかのゲートの線型結合
+ */
+class QuantumGate_LinearCombination : public QuantumGateBase {
+protected:
+    std::vector<CPPCTYPE> _coefs;
+    std::vector<QuantumGateBase*> _gate_list;
+
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param coefs ゲートにかけられる係数
+     * @param gate_list ゲートのリスト
+     */
+    explicit QuantumGate_LinearCombination(const std::vector<CPPCTYPE>& coefs,
+        const std::vector<QuantumGateBase*>& gate_list)
+        : _coefs(coefs) {
+        if (coefs.size() != gate_list.size()) {
+            throw InvalidCoefListException(
+                "Error: "
+                "QuantumGate_LinearCombination::LinearCombination(vector<"
+                "CPPCTYPE>, vector<QuantumGateBase*>): gate_list.size() must "
+                "be "
+                "equal to coefs.size().");
+        }
+        _gate_list.reserve(gate_list.size());
+        std::transform(gate_list.begin(), gate_list.end(),
+            std::back_inserter(_gate_list),
+            [&](const QuantumGateBase* gate) { return gate->copy(); });
+    };
+
+    virtual ~QuantumGate_LinearCombination() {
+        for (unsigned int i = 0; i < _gate_list.size(); ++i) {
+            delete _gate_list[i];
+        }
+    }
+
+    /**
+     * \~japanese-en 量子状態を更新する
+     *
+     * @param state 更新する量子状態
+     */
+    virtual void update_quantum_state(QuantumStateBase* state) override {
+        if (state->is_state_vector()) {
+            auto* updated_state = state->copy();
+            auto* tmp_state = state->copy();
+            updated_state->set_zero_norm_state();
+            for (UINT idx = 0; idx < _gate_list.size(); ++idx) {
+                tmp_state->load(state);
+                _gate_list[idx]->update_quantum_state(tmp_state);
+                updated_state->add_state_with_coef(_coefs[idx], tmp_state);
+            }
+            state->load(updated_state);
+            delete updated_state;
+            delete tmp_state;
+        } else {
+            throw NotImplementedException(
+                "QuantumGate_LinearCombination::update_quantum_state for "
+                "density matrix is not supported.");
+        }
+    };
+    /**
+     * \~japanese-en 自身のディープコピーを生成する
+     *
+     * @return 自身のディープコピー
+     */
+    virtual QuantumGate_LinearCombination* copy() const override {
+        return new QuantumGate_LinearCombination(_coefs, _gate_list);
+    };
+
+    /**
+     * \~japanese-en 自身のゲート行列をセットする
+     *
+     * @param matrix 行列をセットする変数の参照
+     */
+    virtual void set_matrix(ComplexMatrix& matrix) const override {
+        std::cerr << "* Warning : Gate-matrix of linear combination gate is "
+                     "currently not "
+                     "supported. Identity matrix is returned."
+                  << std::endl;
+        matrix = Eigen::MatrixXcd::Ones(1, 1);
+    }
+
+    /**
+     * \~japanese-en ptreeに変換する
+     *
+     * @return ptree
+     */
+    virtual boost::property_tree::ptree to_ptree() const override {
+        boost::property_tree::ptree pt;
+        pt.put("name", "LinearCombinationGate");
+        boost::property_tree::ptree coefs_pt;
+        for (CPPCTYPE c : _coefs) {
+            boost::property_tree::ptree child;
+            child.put("", c);
+            coefs_pt.push_back(std::make_pair("", child));
+        }
+        pt.put_child("coefs", coefs_pt);
+        boost::property_tree::ptree gate_list_pt;
+        for (const QuantumGateBase* gate : _gate_list) {
+            gate_list_pt.push_back(std::make_pair("", gate->to_ptree()));
+        }
+        pt.put_child("gate_list", gate_list_pt);
+        return pt;
+    }
+
+    virtual std::vector<CPPCTYPE> get_coef_list() { return _coefs; };
+    virtual std::vector<QuantumGateBase*> get_gate_list() { return _gate_list; }
+
+    virtual bool is_noise() override { return true; }
+};


### PR DESCRIPTION
close #670 (request from #668 )

Previously, a CPTP map for measuring a single qubit in the computational basis could be implemented using the `Measurement` factory by passing the P0 and P1 gates. However, creating a CPTP map for measuring multiple qubits with arbitrary Pauli operators required passing $(I \pm P)/2$. The only available method to represent this as a gate was using `DenseMatrix`, which is highly inefficient.

This PR introduces a new type of gate that allows for the linear combination of multiple gates. Using this enhancement, the `MultiQubitPauliMeasurement` factory has been implemented, enabling efficient creation of CPTP maps for multi-qubit measurements with arbitrary Pauli operators.