### PR TITLE
Copying gate pointer for binding reference-returning method

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -45,6 +45,10 @@ jobs:
             python-version: "3.12"
           - cibw-python: "cp313"
             python-version: "3.13"
+        exclude:
+          # since `pip install 'openfermion<1.7.0'` fails: https://github.com/qulacs/qulacs/actions/runs/13757608985
+          - os-arch: "win_amd64"
+            cibw-python: "cp313"
 
     runs-on: ${{ matrix.os }}
     env:

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -766,8 +766,17 @@ PYBIND11_MODULE(qulacs_core, m) {
         m, "ClsNoisyEvolution_fast");
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
-        .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,
-            py::keep_alive<0, 1>(), "get_gate_list")
+        .def(
+            "get_gate_list",
+            [](QuantumGate_Probabilistic& gate_prob) {
+                py::list ret;
+                for (auto* g : gate_prob.get_gate_list()) {
+                    ret.append(py::cast(
+                        g->copy(), py::return_value_policy::take_ownership));
+                }
+                return ret;
+            },
+            "get_gate_list")
         .def("optimize_ProbablisticGate",
             &QuantumGate_Probabilistic::optimize_ProbablisticGate,
             "optimize_ProbablisticGate")
@@ -778,11 +787,29 @@ PYBIND11_MODULE(qulacs_core, m) {
             "get_cumulative_distribution");
     py::class_<QuantumGate_CPTP, QuantumGateBase>(
         m, "QuantumGate_CPTP", "QuantumGate_Instrument")
-        .def("get_gate_list", &QuantumGate_CPTP::get_gate_list,
-            py::keep_alive<0, 1>(), "get_gate_list");
+        .def(
+            "get_gate_list",
+            [](QuantumGate_CPTP& gate_cptp) {
+                py::list ret;
+                for (auto* g : gate_cptp.get_gate_list()) {
+                    ret.append(py::cast(
+                        g->copy(), py::return_value_policy::take_ownership));
+                }
+                return ret;
+            },
+            "get_gate_list");
     py::class_<QuantumGate_CP, QuantumGateBase>(m, "QuantumGate_CP")
-        .def("get_gate_list", &QuantumGate_CP::get_gate_list,
-            py::keep_alive<0, 1>(), "get_gate_list");
+        .def(
+            "get_gate_list",
+            [](QuantumGate_CPTP& gate_cp) {
+                py::list ret;
+                for (auto* g : gate_cp.get_gate_list()) {
+                    ret.append(py::cast(
+                        g->copy(), py::return_value_policy::take_ownership));
+                }
+                return ret;
+            },
+            "get_gate_list");
     py::class_<QuantumGate_Adaptive, QuantumGateBase>(
         m, "QuantumGate_Adaptive");
     py::class_<QuantumGateDiagonalMatrix, QuantumGateBase>(
@@ -1612,8 +1639,21 @@ Matrix Representation
         .def("get_expectation_value",
             &CausalConeSimulator::get_expectation_value,
             "Return expectation_value")
-        .def("get_circuit_list", &CausalConeSimulator::get_circuit_list,
-            py::keep_alive<0, 1>(), "Return circuit_list")
+        .def(
+            "get_circuit_list",
+            [](CausalConeSimulator& ccs) {
+                py::list ret;
+                for (const auto& circ_list : ccs.get_circuit_list()) {
+                    py::list ret_child;
+                    for (auto* circ : circ_list) {
+                        ret_child.append(py::cast(circ->copy(),
+                            py::return_value_policy::take_ownership));
+                    }
+                    ret.append(ret_child);
+                }
+                return ret;
+            },
+            "Return circuit_list")
         .def("get_pauli_operator_list",
             &CausalConeSimulator::get_pauli_operator_list,
             "Return pauli_operator_list")

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -767,7 +767,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,
-            py::return_value_policy::reference, "get_gate_list")
+            py::return_value_policy::reference_internal, "get_gate_list")
         .def("optimize_ProbablisticGate",
             &QuantumGate_Probabilistic::optimize_ProbablisticGate,
             "optimize_ProbablisticGate")
@@ -779,10 +779,10 @@ PYBIND11_MODULE(qulacs_core, m) {
     py::class_<QuantumGate_CPTP, QuantumGateBase>(
         m, "QuantumGate_CPTP", "QuantumGate_Instrument")
         .def("get_gate_list", &QuantumGate_CPTP::get_gate_list,
-            py::return_value_policy::reference, "get_gate_list");
+            py::return_value_policy::reference_internal, "get_gate_list");
     py::class_<QuantumGate_CP, QuantumGateBase>(m, "QuantumGate_CP")
         .def("get_gate_list", &QuantumGate_CP::get_gate_list,
-            py::return_value_policy::reference, "get_gate_list");
+            py::return_value_policy::reference_internal, "get_gate_list");
     py::class_<QuantumGate_Adaptive, QuantumGateBase>(
         m, "QuantumGate_Adaptive");
     py::class_<QuantumGateDiagonalMatrix, QuantumGateBase>(
@@ -1613,7 +1613,7 @@ Matrix Representation
             &CausalConeSimulator::get_expectation_value,
             "Return expectation_value")
         .def("get_circuit_list", &CausalConeSimulator::get_circuit_list,
-            "Return circuit_list")
+            py::return_value_policy::reference_internal, "Return circuit_list")
         .def("get_pauli_operator_list",
             &CausalConeSimulator::get_pauli_operator_list,
             "Return pauli_operator_list")

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -767,7 +767,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     py::class_<QuantumGate_Probabilistic, QuantumGateBase>(
         m, "QuantumGate_Probabilistic", "QuantumGate_ProbabilisticInstrument")
         .def("get_gate_list", &QuantumGate_Probabilistic::get_gate_list,
-            py::return_value_policy::reference_internal, "get_gate_list")
+            py::keep_alive<0, 1>(), "get_gate_list")
         .def("optimize_ProbablisticGate",
             &QuantumGate_Probabilistic::optimize_ProbablisticGate,
             "optimize_ProbablisticGate")
@@ -779,10 +779,10 @@ PYBIND11_MODULE(qulacs_core, m) {
     py::class_<QuantumGate_CPTP, QuantumGateBase>(
         m, "QuantumGate_CPTP", "QuantumGate_Instrument")
         .def("get_gate_list", &QuantumGate_CPTP::get_gate_list,
-            py::return_value_policy::reference_internal, "get_gate_list");
+            py::keep_alive<0, 1>(), "get_gate_list");
     py::class_<QuantumGate_CP, QuantumGateBase>(m, "QuantumGate_CP")
         .def("get_gate_list", &QuantumGate_CP::get_gate_list,
-            py::return_value_policy::reference_internal, "get_gate_list");
+            py::keep_alive<0, 1>(), "get_gate_list");
     py::class_<QuantumGate_Adaptive, QuantumGateBase>(
         m, "QuantumGate_Adaptive");
     py::class_<QuantumGateDiagonalMatrix, QuantumGateBase>(
@@ -1613,7 +1613,7 @@ Matrix Representation
             &CausalConeSimulator::get_expectation_value,
             "Return expectation_value")
         .def("get_circuit_list", &CausalConeSimulator::get_circuit_list,
-            py::return_value_policy::reference_internal, "Return circuit_list")
+            py::keep_alive<0, 1>(), "Return circuit_list")
         .def("get_pauli_operator_list",
             &CausalConeSimulator::get_pauli_operator_list,
             "Return pauli_operator_list")


### PR DESCRIPTION
The code below may fail with Segmentation Fault.

```py
from qulacs import ParametricQuantumCircuit, Observable, CausalConeSimulator
from qulacs.gate import *
import numpy as np

n = 4
for _ in range(2):
    p_circuit = ParametricQuantumCircuit(n)
    print(p_circuit)
    observable = Observable(n)
    index_particle = 3
    observable.add_operator(1.0, "Z " + str(index_particle))
    p_circuit.add_parametric_RX_gate(0, np.pi / 4)
    p_circuit.add_parametric_RX_gate(1, np.pi / 4)
    p_circuit.add_parametric_RX_gate(2, np.pi / 4)
    p_circuit.add_parametric_RX_gate(3, np.pi / 4)
    p_circuit.add_CNOT_gate(0, 1)
    p_circuit.add_CNOT_gate(1, 2)
    p_circuit.add_CNOT_gate(1, 2)
    p_circuit.add_CNOT_gate(3, 0)
    css = CausalConeSimulator(p_circuit, observable)
    css.build()
    circuit_list = css.get_circuit_list()
    new_circuit = circuit_list[0][0]
    print(new_circuit)
```

This is because `CausalConeSimulator.get_circuit_list` return the list of `QuantumGateBase*` which belongs to `CausalConeSimulator`.
Referencing the gates after deleting `CausalConeSimulator` is an undefined behavior.
This PR resolve this by copying each `QuantumGateBase*` element.
Adding to list with `py::cast(***, py::return_value_policy::take_owhership))` can avoid memory leaks.