### PR TITLE
Remove sequential push_backs to prevent excessive memory allocation

### DIFF
--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -908,12 +908,16 @@ public:
 #endif
         std::vector<double> stacked_prob;
         std::vector<ITYPE> result;
+        // resize
+        stacked_prob.resize(this->dim + 1);
+        result.resize(sampling_count);
+
         double sum = 0.;
         auto ptr = this->data_cpp();
-        stacked_prob.push_back(0.);
+        stacked_prob[0] = 0.;
         for (ITYPE i = 0; i < this->dim; ++i) {
             sum += norm(ptr[i]);
-            stacked_prob.push_back(sum);
+            stacked_prob[i + 1] = sum;
         }
 
         for (UINT count = 0; count < sampling_count; ++count) {
@@ -921,7 +925,7 @@ public:
             auto ite =
                 std::lower_bound(stacked_prob.begin(), stacked_prob.end(), r);
             auto index = std::distance(stacked_prob.begin(), ite) - 1;
-            result.push_back(index);
+            result[count] = index;
         }
         return result;
     }


### PR DESCRIPTION
#690 の修正案です