### PR TITLE
Update boost url, deprecate Python 3.8, support 3.11

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os-arch:
           ["manylinux_x86_64", "win_amd64", "macosx_x86_64", "macosx_arm64"]
-        cibw-python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        cibw-python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
         # Documentation for `include`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
           - os-arch: "manylinux_x86_64"
@@ -35,8 +35,6 @@ jobs:
             os: "macos-13"
           - os-arch: "macosx_arm64"
             os: "macos-14"
-          - cibw-python: "cp38"
-            python-version: "3.8"
           - cibw-python: "cp39"
             python-version: "3.9"
           - cibw-python: "cp310"
@@ -45,6 +43,8 @@ jobs:
             python-version: "3.11"
           - cibw-python: "cp312"
             python-version: "3.12"
+          - cibw-python: "cp313"
+            python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ test-requires = "pytest numpy scipy openfermion"
 environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }
 before-build = """\
 yum install wget -y && \
-wget -q https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz && \
+wget -q https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.gz && \
 tar -zxf boost_1_76_0.tar.gz && \
 cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && \
 cp -r boost /usr/local/include && rm -rf {project}/build \


### PR DESCRIPTION
https://boostorg.jfrog.io is deprecated. (ref: https://github.com/boostorg/boost/issues/843#issuecomment-2567034014)
This PR update the url to https://archive.boost.io .

close #649 
Python 3.8 is now deprecated, and we should support Python 3.11.