### PR TITLE
ci(wheels): build and publish manylinux aarch64 wheels

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -23,11 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         os-arch:
-          ["manylinux_x86_64", "win_amd64", "macosx_x86_64", "macosx_arm64"]
+          ["manylinux_x86_64", "manylinux_aarch64", "win_amd64", "macosx_x86_64", "macosx_arm64"]
         cibw-python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
         # Documentation for `include`: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
           - os-arch: "manylinux_x86_64"
+            os: "ubuntu-24.04"
+          - os-arch: "manylinux_aarch64"
             os: "ubuntu-24.04"
           - os-arch: "win_amd64"
             os: "windows-2022"
@@ -49,7 +51,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
+      CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
       PYTHON: ${{ matrix.python-version }}
       TWINE_USERNAME: "__token__"
     steps:
@@ -62,6 +66,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Setup QEMU for aarch64 wheel build
+        if: ${{ matrix.os-arch == 'manylinux_aarch64' }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Install Python dependencies
         run: python -m pip install cibuildwheel twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ cd boost_1_76_0 && ./bootstrap.sh && ./b2 headers && \
 cp -r boost /usr/local/include && rm -rf {project}/build \
 """
 
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_aarch64"
+environment = { QULACS_OPT_FLAGS = "-march=armv8-a" }
+
 [tool.cibuildwheel.windows]
 environment = { QULACS_OPT_FLAGS = "-mtune=haswell -mfpmath=both" }
 before-test = "rm -rf {project}/build"


### PR DESCRIPTION
## Summary

This PR enables Linux ARM wheel builds for Qulacs by extending the wheel CI/release pipeline to include `manylinux_aarch64`.

## Changes

- Added `manylinux_aarch64` to the wheel build matrix in `.github/workflows/wheel.yml`.
- Configured Linux wheel arch support with:
  - `CIBW_ARCHS_LINUX="x86_64 aarch64"`
  - `CIBW_MANYLINUX_AARCH64_IMAGE=manylinux_2_28`
- Added `docker/setup-qemu-action@v3` for the `manylinux_aarch64` job.
- Added a cibuildwheel override in `pyproject.toml`:
  - `select = "*-manylinux_aarch64"`
  - `QULACS_OPT_FLAGS = "-march=armv8-a"` to avoid x86-specific optimization flags on ARM builds.