### PR TITLE
Use Python3.13 to build wheel

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -35,16 +35,6 @@ jobs:
             os: "macos-15-intel"
           - os-arch: "macosx_arm64"
             os: "macos-15"
-          - cibw-python: "cp39"
-            python-version: "3.9"
-          - cibw-python: "cp310"
-            python-version: "3.10"
-          - cibw-python: "cp311"
-            python-version: "3.11"
-          - cibw-python: "cp312"
-            python-version: "3.12"
-          - cibw-python: "cp313"
-            python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
     env:
@@ -61,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
 
       - name: Install Python dependencies
         run: python -m pip install cibuildwheel twine


### PR DESCRIPTION
As warning [8](https://github.com/qulacs/qulacs/actions/runs/22935454056/job/66565715605?pr=712#step:10:59)
`Warning: cibuildwheel 3 will require Python 3.11+, please upgrade the Python version used to run cibuildwheel. This does not affect the versions you can target when building wheels. See: https://cibuildwheel.pypa.io/en/stable/#what-does-it-do` shows, current cibuildwheel requires Python 3.11+. With Python <= 3.10, cibuildwheel trys to downloads  https://github.com/pypa/get-virtualenv/blob/20.30.0/public/virtualenv.pyz, which sometimes fails.
Builder's Python version does not have to match to target wheel version. This PR fixes builder's Python version to 3.13.