### PR TITLE
Fix notfound mpi.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,9 @@ if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") OR (${CMAKE_CXX_COMPILER_ID} STREQ
 			(NOT "${CMAKE_CXX_COMPILER}" MATCHES ".*mpic\\+\\+"))
 			message(FATAL_ERROR, "USE_MPI must be used in mpicc/mpic++.")
 		endif()
-		add_compile_options("-D _USE_MPI -lmpi")
+		add_compile_options("-D _USE_MPI")
+		include_directories(${MPI_CXX_INCLUDE_DIRS})
+		link_libraries(${MPI_CXX_LIBRARIES})
 	endif()
 
 	# Enable gpu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") OR (${CMAKE_CXX_COMPILER_ID} STREQ
 
 	# Enable openmpi
 	if(USE_MPI)
+	    find_package(MPI REQUIRED)
 		if((NOT "${CMAKE_C_COMPILER}" MATCHES ".*mpicc") OR
 			(NOT "${CMAKE_CXX_COMPILER}" MATCHES ".*mpic\\+\\+"))
 			message(FATAL_ERROR, "USE_MPI must be used in mpicc/mpic++.")


### PR DESCRIPTION
When using a custom-installed Open MPI, the path to `mpi.h` is not appended to `CPLUS_INCLUDE_PATH`. Therefore, I changed `CMakeLists.txt` to use ` FindMPI`.

By the way, I noticed that the test command in CONTRIBUTING.md might be `make pythontest` instead of `make test`. Is that correct?