### PR TITLE
apt update before installing libboost-dev / use local method for CUDA install

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -45,7 +45,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install boost
-        run: sudo apt install libboost-dev
+        run: |
+          sudo apt update
+          sudo apt install libboost-dev
 
       - name: Install LCOV
         run: |
@@ -91,7 +93,9 @@ jobs:
           verbose: 2
 
       - name: Install boost
-        run: sudo apt install libboost-dev
+        run: |
+          sudo apt update
+          sudo apt install libboost-dev
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_memory_sanitizer.sh
@@ -132,13 +136,17 @@ jobs:
           architecture: x64
 
       - name: Install boost
-        run: sudo apt install libboost-dev
+        run: |
+          sudo apt update
+          sudo apt install libboost-dev
 
       - name: Install CUDA toolkit
         uses: Jimver/cuda-toolkit@v0.2.23
         with:
           cuda: "12.6.3"
-          method: "network"
+          method: "local"
+          linux-local-args: '["--toolkit"]'
+          log-file-suffix: '${{ github.job }}'
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh
@@ -175,7 +183,9 @@ jobs:
           sudo make install
 
       - name: Install boost
-        run: sudo apt-get install libboost-dev
+        run: |
+          sudo apt update
+          sudo apt-get install libboost-dev
 
       - name: Install qulacs for Ubuntu
         run: USE_TEST=Yes ./script/build_gcc.sh
@@ -269,7 +279,9 @@ jobs:
         run: sudo apt install openmpi-bin libopenmpi-dev
 
       - name: Install boost
-        run: sudo apt install libboost-dev
+        run: |
+          sudo apt update
+          sudo apt install libboost-dev
 
       - name: Install LCOV
         run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -35,16 +35,6 @@ jobs:
             os: "macos-15-intel"
           - os-arch: "macosx_arm64"
             os: "macos-15"
-          - cibw-python: "cp39"
-            python-version: "3.9"
-          - cibw-python: "cp310"
-            python-version: "3.10"
-          - cibw-python: "cp311"
-            python-version: "3.11"
-          - cibw-python: "cp312"
-            python-version: "3.12"
-          - cibw-python: "cp313"
-            python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
     env:
@@ -61,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
 
       - name: Install Python dependencies
         run: python -m pip install cibuildwheel twine


### PR DESCRIPTION
CI was failing for (temporal) apt condition.
This PR changes that:
- run `sudo apt update` before `sudo apt install libboost-dev`
- use local method for CUDA installing (same as https://github.com/qulacs/scaluq/pull/309 )