### PR TITLE
Fix an incorrect swap insertion location bug related to FusedSWAP insertion

### DIFF
--- a/src/cppsim/circuit_optimizer.cpp
+++ b/src/cppsim/circuit_optimizer.cpp
@@ -753,7 +753,7 @@ void QuantumCircuitOptimizer::revert_qubit_order(QubitTable& qt) {
                 move_matching_qubits_to_local_upper(
                     local_qc - swap_width, qt,
                     [&](UINT q) { return corr_ref_qubits.count(q) == 0; },
-                    circuit->qubit_count /*end of circuit*/);
+                    circuit->gate_list.size() /*end of circuit*/);
 
                 // and then fused-swap between local and global qubits
                 // e.g.

--- a/test/cppsim/test_circuit_multicpu.cpp
+++ b/test/cppsim/test_circuit_multicpu.cpp
@@ -1663,9 +1663,9 @@ TEST(CircuitTest_multicpu, FSWAPOptimizer_bug706) {
     circuit.add_random_unitary_gate({0, 3, 4}, seed);
     circuit.add_random_unitary_gate({0, 3, 1}, seed);
 
-    UINT block_size = -1; // use optimizer_light
+    UINT block_size = -1;  // use optimizer_light
     UINT swap_level = 2;
-    UINT n_expected_swaps = 10000; // don't care # of swaps
+    UINT n_expected_swaps = 10000;  // don't care # of swaps
     _ApplyOptimizer(&circuit, block_size, swap_level, n_expected_swaps);
 }
 #endif

--- a/test/cppsim/test_circuit_multicpu.cpp
+++ b/test/cppsim/test_circuit_multicpu.cpp
@@ -1648,4 +1648,24 @@ TEST(CircuitTest_multicpu, FSWAPOptimizer_with_mpisize) {
     ASSERT_TRUE(has_swap_gate)
         << "circuit optimized with mpi_size=4 should have FusedSWAP gates";
 }
+
+TEST(CircuitTest_multicpu, FSWAPOptimizer_bug706) {
+    MPIutil& m = MPIutil::get_inst();
+    const UINT mpi_size = m.get_size();
+
+    // only for mpi ranks == 4
+    if (mpi_size != 4) {
+        return;
+    }
+
+    QuantumCircuit circuit(5);
+    int seed = 2026;
+    circuit.add_random_unitary_gate({0, 3, 4}, seed);
+    circuit.add_random_unitary_gate({0, 3, 1}, seed);
+
+    UINT block_size = -1; // use optimizer_light
+    UINT swap_level = 2;
+    UINT n_expected_swaps = 10000; // don't care # of swaps
+    _ApplyOptimizer(&circuit, block_size, swap_level, n_expected_swaps);
+}
 #endif


### PR DESCRIPTION
closes #706

I fixed an issue where, when inserting a swap at the end of the circuit, the insertion position should have been specified as `circuit->gate_list.size()`, but was mistakenly set to `circuit->qubit_count`.

The added test can be run as follows:
```
USE_TEST=Yes ./script/build_mpicc.sh
cd build
make test
mpirun -n 4 ../bin/cppsim_test --gtest_filter="CircuitTest_multicpu.FSWAPOptimizer_bug706"
```