### PR TITLE
Update action version

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -32,13 +32,13 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       CACHE_NAME: "ccache-qulacs-build-v2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           # Include compiler to distinguish cache for each compiler.
           key: ${{ github.job }}-macos-12-${{ matrix.compiler }}
@@ -51,7 +51,7 @@ jobs:
           brew link boost
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -28,19 +28,19 @@ jobs:
       COVERAGE: "Yes"
       USE_TEST: "Yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           key: "${{ github.job }}-ubuntu-24.04"
           verbose: 2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -68,7 +68,7 @@ jobs:
           make pythontest -j $(nproc)
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -81,13 +81,13 @@ jobs:
       QULACS_OPT_FLAGS: "-mtune=haswell -march=haswell -mfpmath=both"
       USE_TEST: "Yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           key: "${{ github.job }}-ubuntu-24.04"
           verbose: 2
@@ -118,19 +118,19 @@ jobs:
       USE_TEST: "Yes"
       USE_GPU: "Yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           key: "${{ github.job }}-ubuntu-24.04"
           verbose: 2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12.10"
           architecture: x64
@@ -141,7 +141,7 @@ jobs:
           sudo apt install libboost-dev
 
       - name: Install CUDA toolkit
-        uses: Jimver/cuda-toolkit@v0.2.23
+        uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: "12.6.3"
           method: "local"
@@ -168,7 +168,7 @@ jobs:
       QULACS_OPT_FLAGS: "-march=armv8.2-a+sve"
       QEMU_LD_PREFIX: "/usr/aarch64-linux-gnu"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup qemu
         run: |
@@ -208,7 +208,7 @@ jobs:
     name: Format with clang-format
     runs-on: "ubuntu-24.04"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - run: |
           sudo apt-get install clang-format-14
@@ -235,10 +235,10 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -264,13 +264,13 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -312,4 +312,4 @@ jobs:
           mpirun -n 2 pytest python/tests/multi_cpu
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -20,7 +20,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
@@ -29,12 +29,12 @@ jobs:
       # mozilla/sccache is one candidate for this situation.
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install boost
-        uses: MarkusJx/install-boost@6d8df42f57de83c5b326b5b83e7b35d650030103 # not released yet for resolving https://github.com/MarkusJx/install-boost/issues/89
+        uses: MarkusJx/install-boost@2.6.0
         id: install-boost
         with:
           boost_version: 1.77.0

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install boost
-        uses: MarkusJx/install-boost@2.6.0
+        uses: MarkusJx/install-boost@v2.6.0
         id: install-boost
         with:
           boost_version: 1.77.0

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -37,8 +37,8 @@ jobs:
         uses: MarkusJx/install-boost@v2.6.0
         id: install-boost
         with:
-          boost_version: 1.77.0
-          # platform_version: 2022 Not specified for now because the impact is unpredictable
+          boost_version: 1.83.0
+          platform_version: 2022
 
       - name: Install qulacs for Windows
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -38,7 +38,7 @@ jobs:
         id: install-boost
         with:
           boost_version: 1.77.0
-          platform_version: 2022
+          # platform_version: 2022 Not specified for now because the impact is unpredictable
 
       - name: Install qulacs for Windows
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -38,6 +38,7 @@ jobs:
         id: install-boost
         with:
           boost_version: 1.77.0
+          platform_version: 2022
 
       - name: Install qulacs for Windows
         run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install boost if windows
         if: ${{ contains(matrix.os, 'windows') }}
-        uses: MarkusJx/install-boost@2.6.0
+        uses: MarkusJx/install-boost@v2.6.0
         id: install-boost
         with:
           boost_version: 1.77.0

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -83,7 +83,7 @@ jobs:
         id: install-boost
         with:
           boost_version: 1.77.0
-          platform_version: 2022
+          # platform_version: 2022 Not specified for now because the impact is unpredictable
 
       - name: Run cibuildwheel for Windows
         if: ${{ contains(matrix.os, 'windows') }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -82,8 +82,8 @@ jobs:
         uses: MarkusJx/install-boost@v2.6.0
         id: install-boost
         with:
-          boost_version: 1.77.0
-          # platform_version: 2022 Not specified for now because the impact is unpredictable
+          boost_version: 1.83.0
+          platform_version: 2022
 
       - name: Run cibuildwheel for Windows
         if: ${{ contains(matrix.os, 'windows') }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -47,19 +47,19 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       TWINE_USERNAME: "__token__"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Setup QEMU for aarch64 wheel build
         if: ${{ matrix.os-arch == 'manylinux_aarch64' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install boost if windows
         if: ${{ contains(matrix.os, 'windows') }}
-        uses: MarkusJx/install-boost@6d8df42f57de83c5b326b5b83e7b35d650030103 # not released yet for resolving https://github.com/MarkusJx/install-boost/issues/89
+        uses: MarkusJx/install-boost@2.6.0
         id: install-boost
         with:
           boost_version: 1.77.0
@@ -95,7 +95,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheels
 
       - name: Upload wheel to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
           path: ./wheels/*.whl
@@ -119,13 +119,13 @@ jobs:
       COVERAGE: "ON"
       TWINE_USERNAME: "__token__"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -83,6 +83,7 @@ jobs:
         id: install-boost
         with:
           boost_version: 1.77.0
+          platform_version: 2022
 
       - name: Run cibuildwheel for Windows
         if: ${{ contains(matrix.os, 'windows') }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ A binary that is installed via pip command is optimized for Haswell architecture
 - C++ compiler (gcc or VisualStudio)
   - gcc/g++ >= 7.0.0 (checked in Linux, MacOS, cygwin, MinGW, and WSL)
   - Microsoft VisualStudio C++ 2015 or later
-- [Boost](https://github.com/boostorg/boost) >= 1.71.0 (Minimum version tested in CI)
+- [Boost](https://github.com/boostorg/boost) >= 1.71.0 (Development environment)  
+(Version tested in CI)
+  - macOS == 1.90.0
+  - Ubuntu == 1.76.0
+  - Windows == 1.83.0
 - Python >= 3.9
 - CMake >= 3.21
 - git
@@ -86,9 +90,9 @@ Note that `qulacs-gpu` includes CPU simulator. You don't need to install both.
 
 Qulacs is tested on the following systems.
 
-- Ubuntu 20.04
-- macOS Big Sur 11
-- Windows Server 2019
+- Ubuntu 24.04
+- macOS 15
+- Windows Server 2022
 
 If you encounter some troubles, see [troubleshooting](https://docs.qulacs.org/en/latest/intro/2_faq.html).
 

--- a/doc/en/source/intro/1_install.md
+++ b/doc/en/source/intro/1_install.md
@@ -29,7 +29,11 @@ A binary that is installed via pip command is optimized for Haswell architecture
 - C++ compiler (gcc or VisualStudio)
   - gcc/g++ >= 7.0.0 (checked in Linux, MacOS, cygwin, MinGW, and WSL)
   - Microsoft VisualStudio C++ 2015 or later
-- [Boost](https://github.com/boostorg/boost) >= 1.71.0 (Minimum version tested in CI)
+- [Boost](https://github.com/boostorg/boost) >= 1.71.0 (Development environment)  
+(Version tested in CI)
+  - macOS == 1.90.0
+  - Ubuntu == 1.76.0
+  - Windows == 1.83.0
 - Python >= 3.9
 - CMake >= 3.21
 - git
@@ -42,9 +46,9 @@ Note that `qulacs-gpu` includes CPU simulator. You don't need to install both.
 
 Qulacs is tested on the following systems.
 
-- Ubuntu 20.04
-- macOS Big Sur 11
-- Windows Server 2019
+- Ubuntu 24.04
+- macOS 15
+- Windows Server 2022
 
 If you encounter some troubles, see {doc}`2_faq`.
 

--- a/doc/ja/source/intro/1_install.md
+++ b/doc/ja/source/intro/1_install.md
@@ -29,7 +29,11 @@ A binary that is installed via pip command is optimized for Haswell architecture
 - C++ compiler (gcc or VisualStudio)
   - gcc/g++ >= 7.0.0 (checked in Linux, MacOS, cygwin, MinGW, and WSL)
   - Microsoft VisualStudio C++ 2015 or later
-- [Boost](https://github.com/boostorg/boost) >= 1.71.0 (Minimum version tested in CI)
+- [Boost](https://github.com/boostorg/boost) >= 1.71.0 (Development environment)  
+(Version tested in CI)
+  - macOS == 1.90.0
+  - Ubuntu == 1.76.0
+  - Windows == 1.83.0
 - Python >= 3.9
 - CMake >= 3.21
 - git
@@ -42,9 +46,9 @@ Note that `qulacs-gpu` includes CPU simulator. You don't need to install both.
 
 Qulacs is tested on the following systems.
 
-- Ubuntu 20.04
-- macOS Big Sur 11
-- Windows Server 2019
+- Ubuntu 24.04
+- macOS 15
+- Windows Server 2022
 
 If you encounter some troubles, see {doc}`2_faq`.
 


### PR DESCRIPTION
With Node.js version update,
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: 
actions/checkout@v4, actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
 Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, 
set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. 
Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. 
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
need to update action version.
~~(Note: maybe `lukka/get-cmake@latest` does not support Node.js 24)~~