### PR TITLE
Windows Python3.13 support

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -45,10 +45,6 @@ jobs:
             python-version: "3.12"
           - cibw-python: "cp313"
             python-version: "3.13"
-        exclude:
-          # since `pip install 'openfermion<1.7.0'` fails: https://github.com/qulacs/qulacs/actions/runs/13757608985
-          - os-arch: "win_amd64"
-            cibw-python: "cp313"
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Windows Python3.13 wheel build has been removed because numpy < 2.0 does not support Python 3.13 but openfermion did not support numpy >= 2.0.
Now openfermion supports numpy >= 2.0 (ref: https://github.com/quantumlib/OpenFermion/issues/1008#issuecomment-2940961529 ), so we can support Python 3.13.