### PR TITLE
Fix `PauliGate` and `PauliRotationGate` for MPI distributed state vectors

### DIFF
--- a/python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
+++ b/python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
@@ -55,9 +55,9 @@ _PAULI_GATE_CASES = [
     # Case A-Z: global Z/I only (bit_flip_mask==0, no communication)
     ("Z_global[g0]|000001>", 0b000001, [_G0], [3]),
     ("Z_global[g0]|100001>", 1 << _G0 | 1, [_G0], [3]),
-    ("ZZ_local_global|000001>",0b000001, [_Q0, _G0], [3, 3]),
-    ("ZZ_local_global|000000>",0b000000, [_Q0, _G0], [3, 3]),
-    ("ZZ_local_global|100001>",1 << _G0 | 1, [_Q0, _G0], [3, 3]),
+    ("ZZ_local_global|000001>", 0b000001, [_Q0, _G0], [3, 3]),
+    ("ZZ_local_global|000000>", 0b000000, [_Q0, _G0], [3, 3]),
+    ("ZZ_local_global|100001>", 1 << _G0 | 1, [_Q0, _G0], [3, 3]),
     # Case A-XZ: local X/Y + global Z (no communication)
     ("X_local_Z_global|000001>", 0b000001, [_Q0, _G0], [1, 3]),
     ("Y_local_Z_global|000001>", 0b000001, [_Q0, _G0], [2, 3]),
@@ -168,9 +168,7 @@ class TestPauliGateMultiCpu:
         mpi_s.set_computational_basis(basis)
         gate.update_quantum_state(mpi_s)
 
-        np.testing.assert_allclose(
-            np.array(mpi_s.get_vector()), local_ref, atol=1e-10
-        )
+        np.testing.assert_allclose(np.array(mpi_s.get_vector()), local_ref, atol=1e-10)
 
     @pytest.mark.parametrize("label,basis,qubits,pauli_ids", _PAULI_GATE_CASES)
     @pytest.mark.usefixtures("init_state")

--- a/python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
+++ b/python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
@@ -1,0 +1,183 @@
+"""Tests for MPI-aware PauliGate and PauliRotationGate.
+
+Each test applies the same gate to a serial QuantumState and to a distributed
+QuantumState(n, use_multi_cpu=True), then verifies that each rank's local
+amplitude slice matches the corresponding slice of the serial reference.
+
+Tests cover all three internal cases of the MPI implementation:
+
+  Case A-Z   -- pure Z/I Pauli string; no communication required.
+  Case A-XZ  -- local X/Y + global Z/I; no communication required.
+  Case B1    -- all X/Y qubits are global; sendrecv + element-wise update.
+  Case B2    -- mixed local and global X/Y; sendrecv + pairwise update.
+
+Run with:
+    mpirun -n 2 pytest python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
+    mpirun -n 4 pytest python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
+"""
+from typing import Generator
+
+import numpy as np
+import pytest
+
+import qulacs
+import qulacs.gate as g
+
+pytestmark = pytest.mark.skipif(
+    not qulacs.check_build_for_mpi(),
+    reason="To use multi-cpu, qulacs built for mpi is required.",
+)
+
+# Fixed problem size: n=6 gives inner_qc>=4 for up to 4 ranks.
+_N = 6
+_THETA = 0.7
+
+# Local qubit indices (bits 0-3; always local for <=4 ranks with n=6)
+_Q0, _Q1, _Q2 = 0, 1, 2
+
+# Global qubit indices: highest bits carry rank information.
+# _G0 (qubit 5) is global for all multi-rank runs.
+# _G1 (qubit 4) is global only when outer_qc >= 2 (i.e., 4+ ranks);
+# it is local with 2 ranks but the test is still correct in that case.
+_G0 = _N - 1  # 5
+_G1 = _N - 2  # 4
+
+# == test-case tables ==========================================================
+# Each entry: (label, basis, qubit_list, pauli_id_list)
+
+_PAULI_GATE_CASES = [
+    # Case A-XZ: local-only (all qubits < inner_qc)
+    ("X_local[q0]|0001>", 0b000001, [_Q0], [1]),
+    ("Y_local[q0]|0001>", 0b000001, [_Q0], [2]),
+    ("Z_local[q0]|0001>", 0b000001, [_Q0], [3]),
+    ("XY_local|0011>", 0b000011, [_Q0, _Q1], [1, 2]),
+    ("XYZ_local|0111>", 0b000111, [_Q0, _Q1, _Q2], [1, 2, 3]),
+    # Case A-Z: global Z/I only (bit_flip_mask==0, no communication)
+    ("Z_global[g0]|000001>", 0b000001, [_G0], [3]),
+    ("Z_global[g0]|100001>", 1 << _G0 | 1, [_G0], [3]),
+    ("ZZ_local_global|000001>",0b000001, [_Q0, _G0], [3, 3]),
+    ("ZZ_local_global|000000>",0b000000, [_Q0, _G0], [3, 3]),
+    ("ZZ_local_global|100001>",1 << _G0 | 1, [_Q0, _G0], [3, 3]),
+    # Case A-XZ: local X/Y + global Z (no communication)
+    ("X_local_Z_global|000001>", 0b000001, [_Q0, _G0], [1, 3]),
+    ("Y_local_Z_global|000001>", 0b000001, [_Q0, _G0], [2, 3]),
+    ("XY_local_Z_global|000011>", 0b000011, [_Q0, _Q1, _G0], [1, 2, 3]),
+    ("X_local_Z_global|100001>", 1 << _G0 | 1, [_Q0, _G0], [1, 3]),
+    # Case B1: global X/Y only (sendrecv + element-wise swap)
+    ("X_global[g0]|000000>", 0b000000, [_G0], [1]),
+    ("X_global[g0]|000001>", 0b000001, [_G0], [1]),
+    ("Y_global[g0]|000000>", 0b000000, [_G0], [2]),
+    ("Y_global[g0]|000001>", 0b000001, [_G0], [2]),
+    ("Z_local_X_global|000001>", 0b000001, [_Q0, _G0], [3, 1]),
+    ("Z_local_Y_global|000001>", 0b000001, [_Q0, _G0], [3, 2]),
+    ("Y_local_X_global|000001>", 0b000001, [_Q1, _G0], [2, 1]),
+    # Case B2: mixed local + global X/Y (sendrecv + pairwise swap)
+    ("XX_local_global|000001>", 0b000001, [_Q0, _G0], [1, 1]),
+    ("YY_local_global|000001>", 0b000001, [_Q0, _G0], [2, 2]),
+    ("XY_local_global|000001>", 0b000001, [_Q0, _G0], [1, 2]),
+    ("YX_local_global|000001>", 0b000001, [_Q0, _G0], [2, 1]),
+    ("YZ_local_global|000001>", 0b000001, [_Q0, _G0], [2, 3]),
+    ("XX_local_global|100001>", 1 << _G0 | 1, [_Q0, _G0], [1, 1]),
+    ("YY_local_global|100000>", 1 << _G0, [_Q0, _G0], [2, 2]),
+    ("ZY_local_global|000110>", 0b000110, [_Q1, _G0], [3, 2]),
+    # Multi-global (g1=qubit4 is global for 4+ ranks, local for 2 ranks)
+    ("XX_two_global|000000>", 0b000000, [_G0, _G1], [1, 1]),
+    ("YY_two_global|000000>", 0b000000, [_G0, _G1], [2, 2]),
+    ("XY_two_global|000001>", 0b000001, [_G0, _G1], [1, 2]),
+    ("ZZ_two_global|000000>", 0b000000, [_G0, _G1], [3, 3]),
+    ("X_local_XX_global|000001>", 0b000001, [_Q0, _G0, _G1], [1, 1, 1]),
+]
+
+# Each entry: (label, basis, qubit_list, pauli_id_list, angle)
+_PAULI_ROT_CASES = [
+    # Case A-XZ: local-only
+    ("X_rot_local[q0]|000001>", 0b000001, [_Q0], [1], _THETA),
+    ("Y_rot_local[q0]|000001>", 0b000001, [_Q0], [2], _THETA),
+    ("Z_rot_local[q0]|000001>", 0b000001, [_Q0], [3], _THETA),
+    ("XY_rot_local|000011>", 0b000011, [_Q0, _Q1], [1, 2], _THETA),
+    # Case A-Z: global Z/I only
+    ("Z_rot_global[g0]|000001>", 0b000001, [_G0], [3], _THETA),
+    ("Z_rot_global[g0]|100001>", 1 << _G0 | 1, [_G0], [3], _THETA),
+    ("ZZ_rot_local_global|000001>", 0b000001, [_Q0, _G0], [3, 3], _THETA),
+    ("ZZ_rot_local_global|100001>", 1 << _G0 | 1, [_Q0, _G0], [3, 3], _THETA),
+    ("ZZ_rot_local_global|000000>", 0b000000, [_Q0, _G0], [3, 3], _THETA),
+    # Case A-XZ: local X/Y + global Z
+    ("X_rot_local_Z_global|000001>", 0b000001, [_Q0, _G0], [1, 3], _THETA),
+    ("Y_rot_local_Z_global|000001>", 0b000001, [_Q0, _G0], [2, 3], _THETA),
+    ("X_rot_local_Z_global|100001>", 1 << _G0 | 1, [_Q0, _G0], [1, 3], _THETA),
+    # Case B1: global X/Y only
+    ("X_rot_global[g0]|000001>", 0b000001, [_G0], [1], _THETA),
+    ("Y_rot_global[g0]|000001>", 0b000001, [_G0], [2], _THETA),
+    ("Z_rot_local_X_global|000001>", 0b000001, [_Q0, _G0], [3, 1], _THETA),
+    ("Z_rot_local_Y_global|000001>", 0b000001, [_Q0, _G0], [3, 2], _THETA),
+    # Case B2: mixed local + global X/Y
+    ("XX_rot|000011>", 0b000011, [_Q0, _G0], [1, 1], 1.0),
+    ("XX_rot|000001>", 0b000001, [_Q0, _G0], [1, 1], _THETA),
+    ("YY_rot|000001>", 0b000001, [_Q0, _G0], [2, 2], _THETA),
+    ("XY_rot|000001>", 0b000001, [_Q0, _G0], [1, 2], _THETA),
+    ("YX_rot|000001>", 0b000001, [_Q0, _G0], [2, 1], _THETA),
+    ("YZ_rot|000001>", 0b000001, [_Q0, _G0], [2, 3], _THETA),
+    ("XX_rot|100001>", 1 << _G0 | 1, [_Q0, _G0], [1, 1], _THETA),
+    ("YY_rot|100000>", 1 << _G0, [_Q0, _G0], [2, 2], _THETA),
+    # Multi-global (g1 is global for 4+ ranks)
+    ("XX_rot_two_global|000001>", 0b000001, [_G0, _G1], [1, 1], _THETA),
+    ("YY_rot_two_global|000001>", 0b000001, [_G0, _G1], [2, 2], _THETA),
+    ("ZZ_rot_two_global|000001>", 0b000001, [_G0, _G1], [3, 3], _THETA),
+    ("XXX_rot_local_2global|000001>", 0b000001, [_Q0, _G0, _G1], [1, 1, 1], _THETA),
+    ("YZX_rot_mixed|000011>", 0b000011, [_Q1, _G0, _G1], [2, 3, 1], _THETA),
+    # Full 3x3 sweep of all (local, global) Pauli pairs
+    ("XX_rot_sweep", 0b000001, [_Q0, _G0], [1, 1], _THETA),
+    ("XY_rot_sweep", 0b000001, [_Q0, _G0], [1, 2], _THETA),
+    ("XZ_rot_sweep", 0b000001, [_Q0, _G0], [1, 3], _THETA),
+    ("YX_rot_sweep", 0b000001, [_Q0, _G0], [2, 1], _THETA),
+    ("YY_rot_sweep", 0b000001, [_Q0, _G0], [2, 2], _THETA),
+    ("YZ_rot_sweep", 0b000001, [_Q0, _G0], [2, 3], _THETA),
+    ("ZX_rot_sweep", 0b000001, [_Q0, _G0], [3, 1], _THETA),
+    ("ZY_rot_sweep", 0b000001, [_Q0, _G0], [3, 2], _THETA),
+    ("ZZ_rot_sweep", 0b000001, [_Q0, _G0], [3, 3], _THETA),
+]
+
+
+# == test classes ==============================================================
+
+
+class TestPauliGateMultiCpu:
+    @pytest.fixture
+    def init_state(self, init_mpi) -> Generator[None, None, None]:
+        multicpu, mpicomm = init_mpi
+        if multicpu:
+            self.mpirank = mpicomm.Get_rank()  # type: ignore
+            self.mpisize = mpicomm.Get_size()  # type: ignore
+        else:
+            self.mpirank = 0
+            self.mpisize = 1
+        self.dim_local = 2**_N // self.mpisize
+        yield
+
+    def _check(self, gate, basis) -> None:
+        """Apply gate; assert MPI local slice == serial reference slice."""
+        ref = qulacs.QuantumState(_N)
+        ref.set_computational_basis(basis)
+        gate.update_quantum_state(ref)
+        ref_vec = np.array(ref.get_vector())
+        local_ref = ref_vec[
+            self.dim_local * self.mpirank : self.dim_local * (self.mpirank + 1)
+        ]
+
+        mpi_s = qulacs.QuantumState(_N, True)
+        mpi_s.set_computational_basis(basis)
+        gate.update_quantum_state(mpi_s)
+
+        np.testing.assert_allclose(
+            np.array(mpi_s.get_vector()), local_ref, atol=1e-10
+        )
+
+    @pytest.mark.parametrize("label,basis,qubits,pauli_ids", _PAULI_GATE_CASES)
+    @pytest.mark.usefixtures("init_state")
+    def test_pauli_gate(self, label, basis, qubits, pauli_ids) -> None:
+        self._check(g.Pauli(qubits, pauli_ids), basis)
+
+    @pytest.mark.parametrize("label,basis,qubits,pauli_ids,angle", _PAULI_ROT_CASES)
+    @pytest.mark.usefixtures("init_state")
+    def test_pauli_rotation_gate(self, label, basis, qubits, pauli_ids, angle) -> None:
+        self._check(g.PauliRotation(qubits, pauli_ids, angle), basis)

--- a/python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
+++ b/python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
@@ -15,6 +15,7 @@ Run with:
     mpirun -n 2 pytest python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
     mpirun -n 4 pytest python/tests/multi_cpu/test_gate_pauli_multi_cpu.py
 """
+
 from typing import Generator
 
 import numpy as np
@@ -178,4 +179,115 @@ class TestPauliGateMultiCpu:
     @pytest.mark.parametrize("label,basis,qubits,pauli_ids,angle", _PAULI_ROT_CASES)
     @pytest.mark.usefixtures("init_state")
     def test_pauli_rotation_gate(self, label, basis, qubits, pauli_ids, angle) -> None:
+        self._check(g.PauliRotation(qubits, pauli_ids, angle), basis)
+
+
+# == Regression tests: local qubit index >= _NQUBIT_WORK =======================
+#
+# _NQUBIT_WORK = 22 (MPIutil.hpp) caps the MPI work buffer at 2^22 amplitudes.
+# When a local X/Y qubit has index >= 22, its partner element falls in a
+# different buffer chunk (lbfm_high != 0).  Two bugs existed before the fix:
+#
+#   Bug 1 (OOB read):    j ^ local_bit_flip_mask >= dim_work → SIGSEGV
+#   Bug 2 (wrong phase): phase computed from within-chunk index j instead of
+#                        the full local index (iter * dim_work + j)
+#
+# Triggering either bug requires inner_qc > _NQUBIT_WORK.  With 2 MPI ranks
+# and N=24: inner_qc = 23 > 22; each rank holds 2^23 = 8Mi amplitudes (~128 MB).
+# Tests are skipped automatically when this condition is not met (e.g. 4 ranks
+# with N=24 gives inner_qc=22, or when running without MPI).
+
+_N_LARGE = 24
+_NQUBIT_WORK = 22  # must match _NQUBIT_WORK in src/csim/MPIutil.hpp
+
+# With 2 MPI ranks and N=24: qubit 22 is the highest local qubit (index 22)
+# and qubit 23 is the single global qubit.
+_QL22 = 22
+_GL23 = _N_LARGE - 1  # = 23; global for 2 ranks
+
+# Each tuple: (label, basis, qubit_list, pauli_id_list)
+_LARGE_PAULI_GATE_CASES = [
+    # Bug 1: cross-chunk OOB — X/Y on local qubit 22 (lbfm_high != 0)
+    ("cross_chunk_XX|1>", 0b1, [_QL22, _GL23], [1, 1]),
+    ("cross_chunk_XX|q22>", 1 << _QL22, [_QL22, _GL23], [1, 1]),
+    ("cross_chunk_XY|1>", 0b1, [_QL22, _GL23], [1, 2]),
+    # Bug 1 + 2: Y on local 22 contributes to local_phase_flip_mask too
+    ("cross_chunk_YX|1>", 0b1, [_QL22, _GL23], [2, 1]),
+    ("cross_chunk_YX|q22>", 1 << _QL22, [_QL22, _GL23], [2, 1]),
+    # Bug 2: same-chunk B1 with iter>0 — Z on local 22 sets high phase-mask bit
+    ("same_chunk_B1_ZX|1>", 0b1, [_QL22, _GL23], [3, 1]),
+    ("same_chunk_B1_ZX|q22>", 1 << _QL22, [_QL22, _GL23], [3, 1]),
+    ("same_chunk_B1_ZY|1>", 0b1, [_QL22, _GL23], [3, 2]),
+]
+
+# Each tuple: (label, basis, qubit_list, pauli_id_list, angle)
+_LARGE_PAULI_ROT_CASES = [
+    # Bug 1: cross-chunk OOB
+    ("cross_chunk_rot_XX|1>", 0b1, [_QL22, _GL23], [1, 1], _THETA),
+    ("cross_chunk_rot_XX|q22>", 1 << _QL22, [_QL22, _GL23], [1, 1], _THETA),
+    ("cross_chunk_rot_XY|1>", 0b1, [_QL22, _GL23], [1, 2], _THETA),
+    # Bug 1 + 2: Y on local 22
+    ("cross_chunk_rot_YX|1>", 0b1, [_QL22, _GL23], [2, 1], _THETA),
+    ("cross_chunk_rot_YX|q22>", 1 << _QL22, [_QL22, _GL23], [2, 1], _THETA),
+    # Bug 2: same-chunk B1 with iter>0
+    ("same_chunk_B1_rot_ZX|1>", 0b1, [_QL22, _GL23], [3, 1], _THETA),
+    ("same_chunk_B1_rot_ZX|q22>", 1 << _QL22, [_QL22, _GL23], [3, 1], _THETA),
+    ("same_chunk_B1_rot_ZY|1>", 0b1, [_QL22, _GL23], [3, 2], _THETA),
+]
+
+
+class TestPauliGateLargeChunk:
+    """Regression tests for bugs triggered when local qubit index >= _NQUBIT_WORK.
+
+    Requires 2 MPI ranks with N=24 so that inner_qc=23 > _NQUBIT_WORK=22.
+    Tests are skipped automatically when that condition is not satisfied.
+    """
+
+    @pytest.fixture
+    def init_state(self, init_mpi) -> Generator[None, None, None]:
+        multicpu, mpicomm = init_mpi
+        if multicpu:
+            self.mpirank = mpicomm.Get_rank()  # type: ignore
+            self.mpisize = mpicomm.Get_size()  # type: ignore
+        else:
+            self.mpirank = 0
+            self.mpisize = 1
+        outer_qc = (self.mpisize - 1).bit_length()  # log2(mpisize) for power-of-2
+        inner_qc = _N_LARGE - outer_qc
+        if inner_qc <= _NQUBIT_WORK:
+            pytest.skip(
+                f"inner_qc={inner_qc} <= _NQUBIT_WORK={_NQUBIT_WORK}: "
+                f"need 2 MPI ranks with N={_N_LARGE} to exercise the cross-chunk path"
+            )
+        self.dim_local = 2**_N_LARGE // self.mpisize
+        yield
+
+    def _check(self, gate, basis) -> None:
+        """Apply gate; assert MPI local slice == serial reference slice."""
+        ref = qulacs.QuantumState(_N_LARGE)
+        ref.set_computational_basis(basis)
+        gate.update_quantum_state(ref)
+        ref_vec = np.array(ref.get_vector())
+        local_ref = ref_vec[
+            self.dim_local * self.mpirank : self.dim_local * (self.mpirank + 1)
+        ]
+
+        mpi_s = qulacs.QuantumState(_N_LARGE, True)
+        mpi_s.set_computational_basis(basis)
+        gate.update_quantum_state(mpi_s)
+
+        np.testing.assert_allclose(np.array(mpi_s.get_vector()), local_ref, atol=1e-10)
+
+    @pytest.mark.parametrize("label,basis,qubits,pauli_ids", _LARGE_PAULI_GATE_CASES)
+    @pytest.mark.usefixtures("init_state")
+    def test_pauli_gate_large(self, label, basis, qubits, pauli_ids) -> None:
+        self._check(g.Pauli(qubits, pauli_ids), basis)
+
+    @pytest.mark.parametrize(
+        "label,basis,qubits,pauli_ids,angle", _LARGE_PAULI_ROT_CASES
+    )
+    @pytest.mark.usefixtures("init_state")
+    def test_pauli_rotation_gate_large(
+        self, label, basis, qubits, pauli_ids, angle
+    ) -> None:
         self._check(g.PauliRotation(qubits, pauli_ids, angle), basis)

--- a/src/cppsim/gate_named_pauli.hpp
+++ b/src/cppsim/gate_named_pauli.hpp
@@ -63,14 +63,35 @@ public:
                 // _update_func_gpu(this->_target_qubit_list[0].index(), _angle,
                 // state->data(), state->dim);
             } else {
+#ifdef _USE_MPI
+                if (state->outer_qc > 0) {
+                    multi_qubit_Pauli_gate_partial_list_mpi(
+                        target_index_list.data(), pauli_id_list.data(),
+                        (UINT)target_index_list.size(), state->data_c(),
+                        state->dim, state->inner_qc);
+                } else
+#endif
+                {
+                    multi_qubit_Pauli_gate_partial_list(
+                        target_index_list.data(), pauli_id_list.data(),
+                        (UINT)target_index_list.size(), state->data_c(),
+                        state->dim);
+                }
+            }
+#else
+#ifdef _USE_MPI
+            if (state->outer_qc > 0) {
+                multi_qubit_Pauli_gate_partial_list_mpi(
+                    target_index_list.data(), pauli_id_list.data(),
+                    (UINT)target_index_list.size(), state->data_c(), state->dim,
+                    state->inner_qc);
+            } else
+#endif
+            {
                 multi_qubit_Pauli_gate_partial_list(target_index_list.data(),
                     pauli_id_list.data(), (UINT)target_index_list.size(),
                     state->data_c(), state->dim);
             }
-#else
-            multi_qubit_Pauli_gate_partial_list(target_index_list.data(),
-                pauli_id_list.data(), (UINT)target_index_list.size(),
-                state->data_c(), state->dim);
 #endif
         } else {
             dm_multi_qubit_Pauli_gate_partial_list(target_index_list.data(),
@@ -186,16 +207,36 @@ public:
                     (UINT)target_index_list.size(), _angle, state->data(),
                     state->dim, state->get_cuda_stream(), state->device_number);
             } else {
+#ifdef _USE_MPI
+                if (state->outer_qc > 0) {
+                    multi_qubit_Pauli_rotation_gate_partial_list_mpi(
+                        target_index_list.data(), pauli_id_list.data(),
+                        (UINT)target_index_list.size(), _angle, state->data_c(),
+                        state->dim, state->inner_qc);
+                } else
+#endif
+                {
+                    multi_qubit_Pauli_rotation_gate_partial_list(
+                        target_index_list.data(), pauli_id_list.data(),
+                        (UINT)target_index_list.size(), _angle, state->data_c(),
+                        state->dim);
+                }
+            }
+#else
+#ifdef _USE_MPI
+            if (state->outer_qc > 0) {
+                multi_qubit_Pauli_rotation_gate_partial_list_mpi(
+                    target_index_list.data(), pauli_id_list.data(),
+                    (UINT)target_index_list.size(), _angle, state->data_c(),
+                    state->dim, state->inner_qc);
+            } else
+#endif
+            {
                 multi_qubit_Pauli_rotation_gate_partial_list(
                     target_index_list.data(), pauli_id_list.data(),
                     (UINT)target_index_list.size(), _angle, state->data_c(),
                     state->dim);
             }
-#else
-            multi_qubit_Pauli_rotation_gate_partial_list(
-                target_index_list.data(), pauli_id_list.data(),
-                (UINT)target_index_list.size(), _angle, state->data_c(),
-                state->dim);
 #endif
         } else {
             dm_multi_qubit_Pauli_rotation_gate_partial_list(

--- a/src/csim/update_ops.hpp
+++ b/src/csim/update_ops.hpp
@@ -1004,8 +1004,11 @@ DllExport void multi_qubit_Pauli_gate_partial_list(
     const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list,
     UINT target_qubit_index_count, CTYPE* state, ITYPE dim);
 // This function is used in apply_to_state and gate_noisy_evolution
-// TODO: multi_qubit_Pauli_gate_partial_list is not implemented for multi-cpu
-// yet
+#ifdef _USE_MPI
+DllExport void multi_qubit_Pauli_gate_partial_list_mpi(
+    const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list,
+    UINT target_qubit_index_count, CTYPE* state, ITYPE dim, UINT inner_qc);
+#endif
 
 /**
  * \~english
@@ -1189,8 +1192,12 @@ DllExport void multi_qubit_Pauli_rotation_gate_partial_list(
     const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list,
     UINT target_qubit_index_count, double angle, CTYPE* state, ITYPE dim);
 // This function is used in ClsPauliRotationGate
-// TODO: multi_qubit_Pauli_rotation_gate_partial_list is not implemented for
-// multi-cpu yet
+#ifdef _USE_MPI
+DllExport void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
+    const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list,
+    UINT target_qubit_index_count, double angle, CTYPE* state, ITYPE dim,
+    UINT inner_qc);
+#endif
 
 /**
  * \~english

--- a/src/csim/update_ops_pauli_multi.cpp
+++ b/src/csim/update_ops_pauli_multi.cpp
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <vector>
+
 #include "constant.hpp"
 #include "update_ops.hpp"
 #include "utility.hpp"
@@ -533,53 +535,109 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
     ITYPE num_work = 0;
     CTYPE* ptr_recv = m.get_workarea(&dim_work, &num_work);
     assert(num_work > 0);
-    // Pairs must fit within one work chunk (see implementation notes)
-    assert(local_bit_flip_mask == 0 || local_bit_flip_mask < dim_work);
 
     const UINT adj_count =
         (global_phase_90rot_count + 2 * global_rank_parity) % 4;
-    CTYPE* ptr_state = state;
+
+    // Decompose local_bit_flip_mask across the chunk boundary (_NQUBIT_WORK).
+    // lbfm_high != 0 means a local X/Y qubit lives at bit >= _NQUBIT_WORK,
+    // so its partner element is in a different chunk.
+    const ITYPE lbfm_high = local_bit_flip_mask >> _NQUBIT_WORK;
+    const ITYPE lbfm_low = local_bit_flip_mask & (dim_work - 1);
 
 #ifdef _OPENMP
     OMPutil::get_inst().set_qulacs_num_threads(dim, 13);
 #endif
-    for (ITYPE iter = 0; iter < num_work; ++iter) {
-        m.m_DC_sendrecv(ptr_state, ptr_recv, dim_work, pair_rank);
-
-        if (local_bit_flip_mask == 0) {
-            // B1: all X/Y global - pair j with recv[j]
+    if (lbfm_high == 0) {
+        // ---- Case B same-chunk: partner element is within the same chunk ----
+        CTYPE* ptr_state = state;
+        for (ITYPE iter = 0; iter < num_work; ++iter) {
+            m.m_DC_sendrecv(ptr_state, ptr_recv, dim_work, pair_rank);
+            // Use the global local index for correct phase computation when
+            // local_phase_flip_mask has bits >= _NQUBIT_WORK.
+            const ITYPE jg_base = iter << _NQUBIT_WORK;
+            if (local_bit_flip_mask == 0) {
+                // B1: all X/Y global - pair j with recv[j]
+#pragma omp parallel for
+                for (ITYPE j = 0; j < dim_work; ++j) {
+                    int bp = (int)(count_population(
+                                       (jg_base | j) & local_phase_flip_mask) %
+                                   2);
+                    ptr_state[j] = ptr_recv[j] *
+                                   PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
+                }
+            } else {
+                // B2 (same-chunk): pair j with recv[j ^ lbfm_low]
+                const UINT local_pivot =
+                    (UINT)__builtin_ctzll((unsigned long long)lbfm_low);
+                const ITYPE lp_mask = 1ULL << local_pivot;
+                const ITYPE lp_mask_low = lp_mask - 1;
+                const ITYPE lp_mask_high = ~lp_mask_low;
+                const ITYPE loop_dim = dim_work / 2;
+#pragma omp parallel for
+                for (ITYPE si = 0; si < loop_dim; ++si) {
+                    const ITYPE j =
+                        (si & lp_mask_low) + ((si & lp_mask_high) << 1);
+                    const ITYPE j_pair = j ^ lbfm_low;
+                    int bp_j = (int)(count_population((jg_base | j) &
+                                                      local_phase_flip_mask) %
+                                     2);
+                    int bp_jp = (int)(count_population((jg_base | j_pair) &
+                                                       local_phase_flip_mask) %
+                                      2);
+                    ptr_state[j] =
+                        ptr_recv[j_pair] *
+                        PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
+                    ptr_state[j_pair] =
+                        ptr_recv[j] *
+                        PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
+                }
+            }
+            ptr_state += dim_work;
+        }
+    } else {
+        // ---- Case B cross-chunk: local X/Y qubit index >= _NQUBIT_WORK ----
+        // Element at global-local index g = iter*dim_work + j pairs with
+        //   g ^ local_bit_flip_mask = (iter^lbfm_high)*dim_work + (j^lbfm_low)
+        // i.e., a different chunk. Process chunk pairs (iter, iter^lbfm_high)
+        // together with two sendrecvs so both ranks issue matched calls:
+        //   sendrecv(our[iter])     -> recv_a = partner[iter]
+        //   sendrecv(our[iter_xor]) -> recv_b = partner[iter_xor]
+        // then: our[iter][j]     <- recv_b[j^lbfm_low]
+        //        our[iter_xor][j] <- recv_a[j^lbfm_low]
+        //
+        // lbfm_high != 0 is guaranteed here, so __builtin_clzll is safe.
+        const ITYPE lbfm_high_msb =
+            (ITYPE)1 << (sizeof(ITYPE) * 8 - 1 -
+                         __builtin_clzll((unsigned long long)lbfm_high));
+        std::vector<CTYPE> recv_b_vec(dim_work);
+        CTYPE* const ptr_recv_b = recv_b_vec.data();
+        for (ITYPE iter = 0; iter < num_work; ++iter) {
+            if (iter & lbfm_high_msb) continue;  // skip second-of-pair
+            const ITYPE iter_xor = iter ^ lbfm_high;
+            CTYPE* const ptr_A = state + iter * dim_work;
+            CTYPE* const ptr_B = state + iter_xor * dim_work;
+            m.m_DC_sendrecv(ptr_A, ptr_recv, dim_work, pair_rank);
+            m.m_DC_sendrecv(ptr_B, ptr_recv_b, dim_work, pair_rank);
+            const ITYPE jg_base_A = iter << _NQUBIT_WORK;
+            const ITYPE jg_base_B = iter_xor << _NQUBIT_WORK;
 #pragma omp parallel for
             for (ITYPE j = 0; j < dim_work; ++j) {
-                int bp = (int)(count_population(j & local_phase_flip_mask) % 2);
-                ptr_state[j] =
-                    ptr_recv[j] * PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
-            }
-        } else {
-            // B2: mixed - pair j with recv[j ^ local_bit_flip_mask]
-            const UINT local_pivot =
-                (UINT)__builtin_ctzll((unsigned long long)local_bit_flip_mask);
-            const ITYPE lp_mask = 1ULL << local_pivot;
-            const ITYPE lp_mask_low = lp_mask - 1;
-            const ITYPE lp_mask_high = ~lp_mask_low;
-            const ITYPE loop_dim = dim_work / 2;
-#pragma omp parallel for
-            for (ITYPE si = 0; si < loop_dim; ++si) {
-                const ITYPE j = (si & lp_mask_low) + ((si & lp_mask_high) << 1);
-                const ITYPE j_pair = j ^ local_bit_flip_mask;
-
-                int bp_j =
-                    (int)(count_population(j & local_phase_flip_mask) % 2);
-                int bp_jp =
-                    (int)(count_population(j_pair & local_phase_flip_mask) % 2);
-
-                ptr_state[j] = ptr_recv[j_pair] *
-                               PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
-                ptr_state[j_pair] =
-                    ptr_recv[j] *
-                    PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
+                const ITYPE jp = j ^ lbfm_low;
+                int bp_A = (int)(count_population(
+                                     (jg_base_A | j) & local_phase_flip_mask) %
+                                 2);
+                int bp_B = (int)(count_population(
+                                     (jg_base_B | j) & local_phase_flip_mask) %
+                                 2);
+                // our[iter][j]     <- partner[iter_xor][jp]  (in recv_b)
+                ptr_A[j] = ptr_recv_b[jp] *
+                           PHASE_M90ROT[(adj_count + (UINT)bp_A * 2) % 4];
+                // our[iter_xor][j] <- partner[iter][jp]      (in recv_a)
+                ptr_B[j] = ptr_recv[jp] *
+                           PHASE_M90ROT[(adj_count + (UINT)bp_B * 2) % 4];
             }
         }
-        ptr_state += dim_work;
     }
 #ifdef _OPENMP
     OMPutil::get_inst().reset_qulacs_num_threads();
@@ -641,66 +699,120 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
     ITYPE num_work = 0;
     CTYPE* ptr_recv = m.get_workarea(&dim_work, &num_work);
     assert(num_work > 0);
-    // Pairs must fit within one work chunk (see implementation notes).
-    // This holds whenever dim <= _NQUBIT_WORK capacity (2^22 * 16 B = 64 MB).
-    // For larger distributed states with mixed local+global X qubits this
-    // assertion will fire and the implementation needs to be extended (TODO).
-    assert(local_bit_flip_mask == 0 || local_bit_flip_mask < dim_work);
 
     const UINT adj_count =
         (global_phase_90rot_count + 2 * global_rank_parity) % 4;
     const double cosval = cos(angle / 2);
     const double sinval = sin(angle / 2);
-    CTYPE* ptr_state = state;
+
+    // Decompose local_bit_flip_mask across the chunk boundary (_NQUBIT_WORK).
+    // lbfm_high != 0 means a local X/Y qubit lives at bit >= _NQUBIT_WORK,
+    // so its partner element is in a different chunk.
+    const ITYPE lbfm_high = local_bit_flip_mask >> _NQUBIT_WORK;
+    const ITYPE lbfm_low = local_bit_flip_mask & (dim_work - 1);
 
 #ifdef _OPENMP
     OMPutil::get_inst().set_qulacs_num_threads(dim, 13);
 #endif
-    for (ITYPE iter = 0; iter < num_work; ++iter) {
-        m.m_DC_sendrecv(ptr_state, ptr_recv, dim_work, pair_rank);
-
-        if (local_bit_flip_mask == 0) {
-            // B1: all X/Y global - pair state[j] with recv[j]
+    if (lbfm_high == 0) {
+        // ---- Case B same-chunk: partner element is within the same chunk ----
+        CTYPE* ptr_state = state;
+        for (ITYPE iter = 0; iter < num_work; ++iter) {
+            m.m_DC_sendrecv(ptr_state, ptr_recv, dim_work, pair_rank);
+            // Use the global local index for correct phase computation when
+            // local_phase_flip_mask has bits >= _NQUBIT_WORK.
+            const ITYPE jg_base = iter << _NQUBIT_WORK;
+            if (local_bit_flip_mask == 0) {
+                // B1: all X/Y global - pair state[j] with recv[j]
+#pragma omp parallel for
+                for (ITYPE j = 0; j < dim_work; ++j) {
+                    int bp = (int)(count_population(
+                                       (jg_base | j) & local_phase_flip_mask) %
+                                   2);
+                    CTYPE phase = PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
+                    ptr_state[j] = cosval * ptr_state[j] +
+                                   1.i * sinval * ptr_recv[j] * phase;
+                }
+            } else {
+                // B2 (same-chunk): pair state[j] with recv[j ^ lbfm_low]
+                const UINT local_pivot =
+                    (UINT)__builtin_ctzll((unsigned long long)lbfm_low);
+                const ITYPE lp_mask = 1ULL << local_pivot;
+                const ITYPE lp_mask_low = lp_mask - 1;
+                const ITYPE lp_mask_high = ~lp_mask_low;
+                const ITYPE loop_dim = dim_work / 2;
+#pragma omp parallel for
+                for (ITYPE si = 0; si < loop_dim; ++si) {
+                    const ITYPE j =
+                        (si & lp_mask_low) + ((si & lp_mask_high) << 1);
+                    const ITYPE j_pair = j ^ lbfm_low;
+                    // Save originals before overwriting.
+                    const CTYPE a = ptr_state[j];
+                    const CTYPE b = ptr_state[j_pair];
+                    int bp_j = (int)(count_population((jg_base | j) &
+                                                      local_phase_flip_mask) %
+                                     2);
+                    int bp_jp = (int)(count_population((jg_base | j_pair) &
+                                                       local_phase_flip_mask) %
+                                      2);
+                    ptr_state[j] =
+                        cosval * a +
+                        1.i * sinval * ptr_recv[j_pair] *
+                            PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
+                    ptr_state[j_pair] =
+                        cosval * b +
+                        1.i * sinval * ptr_recv[j] *
+                            PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
+                }
+            }
+            ptr_state += dim_work;
+        }
+    } else {
+        // ---- Case B cross-chunk: local X/Y qubit index >= _NQUBIT_WORK ----
+        // Element at global-local index g = iter*dim_work + j pairs with
+        //   g ^ local_bit_flip_mask = (iter^lbfm_high)*dim_work + (j^lbfm_low)
+        // i.e., a different chunk. Process chunk pairs (iter, iter^lbfm_high)
+        // together with two sendrecvs so both ranks issue matched calls:
+        //   sendrecv(our[iter])     -> recv_a = partner[iter]
+        //   sendrecv(our[iter_xor]) -> recv_b = partner[iter_xor]
+        // then: our[iter][j]     <- cosval*our[iter][j]     + sinval*recv_b[jp]
+        //        our[iter_xor][j] <- cosval*our[iter_xor][j] +
+        //        sinval*recv_a[jp]
+        //
+        // lbfm_high != 0 is guaranteed here, so __builtin_clzll is safe.
+        const ITYPE lbfm_high_msb =
+            (ITYPE)1 << (sizeof(ITYPE) * 8 - 1 -
+                         __builtin_clzll((unsigned long long)lbfm_high));
+        std::vector<CTYPE> recv_b_vec(dim_work);
+        CTYPE* const ptr_recv_b = recv_b_vec.data();
+        for (ITYPE iter = 0; iter < num_work; ++iter) {
+            if (iter & lbfm_high_msb) continue;  // skip second-of-pair
+            const ITYPE iter_xor = iter ^ lbfm_high;
+            CTYPE* const ptr_A = state + iter * dim_work;
+            CTYPE* const ptr_B = state + iter_xor * dim_work;
+            m.m_DC_sendrecv(ptr_A, ptr_recv, dim_work, pair_rank);
+            m.m_DC_sendrecv(ptr_B, ptr_recv_b, dim_work, pair_rank);
+            const ITYPE jg_base_A = iter << _NQUBIT_WORK;
+            const ITYPE jg_base_B = iter_xor << _NQUBIT_WORK;
 #pragma omp parallel for
             for (ITYPE j = 0; j < dim_work; ++j) {
-                int bp = (int)(count_population(j & local_phase_flip_mask) % 2);
-                CTYPE phase = PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
-                ptr_state[j] =
-                    cosval * ptr_state[j] + 1.i * sinval * ptr_recv[j] * phase;
-            }
-        } else {
-            // B2: mixed local+global - pair state[j] with recv[j^local_bfm]
-            const UINT local_pivot =
-                (UINT)__builtin_ctzll((unsigned long long)local_bit_flip_mask);
-            const ITYPE lp_mask = 1ULL << local_pivot;
-            const ITYPE lp_mask_low = lp_mask - 1;
-            const ITYPE lp_mask_high = ~lp_mask_low;
-            const ITYPE loop_dim = dim_work / 2;
-#pragma omp parallel for
-            for (ITYPE si = 0; si < loop_dim; ++si) {
-                const ITYPE j = (si & lp_mask_low) + ((si & lp_mask_high) << 1);
-                const ITYPE j_pair = j ^ local_bit_flip_mask;
-
-                // Save originals before overwriting
-                const CTYPE a = ptr_state[j];
-                const CTYPE b = ptr_state[j_pair];
-
-                int bp_j =
-                    (int)(count_population(j & local_phase_flip_mask) % 2);
-                int bp_jp =
-                    (int)(count_population(j_pair & local_phase_flip_mask) % 2);
-
-                ptr_state[j] =
-                    cosval * a +
-                    1.i * sinval * ptr_recv[j_pair] *
-                        PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
-                ptr_state[j_pair] =
-                    cosval * b +
-                    1.i * sinval * ptr_recv[j] *
-                        PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
+                const ITYPE jp = j ^ lbfm_low;
+                int bp_A = (int)(count_population(
+                                     (jg_base_A | j) & local_phase_flip_mask) %
+                                 2);
+                int bp_B = (int)(count_population(
+                                     (jg_base_B | j) & local_phase_flip_mask) %
+                                 2);
+                // our[iter][j]     <- cosval*old + sinval*partner[iter_xor][jp]
+                ptr_A[j] = cosval * ptr_A[j] +
+                           1.i * sinval * ptr_recv_b[jp] *
+                               PHASE_M90ROT[(adj_count + (UINT)bp_A * 2) % 4];
+                // our[iter_xor][j] <- cosval*old + sinval*partner[iter][jp]
+                ptr_B[j] = cosval * ptr_B[j] +
+                           1.i * sinval * ptr_recv[jp] *
+                               PHASE_M90ROT[(adj_count + (UINT)bp_B * 2) % 4];
             }
         }
-        ptr_state += dim_work;
     }
 #ifdef _OPENMP
     OMPutil::get_inst().reset_qulacs_num_threads();

--- a/src/csim/update_ops_pauli_multi.cpp
+++ b/src/csim/update_ops_pauli_multi.cpp
@@ -10,6 +10,9 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#ifdef _USE_MPI
+#include "MPIutil.hpp"
+#endif
 
 /**
  * perform multi_qubit_Pauli_gate with XZ mask.
@@ -456,3 +459,278 @@ void multi_qubit_Pauli_rotation_gate_whole_list_single_thread(
             state, dim);
     }
 }
+
+#ifdef _USE_MPI
+/**
+ * MPI-aware multi-qubit Pauli gate.
+ *
+ * Handles global qubits (those >= inner_qc, whose values are encoded in the
+ * MPI rank number) by using sendrecv to exchange amplitudes with the partner
+ * rank that holds the other half of each amplitude pair.
+ *
+ * Three cases:
+ *   A) No global X/Y qubits: all pairs are local; delegate to the serial
+ *      implementation with the global-Z rank-parity folded into the phase.
+ *   B1) Global X/Y, no local X/Y: pair j with recv[j] from partner rank.
+ *   B2) Mixed local+global X/Y: pair j with recv[j^local_bit_flip_mask].
+ *       Requires local_bit_flip_mask < dim_work (pairs within one work chunk).
+ */
+void multi_qubit_Pauli_gate_partial_list_mpi(
+    const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list,
+    UINT target_qubit_index_count, CTYPE* state, ITYPE dim, UINT inner_qc) {
+    // Build masks (identical to the local wrapper)
+    ITYPE bit_flip_mask = 0;
+    ITYPE phase_flip_mask = 0;
+    UINT global_phase_90rot_count = 0;
+    UINT pivot_qubit_index = 0;
+    get_Pauli_masks_partial_list(target_qubit_index_list,
+        Pauli_operator_type_list, target_qubit_index_count, &bit_flip_mask,
+        &phase_flip_mask, &global_phase_90rot_count, &pivot_qubit_index);
+
+    // Partition at the MPI boundary
+    const ITYPE inner_mask = (1ULL << inner_qc) - 1;
+    const ITYPE local_bit_flip_mask = bit_flip_mask & inner_mask;
+    const ITYPE global_bit_flip_rank_bits = bit_flip_mask >> inner_qc;
+    const ITYPE local_phase_flip_mask = phase_flip_mask & inner_mask;
+    const ITYPE global_phase_flip_rank_bits = phase_flip_mask >> inner_qc;
+
+    const UINT rank = (UINT)MPIutil::get_inst().get_rank();
+    const UINT global_rank_parity =
+        (UINT)(count_population((ITYPE)rank & global_phase_flip_rank_bits) % 2);
+
+    // ---- Case A: no global X/Y qubits: no MPI communication needed ----
+    if (global_bit_flip_rank_bits == 0) {
+        const UINT adj_count =
+            (global_phase_90rot_count + 2 * global_rank_parity) % 4;
+        if (bit_flip_mask == 0) {
+            // Pure Z: flip sign of all affected amplitudes; global Z folds
+            // into sign via adj_count parity (odd → negate all)
+            if (adj_count % 2 == 0) {
+                multi_qubit_Pauli_gate_Z_mask(
+                    local_phase_flip_mask, state, dim);
+            } else {
+                // adj_count odd means global rank parity flips the overall
+                // sign: invert Z mask action by negating the whole state then
+                // applying the Z_mask with complement, or equivalently just
+                // apply on local_phase_flip_mask with toggled parity.
+                // Simplest: use XZ path with bit_flip_mask=0 special case.
+                // For Pauli gate (not rotation) Z-only case the formula is
+                // state[j] *= (-1)^{parity(j & phase_flip_mask)}.
+                // With global rank parity odd we need the complement, so we
+                // just flip every element and then apply Z_mask, equivalent
+                // to negating all then applying. Use state_multiply(-1) +
+                // Z_mask on complement, but simplest is inline:
+                for (ITYPE j = 0; j < dim; ++j) {
+                    int bp =
+                        (int)(count_population(j & local_phase_flip_mask) % 2);
+                    // total parity = global_rank_parity(1) XOR bp
+                    if ((1 ^ bp) == 0) state[j] *= -1;
+                }
+            }
+        } else {
+            multi_qubit_Pauli_gate_XZ_mask(local_bit_flip_mask,
+                local_phase_flip_mask, adj_count, pivot_qubit_index, state,
+                dim);
+        }
+        return;
+    }
+
+    // ---- Case B: global X/Y qubits - sendrecv with partner rank ----
+    const UINT pair_rank = rank ^ (UINT)global_bit_flip_rank_bits;
+    MPIutil& m = MPIutil::get_inst();
+    ITYPE dim_work = dim;
+    ITYPE num_work = 0;
+    CTYPE* ptr_recv = m.get_workarea(&dim_work, &num_work);
+    assert(num_work > 0);
+    // Pairs must fit within one work chunk (see implementation notes)
+    assert(local_bit_flip_mask == 0 || local_bit_flip_mask < dim_work);
+
+    const UINT adj_count =
+        (global_phase_90rot_count + 2 * global_rank_parity) % 4;
+    CTYPE* ptr_state = state;
+
+#ifdef _OPENMP
+    OMPutil::get_inst().set_qulacs_num_threads(dim, 13);
+#endif
+    for (ITYPE iter = 0; iter < num_work; ++iter) {
+        m.m_DC_sendrecv(ptr_state, ptr_recv, dim_work, pair_rank);
+
+        if (local_bit_flip_mask == 0) {
+            // B1: all X/Y global - pair j with recv[j]
+#pragma omp parallel for
+            for (ITYPE j = 0; j < dim_work; ++j) {
+                int bp = (int)((global_rank_parity +
+                                   count_population(j & local_phase_flip_mask)) %
+                               2);
+                ptr_state[j] =
+                    ptr_recv[j] *
+                    PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
+            }
+        } else {
+            // B2: mixed - pair j with recv[j ^ local_bit_flip_mask]
+            const UINT local_pivot =
+                (UINT)__builtin_ctzll((unsigned long long)local_bit_flip_mask);
+            const ITYPE lp_mask = 1ULL << local_pivot;
+            const ITYPE lp_mask_low = lp_mask - 1;
+            const ITYPE lp_mask_high = ~lp_mask_low;
+            const ITYPE loop_dim = dim_work / 2;
+#pragma omp parallel for
+            for (ITYPE si = 0; si < loop_dim; ++si) {
+                const ITYPE j =
+                    (si & lp_mask_low) + ((si & lp_mask_high) << 1);
+                const ITYPE j_pair = j ^ local_bit_flip_mask;
+
+                int bp_j =
+                    (int)((global_rank_parity +
+                              count_population(j & local_phase_flip_mask)) %
+                          2);
+                int bp_jp =
+                    (int)((global_rank_parity +
+                              count_population(j_pair & local_phase_flip_mask)) %
+                          2);
+
+                ptr_state[j] =
+                    ptr_recv[j_pair] *
+                    PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
+                ptr_state[j_pair] =
+                    ptr_recv[j] *
+                    PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
+            }
+        }
+        ptr_state += dim_work;
+    }
+#ifdef _OPENMP
+    OMPutil::get_inst().reset_qulacs_num_threads();
+#endif
+}
+
+/**
+ * MPI-aware multi-qubit Pauli rotation gate exp(-i*angle/2 * P).
+ *
+ * Same three-case structure as multi_qubit_Pauli_gate_partial_list_mpi but
+ * applies the rotation formula instead of a plain swap.
+ */
+void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
+    const UINT* target_qubit_index_list, const UINT* Pauli_operator_type_list,
+    UINT target_qubit_index_count, double angle, CTYPE* state, ITYPE dim,
+    UINT inner_qc) {
+    // Build masks
+    ITYPE bit_flip_mask = 0;
+    ITYPE phase_flip_mask = 0;
+    UINT global_phase_90rot_count = 0;
+    UINT pivot_qubit_index = 0;
+    get_Pauli_masks_partial_list(target_qubit_index_list,
+        Pauli_operator_type_list, target_qubit_index_count, &bit_flip_mask,
+        &phase_flip_mask, &global_phase_90rot_count, &pivot_qubit_index);
+
+    // Partition at the MPI boundary
+    const ITYPE inner_mask = (1ULL << inner_qc) - 1;
+    const ITYPE local_bit_flip_mask = bit_flip_mask & inner_mask;
+    const ITYPE global_bit_flip_rank_bits = bit_flip_mask >> inner_qc;
+    const ITYPE local_phase_flip_mask = phase_flip_mask & inner_mask;
+    const ITYPE global_phase_flip_rank_bits = phase_flip_mask >> inner_qc;
+
+    const UINT rank = (UINT)MPIutil::get_inst().get_rank();
+    const UINT global_rank_parity =
+        (UINT)(count_population((ITYPE)rank & global_phase_flip_rank_bits) % 2);
+
+    // ---- Case A: no global X/Y qubits - no MPI communication needed ----
+    if (global_bit_flip_rank_bits == 0) {
+        const UINT adj_count =
+            (global_phase_90rot_count + 2 * global_rank_parity) % 4;
+        if (bit_flip_mask == 0) {
+            // Pure Z rotation: negate angle if global rank parity is odd
+            double adj_angle = (global_rank_parity % 2) ? -angle : angle;
+            multi_qubit_Pauli_rotation_gate_Z_mask(
+                local_phase_flip_mask, adj_angle, state, dim);
+        } else {
+            // XZ rotation: pivot is guaranteed < inner_qc when no global X/Y
+            multi_qubit_Pauli_rotation_gate_XZ_mask(local_bit_flip_mask,
+                local_phase_flip_mask, adj_count, pivot_qubit_index, angle,
+                state, dim);
+        }
+        return;
+    }
+
+    // ---- Case B: global X/Y qubits - sendrecv with partner rank ----
+    const UINT pair_rank = rank ^ (UINT)global_bit_flip_rank_bits;
+    MPIutil& m = MPIutil::get_inst();
+    ITYPE dim_work = dim;
+    ITYPE num_work = 0;
+    CTYPE* ptr_recv = m.get_workarea(&dim_work, &num_work);
+    assert(num_work > 0);
+    // Pairs must fit within one work chunk (see implementation notes).
+    // This holds whenever dim <= _NQUBIT_WORK capacity (2^22 * 16 B = 64 MB),
+    // which covers all practical QSCI benchmark cases.  For larger distributed
+    // states with mixed local+global X qubits this assertion will fire and the
+    // implementation needs to be extended (TODO).
+    assert(local_bit_flip_mask == 0 || local_bit_flip_mask < dim_work);
+
+    const UINT adj_count =
+        (global_phase_90rot_count + 2 * global_rank_parity) % 4;
+    const double cosval = cos(angle / 2);
+    const double sinval = sin(angle / 2);
+    CTYPE* ptr_state = state;
+
+#ifdef _OPENMP
+    OMPutil::get_inst().set_qulacs_num_threads(dim, 13);
+#endif
+    for (ITYPE iter = 0; iter < num_work; ++iter) {
+        m.m_DC_sendrecv(ptr_state, ptr_recv, dim_work, pair_rank);
+
+        if (local_bit_flip_mask == 0) {
+            // B1: all X/Y global - pair state[j] with recv[j]
+#pragma omp parallel for
+            for (ITYPE j = 0; j < dim_work; ++j) {
+                int bp = (int)((global_rank_parity +
+                                   count_population(j & local_phase_flip_mask)) %
+                               2);
+                CTYPE phase =
+                    PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
+                ptr_state[j] = cosval * ptr_state[j] +
+                               1.i * sinval * ptr_recv[j] * phase;
+            }
+        } else {
+            // B2: mixed local+global - pair state[j] with recv[j^local_bfm]
+            const UINT local_pivot =
+                (UINT)__builtin_ctzll((unsigned long long)local_bit_flip_mask);
+            const ITYPE lp_mask = 1ULL << local_pivot;
+            const ITYPE lp_mask_low = lp_mask - 1;
+            const ITYPE lp_mask_high = ~lp_mask_low;
+            const ITYPE loop_dim = dim_work / 2;
+#pragma omp parallel for
+            for (ITYPE si = 0; si < loop_dim; ++si) {
+                const ITYPE j =
+                    (si & lp_mask_low) + ((si & lp_mask_high) << 1);
+                const ITYPE j_pair = j ^ local_bit_flip_mask;
+
+                // Save originals before overwriting
+                const CTYPE a = ptr_state[j];
+                const CTYPE b = ptr_state[j_pair];
+
+                int bp_j =
+                    (int)((global_rank_parity +
+                              count_population(j & local_phase_flip_mask)) %
+                          2);
+                int bp_jp =
+                    (int)((global_rank_parity +
+                              count_population(j_pair & local_phase_flip_mask)) %
+                          2);
+
+                ptr_state[j] =
+                    cosval * a +
+                    1.i * sinval * ptr_recv[j_pair] *
+                        PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
+                ptr_state[j_pair] =
+                    cosval * b +
+                    1.i * sinval * ptr_recv[j] *
+                        PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
+            }
+        }
+        ptr_state += dim_work;
+    }
+#ifdef _OPENMP
+    OMPutil::get_inst().reset_qulacs_num_threads();
+#endif
+}
+#endif  // _USE_MPI

--- a/src/csim/update_ops_pauli_multi.cpp
+++ b/src/csim/update_ops_pauli_multi.cpp
@@ -550,11 +550,9 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
             // B1: all X/Y global - pair j with recv[j]
 #pragma omp parallel for
             for (ITYPE j = 0; j < dim_work; ++j) {
-                int bp =
-                    (int)(count_population(j & local_phase_flip_mask) % 2);
+                int bp = (int)(count_population(j & local_phase_flip_mask) % 2);
                 ptr_state[j] =
-                    ptr_recv[j] *
-                    PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
+                    ptr_recv[j] * PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
             }
         } else {
             // B2: mixed - pair j with recv[j ^ local_bit_flip_mask]
@@ -566,8 +564,7 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
             const ITYPE loop_dim = dim_work / 2;
 #pragma omp parallel for
             for (ITYPE si = 0; si < loop_dim; ++si) {
-                const ITYPE j =
-                    (si & lp_mask_low) + ((si & lp_mask_high) << 1);
+                const ITYPE j = (si & lp_mask_low) + ((si & lp_mask_high) << 1);
                 const ITYPE j_pair = j ^ local_bit_flip_mask;
 
                 int bp_j =
@@ -575,9 +572,8 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
                 int bp_jp =
                     (int)(count_population(j_pair & local_phase_flip_mask) % 2);
 
-                ptr_state[j] =
-                    ptr_recv[j_pair] *
-                    PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
+                ptr_state[j] = ptr_recv[j_pair] *
+                               PHASE_M90ROT[(adj_count + (UINT)bp_j * 2) % 4];
                 ptr_state[j_pair] =
                     ptr_recv[j] *
                     PHASE_M90ROT[(adj_count + (UINT)bp_jp * 2) % 4];
@@ -647,7 +643,7 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
     assert(num_work > 0);
     // Pairs must fit within one work chunk (see implementation notes).
     // This holds whenever dim <= _NQUBIT_WORK capacity (2^22 * 16 B = 64 MB).
-    // For larger distributed states with mixed local+global X qubits this 
+    // For larger distributed states with mixed local+global X qubits this
     // assertion will fire and the implementation needs to be extended (TODO).
     assert(local_bit_flip_mask == 0 || local_bit_flip_mask < dim_work);
 
@@ -667,12 +663,10 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
             // B1: all X/Y global - pair state[j] with recv[j]
 #pragma omp parallel for
             for (ITYPE j = 0; j < dim_work; ++j) {
-                int bp =
-                    (int)(count_population(j & local_phase_flip_mask) % 2);
-                CTYPE phase =
-                    PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
-                ptr_state[j] = cosval * ptr_state[j] +
-                               1.i * sinval * ptr_recv[j] * phase;
+                int bp = (int)(count_population(j & local_phase_flip_mask) % 2);
+                CTYPE phase = PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
+                ptr_state[j] =
+                    cosval * ptr_state[j] + 1.i * sinval * ptr_recv[j] * phase;
             }
         } else {
             // B2: mixed local+global - pair state[j] with recv[j^local_bfm]
@@ -684,8 +678,7 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
             const ITYPE loop_dim = dim_work / 2;
 #pragma omp parallel for
             for (ITYPE si = 0; si < loop_dim; ++si) {
-                const ITYPE j =
-                    (si & lp_mask_low) + ((si & lp_mask_high) << 1);
+                const ITYPE j = (si & lp_mask_low) + ((si & lp_mask_high) << 1);
                 const ITYPE j_pair = j ^ local_bit_flip_mask;
 
                 // Save originals before overwriting

--- a/src/csim/update_ops_pauli_multi.cpp
+++ b/src/csim/update_ops_pauli_multi.cpp
@@ -503,28 +503,19 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
         const UINT adj_count =
             (global_phase_90rot_count + 2 * global_rank_parity) % 4;
         if (bit_flip_mask == 0) {
-            // Pure Z: flip sign of all affected amplitudes; global Z folds
-            // into sign via adj_count parity (odd → negate all)
-            if (adj_count % 2 == 0) {
+            // Pure Z: global_phase_90rot_count == 0 here, so adj_count is 0
+            // (global_rank_parity==0) or 2 (global_rank_parity==1).
+            // Total sign for amplitude j: (-1)^(global_rank_parity + local_bp)
+            if (adj_count % 4 == 0) {
                 multi_qubit_Pauli_gate_Z_mask(
                     local_phase_flip_mask, state, dim);
             } else {
-                // adj_count odd means global rank parity flips the overall
-                // sign: invert Z mask action by negating the whole state then
-                // applying the Z_mask with complement, or equivalently just
-                // apply on local_phase_flip_mask with toggled parity.
-                // Simplest: use XZ path with bit_flip_mask=0 special case.
-                // For Pauli gate (not rotation) Z-only case the formula is
-                // state[j] *= (-1)^{parity(j & phase_flip_mask)}.
-                // With global rank parity odd we need the complement, so we
-                // just flip every element and then apply Z_mask, equivalent
-                // to negating all then applying. Use state_multiply(-1) +
-                // Z_mask on complement, but simplest is inline:
+                // global_rank_parity == 1: negate where local parity is even
+                // (total parity = 1+0 = odd -> negate)
                 for (ITYPE j = 0; j < dim; ++j) {
                     int bp =
                         (int)(count_population(j & local_phase_flip_mask) % 2);
-                    // total parity = global_rank_parity(1) XOR bp
-                    if ((1 ^ bp) == 0) state[j] *= -1;
+                    if (bp == 0) state[j] *= -1;
                 }
             }
         } else {
@@ -559,9 +550,8 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
             // B1: all X/Y global - pair j with recv[j]
 #pragma omp parallel for
             for (ITYPE j = 0; j < dim_work; ++j) {
-                int bp = (int)((global_rank_parity +
-                                   count_population(j & local_phase_flip_mask)) %
-                               2);
+                int bp =
+                    (int)(count_population(j & local_phase_flip_mask) % 2);
                 ptr_state[j] =
                     ptr_recv[j] *
                     PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
@@ -581,13 +571,9 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
                 const ITYPE j_pair = j ^ local_bit_flip_mask;
 
                 int bp_j =
-                    (int)((global_rank_parity +
-                              count_population(j & local_phase_flip_mask)) %
-                          2);
+                    (int)(count_population(j & local_phase_flip_mask) % 2);
                 int bp_jp =
-                    (int)((global_rank_parity +
-                              count_population(j_pair & local_phase_flip_mask)) %
-                          2);
+                    (int)(count_population(j_pair & local_phase_flip_mask) % 2);
 
                 ptr_state[j] =
                     ptr_recv[j_pair] *
@@ -660,10 +646,9 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
     CTYPE* ptr_recv = m.get_workarea(&dim_work, &num_work);
     assert(num_work > 0);
     // Pairs must fit within one work chunk (see implementation notes).
-    // This holds whenever dim <= _NQUBIT_WORK capacity (2^22 * 16 B = 64 MB),
-    // which covers all practical QSCI benchmark cases.  For larger distributed
-    // states with mixed local+global X qubits this assertion will fire and the
-    // implementation needs to be extended (TODO).
+    // This holds whenever dim <= _NQUBIT_WORK capacity (2^22 * 16 B = 64 MB).
+    // For larger distributed states with mixed local+global X qubits this 
+    // assertion will fire and the implementation needs to be extended (TODO).
     assert(local_bit_flip_mask == 0 || local_bit_flip_mask < dim_work);
 
     const UINT adj_count =
@@ -682,9 +667,8 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
             // B1: all X/Y global - pair state[j] with recv[j]
 #pragma omp parallel for
             for (ITYPE j = 0; j < dim_work; ++j) {
-                int bp = (int)((global_rank_parity +
-                                   count_population(j & local_phase_flip_mask)) %
-                               2);
+                int bp =
+                    (int)(count_population(j & local_phase_flip_mask) % 2);
                 CTYPE phase =
                     PHASE_M90ROT[(adj_count + (UINT)bp * 2) % 4];
                 ptr_state[j] = cosval * ptr_state[j] +
@@ -709,13 +693,9 @@ void multi_qubit_Pauli_rotation_gate_partial_list_mpi(
                 const CTYPE b = ptr_state[j_pair];
 
                 int bp_j =
-                    (int)((global_rank_parity +
-                              count_population(j & local_phase_flip_mask)) %
-                          2);
+                    (int)(count_population(j & local_phase_flip_mask) % 2);
                 int bp_jp =
-                    (int)((global_rank_parity +
-                              count_population(j_pair & local_phase_flip_mask)) %
-                          2);
+                    (int)(count_population(j_pair & local_phase_flip_mask) % 2);
 
                 ptr_state[j] =
                     cosval * a +

--- a/src/csim/update_ops_pauli_multi.cpp
+++ b/src/csim/update_ops_pauli_multi.cpp
@@ -514,6 +514,7 @@ void multi_qubit_Pauli_gate_partial_list_mpi(
             } else {
                 // global_rank_parity == 1: negate where local parity is even
                 // (total parity = 1+0 = odd -> negate)
+#pragma omp parallel for
                 for (ITYPE j = 0; j < dim; ++j) {
                     int bp =
                         (int)(count_population(j & local_phase_flip_mask) % 2);


### PR DESCRIPTION
## Problem

`ClsPauliRotationGate::update_quantum_state()` and `ClsPauliGate::update_quantum_state()` call the single-rank csim functions unconditionally, even on MPI-distributed states. This violated unitarity whenever the Pauli string contained an X or Y operator on a "global" qubit. The csim header contained an explicit TODO comment acknowledging that the MPI variants were never written.

More info and an MRE can be found here: https://github.com/qulacs/qulacs/issues/710

## Solution
Implemented `multi_qubit_Pauli_gate_partial_list_mpi` and `multi_qubit_Pauli_rotation_gate_partial_list_mpi` in `src/csim/update_ops_pauli_multi.cpp`, using a three-case algorithm:

- **Case A - no global X/Y qubits:** No MPI communication needed. The contribution from global Z/Y qubits is a fixed per-rank phase; fold it into the existing local functions via parameter adjustment.
- **Case B1 - all X/Y are global qubits:** Exchange full local state buffers with `pair_rank = rank XOR global_x_rank_bits` via `sendrecv`, then apply the rotation element-wise.
- **Case B2 - mixed local + global X/Y:** After `sendrecv`, apply pairwise rotation within the local buffer using a standard "expand index" trick to enumerate pairs at the `local_pivot` bit.
